### PR TITLE
Add OpenVINO Execution Provider support for Intel GPU acceleration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2407,7 +2407,7 @@ dependencies = [
 
 [[package]]
 name = "transcribe-rs"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "async-openai",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "transcribe-rs"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 description = "A simple library to help you transcribe audio"
 license = "MIT"
@@ -11,9 +11,12 @@ default = []
 
 # Local engines
 whisper = ["dep:whisper-rs"]
-parakeet = ["dep:ort", "dep:ndarray", "dep:regex", "dep:once_cell"]
-moonshine = ["dep:ort", "dep:ndarray", "dep:tokenizers"]
+parakeet = ["dep:ort", "dep:ndarray", "dep:regex", "dep:once_cell", "openvino"]
+moonshine = ["dep:ort", "dep:ndarray", "dep:tokenizers", "openvino"]
 whisperfile = ["dep:ureq"]
+
+# OpenVINO GPU acceleration (Intel iGPU/dGPU)
+openvino = ["ort/openvino"]
 
 # Remote engines
 openai = ["dep:async-openai", "dep:tokio", "dep:async-trait"]

--- a/src/engines/moonshine/model.rs
+++ b/src/engines/moonshine/model.rs
@@ -1,5 +1,5 @@
 use ndarray::{Array2, ArrayD};
-use ort::execution_providers::CPUExecutionProvider;
+use ort::execution_providers::{CPUExecutionProvider, OpenVINOExecutionProvider};
 use ort::inputs;
 use ort::session::builder::GraphOptimizationLevel;
 use ort::session::Session;
@@ -94,7 +94,11 @@ impl MoonshineModel {
     }
 
     fn init_session(path: &Path) -> Result<Session, MoonshineError> {
-        let providers = vec![CPUExecutionProvider::default().build()];
+        // OpenVINO with CPU fallback for Intel iGPU/dGPU acceleration
+        let providers = vec![
+            OpenVINOExecutionProvider::default().build(),
+            CPUExecutionProvider::default().build(),
+        ];
 
         let session = Session::builder()?
             .with_optimization_level(GraphOptimizationLevel::Level3)?

--- a/src/engines/parakeet/model.rs
+++ b/src/engines/parakeet/model.rs
@@ -1,6 +1,6 @@
 use ndarray::{Array, Array1, Array2, Array3, ArrayD, ArrayViewD, IxDyn};
 use once_cell::sync::Lazy;
-use ort::execution_providers::CPUExecutionProvider;
+use ort::execution_providers::{CPUExecutionProvider, OpenVINOExecutionProvider};
 use ort::inputs;
 use ort::session::builder::GraphOptimizationLevel;
 use ort::session::Session;
@@ -88,7 +88,11 @@ impl ParakeetModel {
         intra_threads: Option<usize>,
         try_quantized: bool,
     ) -> Result<Session, ParakeetError> {
-        let providers = vec![CPUExecutionProvider::default().build()];
+        // OpenVINO with CPU fallback for Intel iGPU/dGPU acceleration
+        let providers = vec![
+            OpenVINOExecutionProvider::default().build(),
+            CPUExecutionProvider::default().build(),
+        ];
 
         // Try quantized version first if requested, fallback to regular version
         let model_filename = if try_quantized {


### PR DESCRIPTION
This PR adds support for Intel iGPU/dGPU acceleration via OpenVINO Execution Provider in ONNX Runtime. The implementation includes automatic CPU fallback for systems without compatible Intel GPU hardware.

## Changes
- **Cargo.toml**: Added `openvino` feature flag that enables `ort/openvino`
- **Cargo.toml**: Enabled `openvino` feature for `parakeet` and `moonshine` engines
- **src/engines/parakeet/model.rs**: Configure OpenVINO EP with CPU fallback
- **src/engines/moonshine/model.rs**: Configure OpenVINO EP with CPU fallback
- **Version bump**: 0.2.1 → 0.2.2

## Supported Hardware
- ✅ Intel Arc GPUs (DG1, DG2, Meteor Lake, etc.)
- ✅ Intel integrated GPUs (8th Gen+ / Coffee Lake and newer)
- ⚠️ Legacy GPUs (7th Gen / Kaby Lake) require compatible Intel GPU Compute Runtime
- ✅ Automatic CPU fallback for unsupported configurations

## Testing
- ✅ Built successfully with `--features parakeet,moonshine,openvino`
- ✅ Verified OpenVINO strings in compiled binary
- ✅ CPU fallback works correctly
- ✅ Transcription functional on CPU-only system

## How It Works
```rust
// OpenVINO with CPU fallback for Intel iGPU/dGPU acceleration
let providers = vec![
    OpenVINOExecutionProvider::default().build(),  // Try Intel GPU first
    CPUExecutionProvider::default().build(),       // Fall back to CPU
];
```

The OpenVINO EP automatically detects and uses available Intel GPUs, falling back to CPU if:
- No supported GPU is present
- Intel GPU drivers are not installed
- The GPU model is not supported by the installed driver version