### PR TITLE
feat: add optional CUDA support for Windows x64

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,12 +15,13 @@ audio-features = ["dep:ndarray", "dep:rustfft"]
 # ONNX-based models (SenseVoice, GigaAM, Parakeet, Moonshine, Canary)
 onnx = ["audio-features", "dep:ort", "dep:base64", "dep:regex", "dep:once_cell"]
 
-# Whisper via whisper.cpp (CPU-only by default; add whisper-metal or whisper-vulkan for GPU)
+# Whisper via whisper.cpp (CPU-only by default; add whisper-metal, whisper-vulkan, or whisper-cuda for GPU)
 whisper-cpp = ["dep:whisper-rs"]
 
 # --- Whisper Accelerators ---
 whisper-metal  = ["whisper-cpp", "whisper-rs/metal"]
 whisper-vulkan = ["whisper-cpp", "whisper-rs/vulkan"]
+whisper-cuda   = ["whisper-cpp", "whisper-rs/cuda"]
 
 # Whisperfile server
 whisperfile = ["dep:ureq"]
@@ -66,7 +67,7 @@ tokio = { version = "1.47.1", features = ["rt-multi-thread"], optional = true }
 async-openai = { version = "0.29.3", optional = true }
 async-trait = { version = "0.1.89", optional = true }
 
-# Whisper (GPU features controlled by whisper-metal / whisper-vulkan feature flags)
+# Whisper (GPU features controlled by whisper-metal / whisper-vulkan / whisper-cuda feature flags)
 whisper-rs = { version = "0.16.0", optional = true }
 
 # Examples with required features

--- a/README.md
+++ b/README.md
@@ -25,10 +25,18 @@ No features are enabled by default. Pick the engines you need:
 | Feature | Engines |
 |---------|---------|
 | `onnx` | Parakeet, Canary, Moonshine, SenseVoice, GigaAM (via ONNX Runtime) |
-| `whisper-cpp` | Whisper (local, GGML via whisper.cpp with Metal/Vulkan) |
+| `whisper-cpp` | Whisper (local, GGML via whisper.cpp with Metal/Vulkan/CUDA) |
 | `whisperfile` | Whisperfile (local server wrapper) |
 | `openai` | OpenAI API (remote, async) |
 | `all` | Everything above |
+
+GPU accelerator features for whisper.cpp:
+
+| Feature | Backend |
+|---------|---------|
+| `whisper-metal` | Apple Metal (macOS) |
+| `whisper-vulkan` | Vulkan (Windows/Linux) |
+| `whisper-cuda` | NVIDIA CUDA (requires CUDA Toolkit 12.0+) |
 
 GPU accelerator features for ORT engines:
 
@@ -77,7 +85,7 @@ set_ort_accelerator(OrtAccelerator::Cuda);
 set_ort_accelerator(OrtAccelerator::Auto);
 ```
 
-For whisper.cpp, GPU backend (Metal, Vulkan) is selected at compile time. You can control whether GPU is used at runtime:
+For whisper.cpp, GPU backend (Metal, Vulkan, CUDA) is selected at compile time via feature flags. You can control whether GPU is used at runtime:
 
 ```rust
 use transcribe_rs::{set_whisper_accelerator, WhisperAccelerator};

--- a/src/accel.rs
+++ b/src/accel.rs
@@ -150,12 +150,12 @@ impl WhisperAccelerator {
     /// Return the list of Whisper accelerators available for the current build.
     ///
     /// Always includes `CpuOnly`. Includes `Gpu` when whisper-rs was compiled
-    /// with a GPU backend (Metal on macOS, Vulkan on Windows/Linux).
+    /// with a GPU backend (Metal on macOS, Vulkan on Windows/Linux, CUDA on Windows).
     pub fn available() -> Vec<WhisperAccelerator> {
         #[allow(unused_mut)]
         let mut v = vec![WhisperAccelerator::CpuOnly];
 
-        #[cfg(any(feature = "whisper-metal", feature = "whisper-vulkan"))]
+        #[cfg(any(feature = "whisper-metal", feature = "whisper-vulkan", feature = "whisper-cuda"))]
         v.push(WhisperAccelerator::Gpu);
 
         v


### PR DESCRIPTION
## Summary

Adds CUDA as a whisper.cpp GPU backend, slotting into the accelerator architecture alongside `whisper-metal` and `whisper-vulkan`.

## Performance Results

Tested on Windows 11 with RTX 4090, Whisper Large v3 Q5_0:

| Backend | Speed | Relative |
|---------|-------|----------|
| Vulkan | 3.4× real-time | baseline |
| CUDA | 17× real-time | **5× faster** |

## Changes

- Add `whisper-cuda` feature in Cargo.toml (follows `whisper-metal`/`whisper-vulkan` pattern)
- Update `WhisperAccelerator::available()` cfg gate in `src/accel.rs`
- Add whisper.cpp GPU features table to README

## Usage

```toml
# CUDA backend (NVIDIA GPU)
transcribe-rs = { version = "0.3", features = ["whisper-cuda"] }

# Vulkan backend (cross-platform)
transcribe-rs = { version = "0.3", features = ["whisper-vulkan"] }
```

## Build Requirements

- NVIDIA GPU with compatible drivers
- CUDA Toolkit 12.0+
- Visual Studio Build Tools with C++ workload (Windows)

## Runtime Note

The full CUDA Toolkit (~3GB) is not needed at runtime — just the driver and 3 DLLs (`cublas64_XX.dll`, `cublasLt64_XX.dll`, `cudart64_XX.dll`). These can be bundled with the application per NVIDIA's EULA, similar to how llama.cpp ships them.