### PR TITLE
feat: add Zipformer CTC and Transducer engines

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,8 @@ whisper = ["dep:whisper-rs", "dep:advapi32-sys"]
 parakeet = ["dep:ort", "dep:ndarray", "dep:regex", "dep:once_cell"]
 moonshine = ["dep:ort", "dep:ndarray"]
 sense_voice = ["dep:ort", "dep:ndarray", "dep:rustfft", "dep:base64"]
+zipformer-ctc = ["dep:ort", "dep:ndarray", "dep:rustfft"]
+zipformer-transducer = ["dep:ort", "dep:ndarray", "dep:rustfft"]
 whisperfile = ["dep:ureq"]
 
 # Remote engines
@@ -23,7 +25,7 @@ openai = ["dep:async-openai", "dep:tokio", "dep:async-trait"]
 itn = ["dep:nemo-text-processing"]
 
 # Convenience
-all = ["whisper", "parakeet", "moonshine", "sense_voice", "whisperfile", "openai"]
+all = ["whisper", "parakeet", "moonshine", "sense_voice", "zipformer-ctc", "zipformer-transducer", "whisperfile", "openai"]
 
 [dependencies]
 # Always required
@@ -88,6 +90,14 @@ required-features = ["moonshine"]
 [[example]]
 name = "sense_voice"
 required-features = ["sense_voice"]
+
+[[example]]
+name = "zipformer_ctc"
+required-features = ["zipformer-ctc"]
+
+[[example]]
+name = "zipformer_transducer"
+required-features = ["zipformer-transducer"]
 
 [[example]]
 name = "whisperfile"

--- a/examples/zipformer_ctc.rs
+++ b/examples/zipformer_ctc.rs
@@ -1,0 +1,43 @@
+use std::path::PathBuf;
+
+use transcribe_rs::audio;
+use transcribe_rs::engines::zipformer_ctc::{ZipformerCtcEngine, ZipformerCtcModelParams};
+use transcribe_rs::TranscriptionEngine;
+
+fn main() {
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
+
+    let args: Vec<String> = std::env::args().collect();
+    // Usage: zipformer_ctc [model_dir] [audio_file]
+    let model_dir = PathBuf::from(
+        args.get(1)
+            .map(|s| s.as_str())
+            .unwrap_or("models/sherpa-onnx-zipformer-ctc-small-zh-int8-2025-07-16"),
+    );
+    let audio_path = args
+        .get(2)
+        .map(PathBuf::from)
+        .unwrap_or_else(|| model_dir.join("test_wavs/0.wav"));
+
+    // Auto-detect: use int8 if model.int8.onnx exists, otherwise fp32
+    let params = if model_dir.join("model.int8.onnx").exists() {
+        ZipformerCtcModelParams::int8()
+    } else {
+        ZipformerCtcModelParams::default()
+    };
+
+    println!("Loading model from {:?}...", model_dir);
+    let mut engine = ZipformerCtcEngine::new();
+    engine
+        .load_model_with_params(&model_dir, params)
+        .expect("Failed to load model");
+
+    println!("Transcribing {:?}...", audio_path);
+    let samples = audio::read_wav_samples(&audio_path).expect("Failed to read wav");
+    println!("Loaded {} samples ({:.2}s)", samples.len(), samples.len() as f32 / 16000.0);
+
+    let result = engine
+        .transcribe_samples(samples, None)
+        .expect("Failed to transcribe");
+    println!("Result: {}", result.text);
+}

--- a/examples/zipformer_transducer.rs
+++ b/examples/zipformer_transducer.rs
@@ -1,0 +1,60 @@
+use std::path::PathBuf;
+
+use transcribe_rs::audio;
+use transcribe_rs::engines::zipformer_transducer::{
+    ZipformerTransducerEngine, ZipformerTransducerModelParams,
+};
+use transcribe_rs::TranscriptionEngine;
+
+fn main() {
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
+
+    let args: Vec<String> = std::env::args().collect();
+    // Usage: zipformer_transducer [model_dir] [audio_file]
+    let model_dir = PathBuf::from(
+        args.get(1)
+            .map(|s| s.as_str())
+            .unwrap_or("models/sherpa-onnx-zipformer-zh-en-2023-11-22"),
+    );
+    let audio_path = args
+        .get(2)
+        .map(PathBuf::from)
+        .unwrap_or_else(|| model_dir.join("test_wavs/0.wav"));
+
+    // Auto-detect: look for int8 encoder file, fall back to fp32
+    let has_int8 = std::fs::read_dir(&model_dir)
+        .map(|entries| {
+            entries
+                .filter_map(|e| e.ok())
+                .any(|e| {
+                    let name = e.file_name().to_string_lossy().to_string();
+                    name.starts_with("encoder") && name.contains("int8") && name.ends_with(".onnx")
+                })
+        })
+        .unwrap_or(false);
+
+    let params = if has_int8 {
+        ZipformerTransducerModelParams::int8()
+    } else {
+        ZipformerTransducerModelParams::fp32()
+    };
+
+    println!("Loading model from {:?}...", model_dir);
+    let mut engine = ZipformerTransducerEngine::new();
+    engine
+        .load_model_with_params(&model_dir, params)
+        .expect("Failed to load model");
+
+    println!("Transcribing {:?}...", audio_path);
+    let samples = audio::read_wav_samples(&audio_path).expect("Failed to read wav");
+    println!(
+        "Loaded {} samples ({:.2}s)",
+        samples.len(),
+        samples.len() as f32 / 16000.0
+    );
+
+    let result = engine
+        .transcribe_samples(samples, None)
+        .expect("Failed to transcribe");
+    println!("Result: {}", result.text);
+}

--- a/src/engines/mod.rs
+++ b/src/engines/mod.rs
@@ -29,3 +29,10 @@ pub mod sense_voice;
 pub mod whisper;
 #[cfg(feature = "whisperfile")]
 pub mod whisperfile;
+#[cfg(feature = "zipformer-ctc")]
+pub mod zipformer_ctc;
+#[cfg(feature = "zipformer-transducer")]
+pub mod zipformer_transducer;
+
+#[cfg(any(feature = "zipformer-ctc", feature = "zipformer-transducer"))]
+pub mod zipformer_common;

--- a/src/engines/zipformer_common.rs
+++ b/src/engines/zipformer_common.rs
@@ -1,0 +1,372 @@
+//! Shared utilities for Zipformer-based engines (CTC, Transducer).
+//!
+//! Contains Kaldi-compatible FBank feature extraction, BBPE byte decoding,
+//! and the symbol table used by sherpa-onnx Zipformer models.
+
+use std::collections::HashMap;
+use std::fs;
+use std::path::Path;
+
+use ndarray::Array2;
+use rustfft::{num_complex::Complex, FftPlanner};
+
+/// Kaldi-compatible FBank configuration matching sherpa-onnx / kaldi-native-fbank.
+#[derive(Debug, Clone)]
+pub struct FbankConfig {
+    pub num_bins: usize,
+    pub fft_size: usize,
+    pub window_size: usize,
+    pub hop_size: usize,
+    pub sample_rate: i32,
+    pub low_freq: f32,
+    /// Negative means nyquist + high_freq (Kaldi convention). -400 → 7600 Hz at 16kHz.
+    pub high_freq: f32,
+    pub preemph_coeff: f32,
+    pub snip_edges: bool,
+    pub remove_dc_offset: bool,
+}
+
+impl Default for FbankConfig {
+    fn default() -> Self {
+        Self {
+            num_bins: 80,
+            fft_size: 512,
+            window_size: 400,
+            hop_size: 160,
+            sample_rate: 16000,
+            low_freq: 20.0,
+            high_freq: -400.0,
+            preemph_coeff: 0.97,
+            snip_edges: false,
+            remove_dc_offset: true,
+        }
+    }
+}
+
+// ============== Symbol Table ==============
+
+/// Whether tokens use BBPE byte encoding or standard BPE (literal UTF-8).
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum TokenEncoding {
+    /// Icefall BBPE: token chars are byte-to-unicode mapped, need decoding.
+    Bbpe,
+    /// Standard BPE/sentencepiece: token strings are literal UTF-8.
+    Bpe,
+}
+
+pub struct SymbolTable {
+    id_to_sym: HashMap<i32, String>,
+    encoding: TokenEncoding,
+}
+
+impl SymbolTable {
+    /// Load a symbol table with BBPE encoding (default for zh-en models).
+    pub fn load(path: &Path) -> Result<Self, std::io::Error> {
+        Self::load_with_encoding(path, TokenEncoding::Bbpe)
+    }
+
+    /// Load a symbol table, auto-detecting encoding from sibling files.
+    /// If `bbpe.model` exists in the same directory, use BBPE; otherwise standard BPE.
+    pub fn load_autodetect(path: &Path) -> Result<Self, std::io::Error> {
+        let encoding = if let Some(dir) = path.parent() {
+            if dir.join("bbpe.model").exists() {
+                log::info!("Detected BBPE encoding (bbpe.model found)");
+                TokenEncoding::Bbpe
+            } else {
+                log::info!("Detected standard BPE encoding (no bbpe.model)");
+                TokenEncoding::Bpe
+            }
+        } else {
+            TokenEncoding::Bbpe
+        };
+        Self::load_with_encoding(path, encoding)
+    }
+
+    pub fn load_with_encoding(path: &Path, encoding: TokenEncoding) -> Result<Self, std::io::Error> {
+        let contents = fs::read_to_string(path)?;
+        let mut id_to_sym = HashMap::new();
+
+        for line in contents.lines() {
+            let line = line.trim_end();
+            if line.is_empty() {
+                continue;
+            }
+
+            // Format: "token id" (whitespace separated, token can contain spaces)
+            let parts: Vec<&str> = line.rsplitn(2, |c: char| c.is_whitespace()).collect();
+            if parts.len() != 2 {
+                continue;
+            }
+
+            if let Ok(id) = parts[0].parse::<i32>() {
+                id_to_sym.insert(id, parts[1].to_string());
+            }
+        }
+
+        Ok(Self { id_to_sym, encoding })
+    }
+
+    pub fn get(&self, id: i32) -> Option<&str> {
+        self.id_to_sym.get(&id).map(|s| s.as_str())
+    }
+
+    /// Decode token IDs to text, using the appropriate encoding strategy.
+    pub fn decode(&self, token_ids: &[i32]) -> String {
+        match self.encoding {
+            TokenEncoding::Bbpe => self.decode_bbpe(token_ids),
+            TokenEncoding::Bpe => self.decode_bpe(token_ids),
+        }
+    }
+
+    /// Decode BBPE token IDs to text.
+    ///
+    /// Icefall BBPE tokens use a byte-to-unicode mapping (PRINTABLE_BASE_CHARS).
+    /// We collect all token chars, map each back to a byte, then interpret as UTF-8.
+    fn decode_bbpe(&self, token_ids: &[i32]) -> String {
+        let mut raw_bytes = Vec::new();
+
+        for &id in token_ids {
+            let Some(sym) = self.get(id) else {
+                continue;
+            };
+            if sym.starts_with('<') && sym.ends_with('>') {
+                continue;
+            }
+            for c in sym.chars() {
+                if c == '\u{2581}' {
+                    // ▁ is the sentencepiece space marker
+                    raw_bytes.push(b' ');
+                } else if let Some(byte_val) = bbpe_char_to_byte(c) {
+                    raw_bytes.push(byte_val);
+                }
+            }
+        }
+
+        let text = String::from_utf8_lossy(&raw_bytes);
+        text.trim().to_string()
+    }
+
+    /// Decode standard BPE/sentencepiece tokens (literal UTF-8 strings).
+    fn decode_bpe(&self, token_ids: &[i32]) -> String {
+        let mut text = String::new();
+
+        for &id in token_ids {
+            let Some(sym) = self.get(id) else {
+                continue;
+            };
+            if sym.starts_with('<') && sym.ends_with('>') {
+                continue;
+            }
+            // ▁ is the sentencepiece space marker
+            text.push_str(&sym.replace('\u{2581}', " "));
+        }
+
+        text.trim().to_string()
+    }
+}
+
+// ============== Icefall BBPE byte mapping ==============
+
+/// Icefall PRINTABLE_BASE_CHARS: maps byte index (0-255) to a Unicode codepoint.
+/// Source: icefall/byte_utils.py
+const BBPE_CODEPOINTS: [u32; 256] = [
+    256, 257, 258, 259, 260, 261, 262, 263, 264, 265, 266, 267, 268, 269, 270,
+    271, 272, 273, 274, 275, 276, 277, 278, 279, 280, 281, 282, 283, 284, 285,
+    286, 287, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47,
+    48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65,
+    66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83,
+    84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101,
+    102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116,
+    117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 288, 289, 290, 291, 292,
+    293, 294, 295, 296, 297, 298, 299, 300, 301, 302, 303, 304, 305, 308, 309,
+    310, 311, 312, 313, 314, 315, 316, 317, 318, 321, 322, 323, 324, 325, 326,
+    327, 328, 330, 331, 332, 333, 334, 335, 336, 337, 338, 339, 340, 341, 342,
+    343, 344, 345, 346, 347, 348, 349, 350, 351, 352, 353, 354, 355, 356, 357,
+    358, 359, 360, 361, 362, 363, 364, 365, 366, 367, 368, 369, 370, 371, 372,
+    373, 374, 375, 376, 377, 378, 379, 380, 381, 382, 384, 385, 386, 387, 388,
+    389, 390, 391, 392, 393, 394, 395, 396, 397, 398, 399, 400, 401, 402, 403,
+    404, 405, 406, 407, 408, 409, 410, 411, 412, 413, 414, 415, 416, 417, 418,
+    419, 420, 421, 422,
+];
+
+/// Convert a BBPE-encoded Unicode char back to its byte value.
+pub fn bbpe_char_to_byte(c: char) -> Option<u8> {
+    let cp = c as u32;
+    // ASCII printable (32-126) maps to itself (bytes 32-126)
+    if (32..=126).contains(&cp) {
+        return Some(cp as u8);
+    }
+    // Search the non-identity ranges in the table
+    for (byte_val, &mapped_cp) in BBPE_CODEPOINTS.iter().enumerate() {
+        if mapped_cp == cp {
+            return Some(byte_val as u8);
+        }
+    }
+    None
+}
+
+// ============== Kaldi-compatible Fbank Feature Extraction ==============
+
+pub fn compute_mel_filterbank(config: &FbankConfig) -> Vec<Vec<f32>> {
+    let num_bins = config.num_bins;
+    let fft_size = config.fft_size;
+    let sample_rate = config.sample_rate as f32;
+    let nyquist = sample_rate / 2.0;
+
+    // Kaldi convention: negative high_freq means nyquist + high_freq
+    let low_freq = config.low_freq;
+    let high_freq = if config.high_freq <= 0.0 {
+        nyquist + config.high_freq
+    } else {
+        config.high_freq
+    };
+
+    let hz_to_mel = |hz: f32| 1127.0 * (1.0 + hz / 700.0).ln();
+    let mel_to_hz = |mel: f32| 700.0 * ((mel / 1127.0).exp() - 1.0);
+
+    let low_mel = hz_to_mel(low_freq);
+    let high_mel = hz_to_mel(high_freq);
+
+    let num_points = num_bins + 2;
+    let mel_points: Vec<f32> = (0..num_points)
+        .map(|i| low_mel + (high_mel - low_mel) * i as f32 / (num_points - 1) as f32)
+        .collect();
+    let hz_points: Vec<f32> = mel_points.iter().map(|&m| mel_to_hz(m)).collect();
+    let fft_bins: Vec<usize> = hz_points
+        .iter()
+        .map(|&hz| ((hz * fft_size as f32) / sample_rate).floor() as usize)
+        .collect();
+
+    let half_fft = fft_size / 2 + 1;
+    let mut filterbank = vec![vec![0.0f32; half_fft]; num_bins];
+    for (i, filter) in filterbank.iter_mut().enumerate() {
+        let left = fft_bins[i];
+        let center = fft_bins[i + 1];
+        let right = fft_bins[i + 2];
+
+        if center > left {
+            for j in left..center {
+                if j < half_fft {
+                    filter[j] = (j - left) as f32 / (center - left) as f32;
+                }
+            }
+        }
+        if right > center {
+            for j in center..right {
+                if j < half_fft {
+                    filter[j] = (right - j) as f32 / (right - center) as f32;
+                }
+            }
+        }
+    }
+
+    filterbank
+}
+
+/// Kaldi-compatible FBank: Povey window, preemphasis, natural log, snip_edges=false.
+pub fn compute_fbank_kaldi(samples: &[f32], config: &FbankConfig) -> Array2<f32> {
+    let window_size = config.window_size;
+    let hop_size = config.hop_size;
+    let fft_size = config.fft_size;
+    let half_fft = fft_size / 2 + 1;
+
+    if samples.is_empty() {
+        return Array2::zeros((0, config.num_bins));
+    }
+
+    // Frame count: snip_edges=false pads the signal
+    let num_frames = if config.snip_edges {
+        if samples.len() < window_size {
+            return Array2::zeros((0, config.num_bins));
+        }
+        (samples.len() - window_size) / hop_size + 1
+    } else {
+        (samples.len() + hop_size / 2) / hop_size
+    };
+
+    if num_frames == 0 {
+        return Array2::zeros((0, config.num_bins));
+    }
+
+    let filterbank = compute_mel_filterbank(config);
+
+    // Povey window: hamming^0.85
+    let window: Vec<f32> = (0..window_size)
+        .map(|i| {
+            let hamming =
+                0.54 - 0.46 * (2.0 * std::f32::consts::PI * i as f32 / (window_size as f32 - 1.0)).cos();
+            hamming.powf(0.85)
+        })
+        .collect();
+
+    let mut planner = FftPlanner::new();
+    let fft = planner.plan_fft_forward(fft_size);
+
+    let mut features = Vec::with_capacity(num_frames * config.num_bins);
+
+    for frame_idx in 0..num_frames {
+        // Frame start position (snip_edges=false centers the first frame)
+        let center = if config.snip_edges {
+            frame_idx * hop_size + window_size / 2
+        } else {
+            frame_idx * hop_size
+        };
+        let start = center as isize - (window_size as isize / 2);
+
+        // Extract frame with zero-padding at boundaries
+        let mut frame = vec![0.0f32; window_size];
+        for i in 0..window_size {
+            let idx = start + i as isize;
+            if idx >= 0 && (idx as usize) < samples.len() {
+                frame[i] = samples[idx as usize];
+            }
+        }
+
+        // Remove DC offset
+        if config.remove_dc_offset {
+            let mean: f32 = frame.iter().sum::<f32>() / window_size as f32;
+            for s in frame.iter_mut() {
+                *s -= mean;
+            }
+        }
+
+        // Preemphasis
+        if config.preemph_coeff > 0.0 {
+            for i in (1..window_size).rev() {
+                frame[i] -= config.preemph_coeff * frame[i - 1];
+            }
+            frame[0] *= 1.0 - config.preemph_coeff;
+        }
+
+        // Apply window and zero-pad to FFT size
+        let mut buffer: Vec<Complex<f32>> = frame
+            .iter()
+            .zip(window.iter())
+            .map(|(&s, &w)| Complex::new(s * w, 0.0))
+            .collect();
+        buffer.resize(fft_size, Complex::new(0.0, 0.0));
+
+        fft.process(&mut buffer);
+
+        // Power spectrum
+        let mut power = vec![0.0f32; half_fft];
+        for (i, c) in buffer.iter().take(half_fft).enumerate() {
+            power[i] = c.norm_sqr();
+        }
+
+        // Apply mel filterbank and take natural log (Kaldi convention)
+        for filter in &filterbank {
+            let mut sum = 0.0f32;
+            for (i, &w) in filter.iter().enumerate() {
+                sum += w * power[i];
+            }
+            features.push(if sum > f32::EPSILON {
+                sum.ln()
+            } else {
+                (f32::EPSILON).ln()
+            });
+        }
+    }
+
+    Array2::from_shape_vec((num_frames, config.num_bins), features).unwrap()
+}

--- a/src/engines/zipformer_ctc/engine.rs
+++ b/src/engines/zipformer_ctc/engine.rs
@@ -1,0 +1,166 @@
+use std::path::{Path, PathBuf};
+
+use crate::{TranscriptionEngine, TranscriptionResult};
+
+#[cfg(feature = "punct")]
+use crate::{add_punctuation, add_punctuation_with_model};
+
+use super::model::ZipformerCtcModel;
+
+#[derive(Debug, Clone, Default, PartialEq)]
+pub enum QuantizationType {
+    FP32,
+    #[default]
+    Int8,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct ZipformerCtcModelParams {
+    pub quantization: QuantizationType,
+}
+
+impl ZipformerCtcModelParams {
+    pub fn fp32() -> Self {
+        Self {
+            quantization: QuantizationType::FP32,
+        }
+    }
+
+    pub fn int8() -> Self {
+        Self {
+            quantization: QuantizationType::Int8,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ZipformerCtcInferenceParams {
+    /// Whether to run punctuation restoration after ASR.
+    pub auto_punctuation: bool,
+    /// Optional custom punctuation model directory.
+    pub punct_model_dir: Option<PathBuf>,
+}
+
+impl Default for ZipformerCtcInferenceParams {
+    fn default() -> Self {
+        Self {
+            auto_punctuation: true,
+            punct_model_dir: None,
+        }
+    }
+}
+
+impl ZipformerCtcInferenceParams {
+    pub fn with_punctuation() -> Self {
+        Self {
+            auto_punctuation: true,
+            punct_model_dir: None,
+        }
+    }
+
+    pub fn without_punctuation() -> Self {
+        Self {
+            auto_punctuation: false,
+            punct_model_dir: None,
+        }
+    }
+
+    pub fn with_custom_punctuation_model(model_dir: PathBuf) -> Self {
+        Self {
+            auto_punctuation: true,
+            punct_model_dir: Some(model_dir),
+        }
+    }
+}
+
+pub struct ZipformerCtcEngine {
+    loaded_model_path: Option<PathBuf>,
+    model: Option<ZipformerCtcModel>,
+}
+
+impl ZipformerCtcEngine {
+    pub fn new() -> Self {
+        Self {
+            loaded_model_path: None,
+            model: None,
+        }
+    }
+}
+
+impl Default for ZipformerCtcEngine {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Drop for ZipformerCtcEngine {
+    fn drop(&mut self) {
+        self.unload_model();
+    }
+}
+
+impl TranscriptionEngine for ZipformerCtcEngine {
+    type InferenceParams = ZipformerCtcInferenceParams;
+    type ModelParams = ZipformerCtcModelParams;
+
+    fn load_model_with_params(
+        &mut self,
+        model_path: &Path,
+        params: Self::ModelParams,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        self.unload_model();
+
+        let quantized = matches!(params.quantization, QuantizationType::Int8);
+        let model = ZipformerCtcModel::new(model_path, quantized)?;
+        self.model = Some(model);
+        self.loaded_model_path = Some(model_path.to_path_buf());
+
+        log::info!("Loaded Zipformer CTC model from {:?}", model_path);
+        Ok(())
+    }
+
+    fn unload_model(&mut self) {
+        if self.model.is_some() {
+            log::debug!("Unloading Zipformer CTC model");
+            self.model = None;
+            self.loaded_model_path = None;
+        }
+    }
+
+    fn transcribe_samples(
+        &mut self,
+        samples: Vec<f32>,
+        params: Option<Self::InferenceParams>,
+    ) -> Result<TranscriptionResult, Box<dyn std::error::Error>> {
+        let model = self
+            .model
+            .as_mut()
+            .ok_or("Model not loaded. Call load_model() first.")?;
+
+        let params = params.unwrap_or_default();
+        let result = model.transcribe(&samples)?;
+        log::debug!("Decoded {} zipformer ctc tokens", result.token_ids.len());
+
+        let text = if params.auto_punctuation {
+            #[cfg(feature = "punct")]
+            {
+                if let Some(model_dir) = params.punct_model_dir.as_ref() {
+                    add_punctuation_with_model(&result.text, model_dir)
+                } else {
+                    add_punctuation(&result.text)
+                }
+            }
+            #[cfg(not(feature = "punct"))]
+            {
+                result.text
+            }
+        } else {
+            result.text
+        };
+
+        Ok(TranscriptionResult {
+            text,
+            segments: None,
+        })
+    }
+}

--- a/src/engines/zipformer_ctc/mod.rs
+++ b/src/engines/zipformer_ctc/mod.rs
@@ -1,0 +1,11 @@
+//! Zipformer CTC ONNX transcription engine.
+//!
+//! This module provides an ONNX implementation for Zipformer CTC models
+//! such as `sherpa-onnx-zipformer-ctc-small-zh-int8`.
+
+mod engine;
+mod model;
+
+pub use engine::{
+    ZipformerCtcEngine, ZipformerCtcInferenceParams, ZipformerCtcModelParams, QuantizationType,
+};

--- a/src/engines/zipformer_ctc/model.rs
+++ b/src/engines/zipformer_ctc/model.rs
@@ -1,0 +1,283 @@
+use std::path::Path;
+
+use ndarray::{Array2, ArrayView2};
+use ort::execution_providers::CPUExecutionProvider;
+use ort::inputs;
+use ort::session::builder::GraphOptimizationLevel;
+use ort::session::Session;
+use ort::value::TensorRef;
+
+use super::super::zipformer_common::*;
+
+#[derive(thiserror::Error, Debug)]
+pub enum ZipformerCtcError {
+    #[error("ORT error: {0}")]
+    Ort(#[from] ort::Error),
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("Shape error: {0}")]
+    Shape(#[from] ndarray::ShapeError),
+    #[error("Model file not found: {0}")]
+    ModelNotFound(String),
+    #[error("Tokens file not found: {0}")]
+    TokensNotFound(String),
+    #[error("Invalid model: {0}")]
+    InvalidModel(String),
+    #[error("Model output not found: {0}")]
+    OutputNotFound(String),
+}
+
+pub struct ZipformerCtcModel {
+    session: Session,
+    symbol_table: SymbolTable,
+    blank_id: i32,
+    x_input_name: String,
+    x_lens_input_name: String,
+    log_probs_output_name: String,
+    log_probs_len_output_name: String,
+}
+
+impl Drop for ZipformerCtcModel {
+    fn drop(&mut self) {
+        log::debug!("Dropping ZipformerCtcModel");
+    }
+}
+
+impl ZipformerCtcModel {
+    pub fn new(model_dir: &Path, quantized: bool) -> Result<Self, ZipformerCtcError> {
+        let model_path = if quantized {
+            let int8_path = model_dir.join("model.int8.onnx");
+            if int8_path.exists() {
+                int8_path
+            } else {
+                log::warn!("Quantized model not found, falling back to model.onnx");
+                model_dir.join("model.onnx")
+            }
+        } else {
+            model_dir.join("model.onnx")
+        };
+        let tokens_path = model_dir.join("tokens.txt");
+
+        if !model_path.exists() {
+            return Err(ZipformerCtcError::ModelNotFound(
+                model_path.display().to_string(),
+            ));
+        }
+        if !tokens_path.exists() {
+            return Err(ZipformerCtcError::TokensNotFound(
+                tokens_path.display().to_string(),
+            ));
+        }
+
+        log::info!(
+            "Loading Zipformer CTC model from {:?}...",
+            model_path
+        );
+        let session = Self::init_session(&model_path)?;
+        let symbol_table = SymbolTable::load(&tokens_path)?;
+
+        let input_names: Vec<String> = session.inputs.iter().map(|i| i.name.clone()).collect();
+        let output_names: Vec<String> = session.outputs.iter().map(|o| o.name.clone()).collect();
+
+        if input_names.is_empty() || output_names.is_empty() {
+            return Err(ZipformerCtcError::InvalidModel(
+                "Model has no inputs or outputs".to_string(),
+            ));
+        }
+
+        // Model inputs: x [N, T, 80], x_lens [N]
+        let x_input_name = input_names
+            .iter()
+            .find(|n| n.as_str() == "x")
+            .cloned()
+            .unwrap_or_else(|| input_names[0].clone());
+
+        let x_lens_input_name = input_names
+            .iter()
+            .find(|n| n.as_str() == "x_lens")
+            .or_else(|| input_names.iter().find(|n| n.contains("lens")))
+            .cloned()
+            .unwrap_or_else(|| {
+                if input_names.len() > 1 {
+                    input_names[1].clone()
+                } else {
+                    input_names[0].clone()
+                }
+            });
+
+        // Model outputs: log_probs [N, T, vocab_size], log_probs_len [N]
+        let log_probs_output_name = output_names
+            .iter()
+            .find(|n| n.as_str() == "log_probs")
+            .cloned()
+            .unwrap_or_else(|| output_names[0].clone());
+
+        let log_probs_len_output_name = output_names
+            .iter()
+            .find(|n| n.as_str() == "log_probs_len")
+            .cloned()
+            .unwrap_or_else(|| {
+                if output_names.len() > 1 {
+                    output_names[1].clone()
+                } else {
+                    output_names[0].clone()
+                }
+            });
+
+        log::info!(
+            "Zipformer CTC I/O: x='{}', x_lens='{}', log_probs='{}', log_probs_len='{}'",
+            x_input_name,
+            x_lens_input_name,
+            log_probs_output_name,
+            log_probs_len_output_name
+        );
+
+        // CTC blank_id is typically 0
+        let blank_id = 0;
+
+        Ok(Self {
+            session,
+            symbol_table,
+            blank_id,
+            x_input_name,
+            x_lens_input_name,
+            log_probs_output_name,
+            log_probs_len_output_name,
+        })
+    }
+
+    fn init_session(path: &Path) -> Result<Session, ZipformerCtcError> {
+        let session = Session::builder()?
+            .with_optimization_level(GraphOptimizationLevel::Level3)?
+            .with_execution_providers([CPUExecutionProvider::default().build()])?
+            .with_parallel_execution(true)?
+            .commit_from_file(path)?;
+
+        for input in &session.inputs {
+            log::info!(
+                "Model input: name={}, type={:?}",
+                input.name,
+                input.input_type
+            );
+        }
+        for output in &session.outputs {
+            log::info!(
+                "Model output: name={}, type={:?}",
+                output.name,
+                output.output_type
+            );
+        }
+        Ok(session)
+    }
+
+    fn compute_fbank(&self, samples: &[f32]) -> Array2<f32> {
+        compute_fbank_kaldi(samples, &FbankConfig::default())
+    }
+
+    fn forward(
+        &mut self,
+        features: &ArrayView2<f32>,
+    ) -> Result<(Array2<f32>, i32), ZipformerCtcError> {
+        let feat_3d =
+            features
+                .to_owned()
+                .into_shape_with_order((1, features.nrows(), features.ncols()))?;
+        let x_len = features.nrows() as i32;
+
+        let feat_dyn = feat_3d.into_dyn();
+        let len_dyn = ndarray::arr1(&[x_len as i64]).into_dyn();
+
+        let inputs = inputs![
+            self.x_input_name.as_str() => TensorRef::from_array_view(feat_dyn.view())?,
+            self.x_lens_input_name.as_str() => TensorRef::from_array_view(len_dyn.view())?,
+        ];
+
+        let outputs = self.session.run(inputs)?;
+
+        let log_probs = outputs
+            .get(self.log_probs_output_name.as_str())
+            .ok_or_else(|| {
+                ZipformerCtcError::OutputNotFound(self.log_probs_output_name.clone())
+            })?
+            .try_extract_array::<f32>()?
+            .to_owned()
+            .into_dimensionality::<ndarray::Ix3>()?;
+
+        // Get output length and vocab size before consuming log_probs
+        let time_steps = log_probs.shape()[1] as i32;
+        let vocab_size = log_probs.shape()[2];
+        let output_len = if let Some(v) = outputs.get(self.log_probs_len_output_name.as_str()) {
+            if let Ok(arr) = v.try_extract_array::<i64>() {
+                arr.as_slice().and_then(|s| s.first().copied()).map(|v| v as i32).unwrap_or(time_steps)
+            } else {
+                time_steps
+            }
+        } else {
+            time_steps
+        };
+
+        // Convert log_probs from [1, T, V] to [T, V]
+        let log_probs_2d = log_probs.into_shape_with_order((time_steps as usize, vocab_size))?;
+
+        Ok((log_probs_2d, output_len))
+    }
+
+    fn decode_ctc(&self, log_probs: &Array2<f32>, output_len: i32) -> Vec<i32> {
+        let seq_len = log_probs.shape()[0].min(output_len as usize);
+        let vocab_size = log_probs.shape()[1];
+        let mut token_ids = Vec::new();
+        let mut prev_id: Option<i32> = None;
+
+        for t in 0..seq_len {
+            // Greedy decoding: find argmax
+            let mut max_id = 0i32;
+            let mut max_val = f32::NEG_INFINITY;
+            for v in 0..vocab_size {
+                let val = log_probs[[t, v]];
+                if val > max_val {
+                    max_val = val;
+                    max_id = v as i32;
+                }
+            }
+
+            // CTC collapse: skip blanks and repeated tokens
+            if max_id != self.blank_id && Some(max_id) != prev_id {
+                token_ids.push(max_id);
+            }
+            prev_id = Some(max_id);
+        }
+
+        token_ids
+    }
+
+    pub fn transcribe(&mut self, samples: &[f32]) -> Result<ZipformerCtcResult, ZipformerCtcError> {
+        let features = self.compute_fbank(samples);
+        if features.nrows() == 0 {
+            return Ok(ZipformerCtcResult {
+                text: String::new(),
+                token_ids: Vec::new(),
+            });
+        }
+
+        log::debug!("Computed {} frames, {} dims", features.nrows(), features.ncols());
+
+        let (log_probs, output_len) = self.forward(&features.view())?;
+        log::debug!(
+            "Forward pass done, output_len={}, log_probs shape=[{}, {}]",
+            output_len,
+            log_probs.shape()[0],
+            log_probs.shape()[1]
+        );
+
+        let token_ids = self.decode_ctc(&log_probs, output_len);
+        let text = self.symbol_table.decode(&token_ids);
+        log::debug!("Decoded {} tokens: {}", token_ids.len(), text);
+
+        Ok(ZipformerCtcResult { text, token_ids })
+    }
+}
+
+pub struct ZipformerCtcResult {
+    pub text: String,
+    pub token_ids: Vec<i32>,
+}

--- a/src/engines/zipformer_transducer/engine.rs
+++ b/src/engines/zipformer_transducer/engine.rs
@@ -1,0 +1,166 @@
+use std::path::{Path, PathBuf};
+
+use crate::{TranscriptionEngine, TranscriptionResult};
+
+#[cfg(feature = "punct")]
+use crate::{add_punctuation, add_punctuation_with_model};
+
+use super::model::ZipformerTransducerModel;
+
+#[derive(Debug, Clone, Default, PartialEq)]
+pub enum QuantizationType {
+    FP32,
+    #[default]
+    Int8,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct ZipformerTransducerModelParams {
+    pub quantization: QuantizationType,
+}
+
+impl ZipformerTransducerModelParams {
+    pub fn fp32() -> Self {
+        Self {
+            quantization: QuantizationType::FP32,
+        }
+    }
+
+    pub fn int8() -> Self {
+        Self {
+            quantization: QuantizationType::Int8,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ZipformerTransducerInferenceParams {
+    /// Whether to run punctuation restoration after ASR.
+    pub auto_punctuation: bool,
+    /// Optional custom punctuation model directory.
+    pub punct_model_dir: Option<PathBuf>,
+}
+
+impl Default for ZipformerTransducerInferenceParams {
+    fn default() -> Self {
+        Self {
+            auto_punctuation: true,
+            punct_model_dir: None,
+        }
+    }
+}
+
+impl ZipformerTransducerInferenceParams {
+    pub fn with_punctuation() -> Self {
+        Self {
+            auto_punctuation: true,
+            punct_model_dir: None,
+        }
+    }
+
+    pub fn without_punctuation() -> Self {
+        Self {
+            auto_punctuation: false,
+            punct_model_dir: None,
+        }
+    }
+
+    pub fn with_custom_punctuation_model(model_dir: PathBuf) -> Self {
+        Self {
+            auto_punctuation: true,
+            punct_model_dir: Some(model_dir),
+        }
+    }
+}
+
+pub struct ZipformerTransducerEngine {
+    loaded_model_path: Option<PathBuf>,
+    model: Option<ZipformerTransducerModel>,
+}
+
+impl ZipformerTransducerEngine {
+    pub fn new() -> Self {
+        Self {
+            loaded_model_path: None,
+            model: None,
+        }
+    }
+}
+
+impl Default for ZipformerTransducerEngine {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Drop for ZipformerTransducerEngine {
+    fn drop(&mut self) {
+        self.unload_model();
+    }
+}
+
+impl TranscriptionEngine for ZipformerTransducerEngine {
+    type InferenceParams = ZipformerTransducerInferenceParams;
+    type ModelParams = ZipformerTransducerModelParams;
+
+    fn load_model_with_params(
+        &mut self,
+        model_path: &Path,
+        params: Self::ModelParams,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        self.unload_model();
+
+        let quantized = matches!(params.quantization, QuantizationType::Int8);
+        let model = ZipformerTransducerModel::new(model_path, quantized)?;
+        self.model = Some(model);
+        self.loaded_model_path = Some(model_path.to_path_buf());
+
+        log::info!("Loaded Zipformer Transducer model from {:?}", model_path);
+        Ok(())
+    }
+
+    fn unload_model(&mut self) {
+        if self.model.is_some() {
+            log::debug!("Unloading Zipformer Transducer model");
+            self.model = None;
+            self.loaded_model_path = None;
+        }
+    }
+
+    fn transcribe_samples(
+        &mut self,
+        samples: Vec<f32>,
+        params: Option<Self::InferenceParams>,
+    ) -> Result<TranscriptionResult, Box<dyn std::error::Error>> {
+        let model = self
+            .model
+            .as_mut()
+            .ok_or("Model not loaded. Call load_model() first.")?;
+
+        let params = params.unwrap_or_default();
+        let result = model.transcribe(&samples)?;
+        log::debug!("Decoded {} zipformer transducer tokens", result.token_ids.len());
+
+        let text = if params.auto_punctuation {
+            #[cfg(feature = "punct")]
+            {
+                if let Some(model_dir) = params.punct_model_dir.as_ref() {
+                    add_punctuation_with_model(&result.text, model_dir)
+                } else {
+                    add_punctuation(&result.text)
+                }
+            }
+            #[cfg(not(feature = "punct"))]
+            {
+                result.text
+            }
+        } else {
+            result.text
+        };
+
+        Ok(TranscriptionResult {
+            text,
+            segments: None,
+        })
+    }
+}

--- a/src/engines/zipformer_transducer/mod.rs
+++ b/src/engines/zipformer_transducer/mod.rs
@@ -1,0 +1,13 @@
+//! Zipformer Transducer (RNN-T) ONNX transcription engine.
+//!
+//! This module provides an ONNX implementation for Zipformer Transducer models
+//! such as `sherpa-onnx-zipformer-zh-en-2023-11-22` (multilingual zh/en).
+//! These models use 3 separate ONNX components: encoder, decoder, joiner.
+
+mod engine;
+mod model;
+
+pub use engine::{
+    ZipformerTransducerEngine, ZipformerTransducerInferenceParams,
+    ZipformerTransducerModelParams, QuantizationType,
+};

--- a/src/engines/zipformer_transducer/model.rs
+++ b/src/engines/zipformer_transducer/model.rs
@@ -1,0 +1,403 @@
+use std::path::Path;
+
+use ndarray::Array2;
+use ort::execution_providers::CPUExecutionProvider;
+use ort::inputs;
+use ort::session::builder::GraphOptimizationLevel;
+use ort::session::Session;
+use ort::value::TensorRef;
+
+use super::super::zipformer_common::*;
+
+#[derive(thiserror::Error, Debug)]
+pub enum ZipformerTransducerError {
+    #[error("ORT error: {0}")]
+    Ort(#[from] ort::Error),
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("Shape error: {0}")]
+    Shape(#[from] ndarray::ShapeError),
+    #[error("Model file not found: {0}")]
+    ModelNotFound(String),
+    #[error("Tokens file not found: {0}")]
+    TokensNotFound(String),
+    #[error("Output not found: {0}")]
+    OutputNotFound(String),
+}
+
+pub struct ZipformerTransducerModel {
+    encoder_session: Session,
+    decoder_session: Session,
+    joiner_session: Session,
+    symbol_table: SymbolTable,
+    blank_id: i32,
+    context_size: usize,
+    // Encoder I/O names
+    enc_x_name: String,
+    enc_x_lens_name: String,
+    enc_out_name: String,
+    enc_out_lens_name: String,
+    // Decoder I/O names
+    dec_y_name: String,
+    dec_out_name: String,
+    // Joiner I/O names
+    join_enc_name: String,
+    join_dec_name: String,
+    join_logit_name: String,
+}
+
+impl Drop for ZipformerTransducerModel {
+    fn drop(&mut self) {
+        log::debug!("Dropping ZipformerTransducerModel");
+    }
+}
+
+impl ZipformerTransducerModel {
+    pub fn new(model_dir: &Path, quantized: bool) -> Result<Self, ZipformerTransducerError> {
+        let suffix = if quantized { "int8" } else { "fp32" };
+
+        let encoder_path = Self::find_model_file(model_dir, "encoder", suffix)?;
+        let decoder_path = Self::find_model_file(model_dir, "decoder", suffix)?;
+        let joiner_path = Self::find_model_file(model_dir, "joiner", suffix)?;
+
+        let tokens_path = model_dir.join("tokens.txt");
+        if !tokens_path.exists() {
+            return Err(ZipformerTransducerError::TokensNotFound(
+                tokens_path.display().to_string(),
+            ));
+        }
+
+        log::info!("Loading Zipformer Transducer encoder from {:?}", encoder_path);
+        let encoder_session = Self::init_session(&encoder_path)?;
+        log::info!("Loading Zipformer Transducer decoder from {:?}", decoder_path);
+        let decoder_session = Self::init_session(&decoder_path)?;
+        log::info!("Loading Zipformer Transducer joiner from {:?}", joiner_path);
+        let joiner_session = Self::init_session(&joiner_path)?;
+
+        let symbol_table = SymbolTable::load_autodetect(&tokens_path)?;
+
+        // Detect encoder I/O names
+        let enc_inputs: Vec<String> = encoder_session.inputs.iter().map(|i| i.name.clone()).collect();
+        let enc_outputs: Vec<String> = encoder_session.outputs.iter().map(|o| o.name.clone()).collect();
+
+        let enc_x_name = Self::find_name(&enc_inputs, &["x"])
+            .unwrap_or_else(|| enc_inputs[0].clone());
+        let enc_x_lens_name = Self::find_name(&enc_inputs, &["x_lens", "x_length"])
+            .unwrap_or_else(|| enc_inputs.get(1).cloned().unwrap_or_else(|| enc_inputs[0].clone()));
+        let enc_out_name = Self::find_name(&enc_outputs, &["encoder_out"])
+            .unwrap_or_else(|| enc_outputs[0].clone());
+        let enc_out_lens_name = Self::find_name(&enc_outputs, &["encoder_out_lens", "encoder_out_length"])
+            .unwrap_or_else(|| enc_outputs.get(1).cloned().unwrap_or_else(|| enc_outputs[0].clone()));
+
+        // Detect decoder I/O names
+        let dec_inputs: Vec<String> = decoder_session.inputs.iter().map(|i| i.name.clone()).collect();
+        let dec_outputs: Vec<String> = decoder_session.outputs.iter().map(|o| o.name.clone()).collect();
+
+        let dec_y_name = Self::find_name(&dec_inputs, &["y"])
+            .unwrap_or_else(|| dec_inputs[0].clone());
+        let dec_out_name = Self::find_name(&dec_outputs, &["decoder_out"])
+            .unwrap_or_else(|| dec_outputs[0].clone());
+
+        // Context size is 2 for all sherpa-onnx zipformer transducer models
+        let context_size = 2;
+        log::info!("Using context_size={}", context_size);
+
+        // Detect joiner I/O names
+        let join_inputs: Vec<String> = joiner_session.inputs.iter().map(|i| i.name.clone()).collect();
+        let join_outputs: Vec<String> = joiner_session.outputs.iter().map(|o| o.name.clone()).collect();
+
+        let join_enc_name = Self::find_name(&join_inputs, &["encoder_out"])
+            .unwrap_or_else(|| join_inputs[0].clone());
+        let join_dec_name = Self::find_name(&join_inputs, &["decoder_out"])
+            .unwrap_or_else(|| join_inputs.get(1).cloned().unwrap_or_else(|| join_inputs[0].clone()));
+        let join_logit_name = Self::find_name(&join_outputs, &["logit"])
+            .unwrap_or_else(|| join_outputs[0].clone());
+
+        log::info!(
+            "Encoder I/O: x='{}', x_lens='{}' -> out='{}', out_lens='{}'",
+            enc_x_name, enc_x_lens_name, enc_out_name, enc_out_lens_name
+        );
+        log::info!(
+            "Decoder I/O: y='{}' -> out='{}'",
+            dec_y_name, dec_out_name
+        );
+        log::info!(
+            "Joiner I/O: enc='{}', dec='{}' -> logit='{}'",
+            join_enc_name, join_dec_name, join_logit_name
+        );
+
+        let blank_id = 0;
+
+        Ok(Self {
+            encoder_session,
+            decoder_session,
+            joiner_session,
+            symbol_table,
+            blank_id,
+            context_size,
+            enc_x_name,
+            enc_x_lens_name,
+            enc_out_name,
+            enc_out_lens_name,
+            dec_y_name,
+            dec_out_name,
+            join_enc_name,
+            join_dec_name,
+            join_logit_name,
+        })
+    }
+
+    /// Find an ONNX model file by component name, trying various naming conventions.
+    /// e.g. encoder-epoch-34-avg-19.int8.onnx, encoder.int8.onnx, encoder.onnx
+    fn find_model_file(
+        model_dir: &Path,
+        component: &str,
+        suffix: &str,
+    ) -> Result<std::path::PathBuf, ZipformerTransducerError> {
+        // Try exact names first
+        let exact_suffixed = model_dir.join(format!("{component}.{suffix}.onnx"));
+        if exact_suffixed.exists() {
+            return Ok(exact_suffixed);
+        }
+        let exact = model_dir.join(format!("{component}.onnx"));
+        if exact.exists() {
+            return Ok(exact);
+        }
+
+        // Glob for pattern: component*.suffix.onnx then component*.onnx
+        if let Ok(entries) = std::fs::read_dir(model_dir) {
+            let files: Vec<_> = entries
+                .filter_map(|e| e.ok())
+                .map(|e| e.file_name().to_string_lossy().to_string())
+                .collect();
+
+            // Prefer suffixed (e.g. int8) variant
+            if let Some(f) = files.iter().find(|f| {
+                f.starts_with(component)
+                    && f.ends_with(&format!(".{suffix}.onnx"))
+            }) {
+                return Ok(model_dir.join(f));
+            }
+
+            // Fall back to any matching component ONNX
+            if let Some(f) = files.iter().find(|f| {
+                f.starts_with(component) && f.ends_with(".onnx")
+            }) {
+                return Ok(model_dir.join(f));
+            }
+        }
+
+        Err(ZipformerTransducerError::ModelNotFound(format!(
+            "No {component}*.onnx found in {}",
+            model_dir.display()
+        )))
+    }
+
+    fn find_name(names: &[String], candidates: &[&str]) -> Option<String> {
+        for &candidate in candidates {
+            if let Some(n) = names.iter().find(|n| n.as_str() == candidate) {
+                return Some(n.clone());
+            }
+        }
+        None
+    }
+
+    fn init_session(path: &Path) -> Result<Session, ZipformerTransducerError> {
+        let session = Session::builder()?
+            .with_optimization_level(GraphOptimizationLevel::Level3)?
+            .with_execution_providers([CPUExecutionProvider::default().build()])?
+            .commit_from_file(path)?;
+
+        for input in &session.inputs {
+            log::info!(
+                "  input: name={}, type={:?}",
+                input.name,
+                input.input_type
+            );
+        }
+        for output in &session.outputs {
+            log::info!(
+                "  output: name={}, type={:?}",
+                output.name,
+                output.output_type
+            );
+        }
+        Ok(session)
+    }
+
+    fn compute_fbank(&self, samples: &[f32]) -> Array2<f32> {
+        compute_fbank_kaldi(samples, &FbankConfig::default())
+    }
+
+    /// Run the encoder: features [N,T,80] + lens [N] -> encoder_out [N,T',D] + encoder_out_lens [N]
+    fn run_encoder(
+        &mut self,
+        features: &Array2<f32>,
+    ) -> Result<(ndarray::Array3<f32>, i64), ZipformerTransducerError> {
+        let num_frames = features.nrows();
+        let num_features = features.ncols();
+
+        let feat_3d = features
+            .to_owned()
+            .into_shape_with_order((1, num_frames, num_features))?;
+        let feat_dyn = feat_3d.into_dyn();
+        let lens = ndarray::arr1(&[num_frames as i64]).into_dyn();
+
+        let inputs = inputs![
+            self.enc_x_name.as_str() => TensorRef::from_array_view(feat_dyn.view())?,
+            self.enc_x_lens_name.as_str() => TensorRef::from_array_view(lens.view())?,
+        ];
+
+        let outputs = self.encoder_session.run(inputs)?;
+
+        let encoder_out = outputs
+            .get(self.enc_out_name.as_str())
+            .ok_or_else(|| ZipformerTransducerError::OutputNotFound(self.enc_out_name.clone()))?
+            .try_extract_array::<f32>()?
+            .to_owned()
+            .into_dimensionality::<ndarray::Ix3>()?;
+
+        let encoder_out_lens = outputs
+            .get(self.enc_out_lens_name.as_str())
+            .and_then(|v| v.try_extract_array::<i64>().ok())
+            .and_then(|arr| arr.as_slice().and_then(|s| s.first().copied()))
+            .unwrap_or(encoder_out.shape()[1] as i64);
+
+        log::debug!(
+            "Encoder output: shape={:?}, lens={}",
+            encoder_out.shape(),
+            encoder_out_lens
+        );
+
+        Ok((encoder_out, encoder_out_lens))
+    }
+
+    /// Run the decoder: y [N, context_size] (i64) -> decoder_out [N, D]
+    fn run_decoder(
+        &mut self,
+        context: &[i64],
+    ) -> Result<ndarray::Array2<f32>, ZipformerTransducerError> {
+        let y = ndarray::Array2::from_shape_vec(
+            (1, self.context_size),
+            context.to_vec(),
+        )?;
+        let y_dyn = y.into_dyn();
+
+        let inputs = inputs![
+            self.dec_y_name.as_str() => TensorRef::from_array_view(y_dyn.view())?,
+        ];
+
+        let outputs = self.decoder_session.run(inputs)?;
+
+        let decoder_out = outputs
+            .get(self.dec_out_name.as_str())
+            .ok_or_else(|| ZipformerTransducerError::OutputNotFound(self.dec_out_name.clone()))?
+            .try_extract_array::<f32>()?
+            .to_owned()
+            .into_dimensionality::<ndarray::Ix2>()?;
+
+        Ok(decoder_out)
+    }
+
+    /// Run the joiner: encoder_out [N, D] + decoder_out [N, D] -> logit [N, vocab_size]
+    fn run_joiner(
+        &mut self,
+        encoder_out_frame: &ndarray::ArrayView1<f32>,
+        decoder_out: &ndarray::Array2<f32>,
+    ) -> Result<ndarray::Array2<f32>, ZipformerTransducerError> {
+        // encoder_out_frame is [D], reshape to [1, D]
+        let enc = encoder_out_frame
+            .to_owned()
+            .into_shape_with_order((1, encoder_out_frame.len()))?
+            .into_dyn();
+
+        let dec_dyn = decoder_out.clone().into_dyn();
+
+        let inputs = inputs![
+            self.join_enc_name.as_str() => TensorRef::from_array_view(enc.view())?,
+            self.join_dec_name.as_str() => TensorRef::from_array_view(dec_dyn.view())?,
+        ];
+
+        let outputs = self.joiner_session.run(inputs)?;
+
+        let logit = outputs
+            .get(self.join_logit_name.as_str())
+            .ok_or_else(|| ZipformerTransducerError::OutputNotFound(self.join_logit_name.clone()))?
+            .try_extract_array::<f32>()?
+            .to_owned()
+            .into_dimensionality::<ndarray::Ix2>()?;
+
+        Ok(logit)
+    }
+
+    /// Greedy search decoding for transducer models.
+    fn greedy_search(
+        &mut self,
+        features: &Array2<f32>,
+    ) -> Result<Vec<i32>, ZipformerTransducerError> {
+        let (encoder_out, encoder_out_lens) = self.run_encoder(features)?;
+        let t_max = (encoder_out_lens as usize).min(encoder_out.shape()[1]);
+
+        // Initialize decoder context with blank_id
+        let mut context = vec![self.blank_id as i64; self.context_size];
+        let mut decoder_out = self.run_decoder(&context)?;
+
+        let mut tokens = Vec::new();
+
+        for t in 0..t_max {
+            let enc_frame = encoder_out.slice(ndarray::s![0, t, ..]);
+            let logit = self.run_joiner(&enc_frame, &decoder_out)?;
+
+            // argmax over vocab dimension
+            let logit_row = logit.row(0);
+            let mut max_id = 0usize;
+            let mut max_val = f32::NEG_INFINITY;
+            for (i, &v) in logit_row.iter().enumerate() {
+                if v > max_val {
+                    max_val = v;
+                    max_id = i;
+                }
+            }
+
+            if max_id as i32 != self.blank_id {
+                tokens.push(max_id as i32);
+                // Slide context window and re-run decoder
+                context.rotate_left(1);
+                *context.last_mut().unwrap() = max_id as i64;
+                decoder_out = self.run_decoder(&context)?;
+            }
+        }
+
+        Ok(tokens)
+    }
+
+    pub fn transcribe(
+        &mut self,
+        samples: &[f32],
+    ) -> Result<ZipformerTransducerResult, ZipformerTransducerError> {
+        let features = self.compute_fbank(samples);
+        if features.nrows() == 0 {
+            return Ok(ZipformerTransducerResult {
+                text: String::new(),
+                token_ids: Vec::new(),
+            });
+        }
+
+        log::debug!(
+            "Computed {} frames, {} dims",
+            features.nrows(),
+            features.ncols()
+        );
+
+        let token_ids = self.greedy_search(&features)?;
+        let text = self.symbol_table.decode(&token_ids);
+        log::debug!("Decoded {} tokens: {:?} -> {}", token_ids.len(), token_ids, text);
+
+        Ok(ZipformerTransducerResult { text, token_ids })
+    }
+}
+
+pub struct ZipformerTransducerResult {
+    pub text: String,
+    pub token_ids: Vec<i32>,
+}


### PR DESCRIPTION
## Summary
- Add **Zipformer CTC** engine: single ONNX model with CTC greedy decoding
- Add **Zipformer Transducer (RNN-T)** engine: 3-component architecture (encoder/decoder/joiner) with autoregressive greedy search
- Extract shared code (FBank, SymbolTable, BBPE) into `zipformer_common` module to avoid duplication

## Features
- Auto-detects model file naming variants (`encoder-epoch-34-avg-19.int8.onnx`, `encoder.int8.onnx`, etc.)
- Auto-detects BBPE vs standard BPE token encoding via `bbpe.model` file presence
- Mixed quantization support (e.g. int8 encoder + fp32 decoder)
- Follows the same `TranscriptionEngine` trait pattern as other engines

## Tested Models
- `sherpa-onnx-zipformer-zh-en-2023-11-22` (Chinese-English bilingual, BBPE)
- `sherpa-onnx-zipformer-vi-30M-int8-2026-02-09` (Vietnamese, BPE)
- `sherpa-onnx-zipformer-ru-int8-2025-04-20` (Russian, BPE)
- `sherpa-onnx-zipformer-korean-2024-06-24` (Korean, BPE)

## Test plan
- [x] `cargo build --features zipformer-ctc` compiles
- [x] `cargo build --features zipformer-transducer` compiles
- [x] Transcription output verified against test wavs for all 4 models
- [x] Punctuation restoration works with `punct` feature

🤖 Generated with [Claude Code](https://claude.com/claude-code)