### PR TITLE
feat: add Paraformer engine with punctuation support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,8 @@ whisper = ["dep:whisper-rs", "dep:advapi32-sys"]
 parakeet = ["dep:ort", "dep:ndarray", "dep:regex", "dep:once_cell"]
 moonshine = ["dep:ort", "dep:ndarray"]
 sense_voice = ["dep:ort", "dep:ndarray", "dep:rustfft", "dep:base64"]
+sherpa = ["dep:ort", "dep:ndarray", "dep:rustfft"]
+paraformer = ["dep:ort", "dep:ndarray", "dep:rustfft"]
 whisperfile = ["dep:ureq"]
 
 # Remote engines
@@ -21,9 +23,10 @@ openai = ["dep:async-openai", "dep:tokio", "dep:async-trait"]
 
 # Post-processing
 itn = ["dep:nemo-text-processing"]
+punct = ["dep:ort", "dep:ndarray"]
 
 # Convenience
-all = ["whisper", "parakeet", "moonshine", "sense_voice", "whisperfile", "openai"]
+all = ["whisper", "parakeet", "moonshine", "sense_voice", "sherpa", "paraformer", "whisperfile", "openai", "punct"]
 
 [dependencies]
 # Always required
@@ -88,6 +91,14 @@ required-features = ["moonshine"]
 [[example]]
 name = "sense_voice"
 required-features = ["sense_voice"]
+
+[[example]]
+name = "paraformer"
+required-features = ["paraformer"]
+
+[[example]]
+name = "paraformer_punct"
+required-features = ["paraformer", "punct"]
 
 [[example]]
 name = "whisperfile"

--- a/examples/analyze_paraformer.rs
+++ b/examples/analyze_paraformer.rs
@@ -1,0 +1,25 @@
+use ort::execution_providers::CPUExecutionProvider;
+use ort::session::builder::GraphOptimizationLevel;
+use ort::session::Session;
+
+fn main() {
+    let model_path = "models/sherpa-paraformer/model.int8.onnx";
+
+    let session = Session::builder()
+        .expect("Failed to create session builder")
+        .with_optimization_level(GraphOptimizationLevel::Level3)
+        .expect("Failed to set optimization level")
+        .with_execution_providers(vec![CPUExecutionProvider::default().build()])
+        .expect("Failed to set execution providers")
+        .commit_from_file(model_path)
+        .expect("Failed to load model");
+
+    println!("=== Inputs ===");
+    for input in &session.inputs {
+        println!("{}: {:?}", input.name, input.input_type);
+    }
+    println!("=== Outputs ===");
+    for output in &session.outputs {
+        println!("{}: {:?}", output.name, output.output_type);
+    }
+}

--- a/examples/paraformer.rs
+++ b/examples/paraformer.rs
@@ -1,0 +1,98 @@
+use std::path::PathBuf;
+use std::time::Instant;
+
+use transcribe_rs::{
+    engines::paraformer::{ParaformerEngine, ParaformerInferenceParams, ParaformerModelParams},
+    TranscriptionEngine,
+};
+
+fn get_audio_duration(path: &PathBuf) -> Result<f64, Box<dyn std::error::Error>> {
+    let reader = hound::WavReader::open(path)?;
+    let spec = reader.spec();
+    let duration = reader.duration() as f64 / spec.sample_rate as f64;
+    Ok(duration)
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    env_logger::init();
+
+    let args: Vec<String> = std::env::args().collect();
+    let fp32 = args.iter().any(|a| a == "--fp32");
+    let force_punct = args.iter().any(|a| a == "--punct");
+    let disable_punct = args.iter().any(|a| a == "--no-punct");
+    let punct_model_dir = args
+        .iter()
+        .find_map(|a| a.strip_prefix("--punct-model="))
+        .map(PathBuf::from);
+    let int8 = !fp32;
+    let positional: Vec<&String> = args
+        .iter()
+        .skip(1)
+        .filter(|a| !a.starts_with("--"))
+        .collect();
+
+    let model_path = PathBuf::from(
+        positional
+            .first()
+            .map(|s| s.as_str())
+            .unwrap_or("models/sherpa-paraformer"),
+    );
+    let wav_path = PathBuf::from(
+        positional
+            .get(1)
+            .map(|s| s.as_str())
+            .unwrap_or("models/sherpa-paraformer/test_wavs/0.wav"),
+    );
+
+    let model_params = if int8 {
+        ParaformerModelParams::int8()
+    } else {
+        ParaformerModelParams::fp32()
+    };
+    let auto_punct = if disable_punct {
+        false
+    } else if force_punct {
+        true
+    } else {
+        ParaformerInferenceParams::default().auto_punctuation
+    };
+
+    let audio_duration = get_audio_duration(&wav_path)?;
+    println!("Audio duration: {:.2}s", audio_duration);
+    println!("Using Paraformer engine");
+    println!(
+        "Loading model: {:?} (quantization: {})",
+        model_path,
+        if int8 { "int8" } else { "fp32" }
+    );
+    println!("Auto punctuation: {}", auto_punct);
+    if let Some(ref p) = punct_model_dir {
+        println!("Punctuation model: {:?}", p);
+    }
+
+    let mut engine = ParaformerEngine::new();
+    let load_start = Instant::now();
+    engine.load_model_with_params(&model_path, model_params)?;
+    let load_duration = load_start.elapsed();
+    println!("Model loaded in {:.2?}", load_duration);
+
+    println!("Transcribing file: {:?}", wav_path);
+    let transcribe_start = Instant::now();
+    let infer_params = ParaformerInferenceParams {
+        auto_punctuation: auto_punct,
+        punct_model_dir,
+    };
+    let result = engine.transcribe_file(&wav_path, Some(infer_params))?;
+    let transcribe_duration = transcribe_start.elapsed();
+    println!("Transcription completed in {:.2?}", transcribe_duration);
+
+    let speedup_factor = audio_duration / transcribe_duration.as_secs_f64();
+    println!(
+        "Real-time speedup: {:.2}x faster than real-time",
+        speedup_factor
+    );
+    println!("Transcription result:\n{}", result.text);
+
+    engine.unload_model();
+    Ok(())
+}

--- a/examples/paraformer_punct.rs
+++ b/examples/paraformer_punct.rs
@@ -1,0 +1,47 @@
+use std::path::PathBuf;
+use std::time::Instant;
+
+use transcribe_rs::{
+    engines::paraformer::{ParaformerEngine, ParaformerModelParams},
+    punct::add_punctuation,
+    TranscriptionEngine,
+};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    env_logger::init();
+
+    let args: Vec<String> = std::env::args().collect();
+    let model_path = PathBuf::from(
+        args.get(1)
+            .map(|s| s.as_str())
+            .unwrap_or("models/sherpa-paraformer"),
+    );
+    let wav_path = PathBuf::from(
+        args.get(2)
+            .map(|s| s.as_str())
+            .unwrap_or("/Users/zac/Downloads/test.wav"),
+    );
+
+    let mut engine = ParaformerEngine::new();
+    let load_start = Instant::now();
+    engine.load_model_with_params(&model_path, ParaformerModelParams::int8())?;
+    let load_time = load_start.elapsed();
+
+    let infer_start = Instant::now();
+    let result = engine.transcribe_file(&wav_path, None)?;
+    let infer_time = infer_start.elapsed();
+    let transcribed_text = &result.text;
+    engine.unload_model();
+
+    let punctuated_text = add_punctuation(transcribed_text);
+
+    println!("Model: {:?}", model_path);
+    println!("Audio: {:?}", wav_path);
+    println!("Load time: {:.2?}", load_time);
+    println!("Infer time: {:.2?}", infer_time);
+    println!();
+    println!("Paraformer 识别: {}", transcribed_text);
+    println!("添加标点后: {}", punctuated_text);
+
+    Ok(())
+}

--- a/examples/punct_infer.rs
+++ b/examples/punct_infer.rs
@@ -1,0 +1,31 @@
+use std::fs::File;
+use std::io::Write;
+use transcribe_rs::punct::add_punctuation;
+
+fn main() {
+    let mut file = File::create("/Users/zac/clawd/transcribe-rs/punct_result.txt").unwrap();
+
+    // Test with proper spacing in input
+    let texts = vec![
+        // Input with proper English spacing
+        "hello world how are you today",
+        "this is a test for english punctuation",
+        // Mixed with Chinese
+        "你好吗 how are you today 我很好",
+        "今天天气不错 we should go outside",
+        "这是测试 test for mixed language",
+        // Original paraformer output (no spaces in English)
+        "让我测试一条完整的语音这条语音其实包含了englishandchinesedoyouknowthechinesemeans",
+    ];
+
+    writeln!(file, "=== Punctuation Test Results ===").unwrap();
+    for text in texts {
+        let result = add_punctuation(text);
+        writeln!(file, "Input:  {}", text).unwrap();
+        writeln!(file, "Output: {}", result).unwrap();
+        writeln!(file, "").unwrap();
+        println!("Input:  {}", text);
+        println!("Output: {}", result);
+        println!("");
+    }
+}

--- a/examples/punct_test.rs
+++ b/examples/punct_test.rs
@@ -1,0 +1,16 @@
+use transcribe_rs::punct::add_punctuation;
+
+fn main() {
+    // 测试 sherpa-paraformer 的输出（无标点）
+    let text = "让我测试一条完整的语音这条语音包含了englishandchinesedoyouknowthechinesemeans";
+
+    let result = add_punctuation(text);
+
+    println!("原文本: {}", text);
+    println!("加标点: {}", result);
+    println!();
+
+    // 测试问句
+    let question = "你叫什么名字";
+    println!("问句: {} -> {}", question, add_punctuation(question));
+}

--- a/src/engines/mod.rs
+++ b/src/engines/mod.rs
@@ -21,6 +21,8 @@
 
 #[cfg(feature = "moonshine")]
 pub mod moonshine;
+#[cfg(feature = "paraformer")]
+pub mod paraformer;
 #[cfg(feature = "parakeet")]
 pub mod parakeet;
 #[cfg(feature = "sense_voice")]

--- a/src/engines/paraformer/engine.rs
+++ b/src/engines/paraformer/engine.rs
@@ -1,0 +1,158 @@
+use std::path::{Path, PathBuf};
+
+use crate::{add_punctuation, add_punctuation_with_model};
+use crate::{TranscriptionEngine, TranscriptionResult};
+
+use super::model::ParaformerModel;
+
+#[derive(Debug, Clone, Default, PartialEq)]
+pub enum QuantizationType {
+    FP32,
+    #[default]
+    Int8,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct ParaformerModelParams {
+    pub quantization: QuantizationType,
+}
+
+impl ParaformerModelParams {
+    pub fn fp32() -> Self {
+        Self {
+            quantization: QuantizationType::FP32,
+        }
+    }
+
+    pub fn int8() -> Self {
+        Self {
+            quantization: QuantizationType::Int8,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ParaformerInferenceParams {
+    /// Whether to run punctuation restoration after ASR.
+    pub auto_punctuation: bool,
+    /// Optional custom punctuation model directory.
+    ///
+    /// If `None`, the default punctuation model path is used.
+    pub punct_model_dir: Option<PathBuf>,
+}
+
+impl Default for ParaformerInferenceParams {
+    fn default() -> Self {
+        Self {
+            auto_punctuation: true,
+            punct_model_dir: None,
+        }
+    }
+}
+
+impl ParaformerInferenceParams {
+    pub fn with_punctuation() -> Self {
+        Self {
+            auto_punctuation: true,
+            punct_model_dir: None,
+        }
+    }
+
+    pub fn without_punctuation() -> Self {
+        Self {
+            auto_punctuation: false,
+            punct_model_dir: None,
+        }
+    }
+
+    pub fn with_custom_punctuation_model(model_dir: PathBuf) -> Self {
+        Self {
+            auto_punctuation: true,
+            punct_model_dir: Some(model_dir),
+        }
+    }
+}
+
+pub struct ParaformerEngine {
+    loaded_model_path: Option<PathBuf>,
+    model: Option<ParaformerModel>,
+}
+
+impl ParaformerEngine {
+    pub fn new() -> Self {
+        Self {
+            loaded_model_path: None,
+            model: None,
+        }
+    }
+}
+
+impl Default for ParaformerEngine {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Drop for ParaformerEngine {
+    fn drop(&mut self) {
+        self.unload_model();
+    }
+}
+
+impl TranscriptionEngine for ParaformerEngine {
+    type InferenceParams = ParaformerInferenceParams;
+    type ModelParams = ParaformerModelParams;
+
+    fn load_model_with_params(
+        &mut self,
+        model_path: &Path,
+        params: Self::ModelParams,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        self.unload_model();
+
+        let quantized = matches!(params.quantization, QuantizationType::Int8);
+        let model = ParaformerModel::new(model_path, quantized)?;
+        self.model = Some(model);
+        self.loaded_model_path = Some(model_path.to_path_buf());
+
+        log::info!("Loaded Paraformer model from {:?}", model_path);
+        Ok(())
+    }
+
+    fn unload_model(&mut self) {
+        if self.model.is_some() {
+            log::debug!("Unloading Paraformer model");
+            self.model = None;
+            self.loaded_model_path = None;
+        }
+    }
+
+    fn transcribe_samples(
+        &mut self,
+        samples: Vec<f32>,
+        params: Option<Self::InferenceParams>,
+    ) -> Result<TranscriptionResult, Box<dyn std::error::Error>> {
+        let model = self
+            .model
+            .as_mut()
+            .ok_or("Model not loaded. Call load_model() first.")?;
+
+        let params = params.unwrap_or_default();
+        let result = model.transcribe(&samples)?;
+        log::debug!("Decoded {} paraformer tokens", result.token_ids.len());
+        let text = if params.auto_punctuation {
+            if let Some(model_dir) = params.punct_model_dir.as_ref() {
+                add_punctuation_with_model(&result.text, model_dir)
+            } else {
+                add_punctuation(&result.text)
+            }
+        } else {
+            result.text
+        };
+
+        Ok(TranscriptionResult {
+            text,
+            segments: None,
+        })
+    }
+}

--- a/src/engines/paraformer/features.rs
+++ b/src/engines/paraformer/features.rs
@@ -1,0 +1,163 @@
+use ndarray::{Array1, Array2};
+use rustfft::{num_complex::Complex, FftPlanner};
+
+#[derive(Debug, Clone)]
+pub struct FbankConfig {
+    pub num_bins: usize,
+    pub fft_size: usize,
+    pub window_size: usize,
+    pub hop_size: usize,
+    pub sample_rate: i32,
+    pub low_freq: f32,
+    pub high_freq: f32,
+}
+
+impl Default for FbankConfig {
+    fn default() -> Self {
+        Self {
+            num_bins: 80,
+            fft_size: 512,
+            window_size: 400,
+            hop_size: 160,
+            sample_rate: 16000,
+            low_freq: 0.0,
+            high_freq: 8000.0,
+        }
+    }
+}
+
+fn compute_mel_filterbank(config: &FbankConfig) -> Vec<Vec<f32>> {
+    let num_bins = config.num_bins;
+    let fft_size = config.fft_size;
+    let sample_rate = config.sample_rate as f32;
+    let low_freq = config.low_freq;
+    let high_freq = config.high_freq;
+
+    let hz_to_mel = |hz: f32| 2595.0 * (1.0 + hz / 700.0).log10();
+    let mel_to_hz = |mel: f32| 700.0 * (10.0_f32.powf(mel / 2595.0) - 1.0);
+
+    let low_mel = hz_to_mel(low_freq);
+    let high_mel = hz_to_mel(high_freq);
+
+    let num_points = num_bins + 2;
+    let mel_points: Vec<f32> = (0..num_points)
+        .map(|i| low_mel + (high_mel - low_mel) * i as f32 / (num_points - 1) as f32)
+        .collect();
+    let hz_points: Vec<f32> = mel_points.iter().map(|&m| mel_to_hz(m)).collect();
+    let fft_bins: Vec<usize> = hz_points
+        .iter()
+        .map(|&hz| ((hz * fft_size as f32) / sample_rate).floor() as usize)
+        .collect();
+
+    let mut filterbank = vec![vec![0.0f32; fft_size / 2 + 1]; num_bins];
+    for (i, filter) in filterbank.iter_mut().enumerate() {
+        let left = fft_bins[i];
+        let center = fft_bins[i + 1];
+        let right = fft_bins[i + 2];
+
+        for j in left..center {
+            if j < filter.len() {
+                filter[j] = (j - left) as f32 / (center - left) as f32;
+            }
+        }
+        for j in center..right {
+            if j < filter.len() {
+                filter[j] = (right - j) as f32 / (right - center) as f32;
+            }
+        }
+    }
+
+    filterbank
+}
+
+pub fn compute_fbank(samples: &[f32], config: &FbankConfig) -> Array2<f32> {
+    if samples.len() < config.window_size {
+        return Array2::zeros((0, config.num_bins));
+    }
+
+    let num_frames = (samples.len() - config.window_size) / config.hop_size + 1;
+    let filterbank = compute_mel_filterbank(config);
+    let fft_size = config.fft_size;
+    let half_fft = fft_size / 2 + 1;
+
+    let window: Vec<f32> = (0..config.window_size)
+        .map(|i| {
+            0.54 - 0.46
+                * (2.0 * std::f32::consts::PI * i as f32 / (config.window_size - 1) as f32).cos()
+        })
+        .collect();
+
+    let mut planner = FftPlanner::new();
+    let fft = planner.plan_fft_forward(fft_size);
+
+    let mut features = Vec::with_capacity(num_frames * config.num_bins);
+    for frame_idx in 0..num_frames {
+        let start = frame_idx * config.hop_size;
+
+        let mut buffer: Vec<Complex<f32>> = samples[start..start + config.window_size]
+            .iter()
+            .zip(window.iter())
+            .map(|(&s, &w)| Complex::new(s * w, 0.0))
+            .collect();
+        buffer.resize(fft_size, Complex::new(0.0, 0.0));
+
+        fft.process(&mut buffer);
+
+        let mut power = vec![0.0f32; half_fft];
+        for (i, c) in buffer.iter().take(half_fft).enumerate() {
+            power[i] = c.norm_sqr();
+        }
+
+        for filter in &filterbank {
+            let mut sum = 0.0f32;
+            for (i, &w) in filter.iter().take(half_fft).enumerate() {
+                sum += w * power[i];
+            }
+            features.push(if sum > 1e-10 {
+                10.0 * sum.log10()
+            } else {
+                -80.0
+            });
+        }
+    }
+
+    Array2::from_shape_vec((num_frames, config.num_bins), features).unwrap()
+}
+
+pub fn apply_lfr(features: &Array2<f32>, window_size: usize, window_shift: usize) -> Array2<f32> {
+    let num_frames = features.nrows();
+    let feat_dim = features.ncols();
+
+    if num_frames < window_size || window_size == 0 || window_shift == 0 {
+        return Array2::zeros((0, feat_dim.saturating_mul(window_size)));
+    }
+
+    let num_output_frames = (num_frames - window_size) / window_shift + 1;
+    let mut output = Array2::<f32>::zeros((num_output_frames, feat_dim * window_size));
+
+    for i in 0..num_output_frames {
+        let start = i * window_shift;
+        let frame_data = features.slice(ndarray::s![start..start + window_size, ..]);
+        for j in 0..window_size {
+            for k in 0..feat_dim {
+                output[[i, j * feat_dim + k]] = frame_data[[j, k]];
+            }
+        }
+    }
+
+    output
+}
+
+pub fn apply_mean_cmvn(features: &mut Array2<f32>, mean: &Array1<f32>) {
+    if features.ncols() == 0 || mean.is_empty() {
+        return;
+    }
+
+    for i in 0..features.nrows() {
+        for j in 0..features.ncols() {
+            if j < mean.len() {
+                features[[i, j]] -= mean[j];
+            }
+        }
+    }
+}

--- a/src/engines/paraformer/mod.rs
+++ b/src/engines/paraformer/mod.rs
@@ -1,0 +1,13 @@
+//! Paraformer ONNX transcription engine.
+//!
+//! This module provides a dedicated ONNX implementation for Paraformer models
+//! such as `models/sherpa-paraformer`, without depending on the sherpa engine.
+
+mod engine;
+mod features;
+mod model;
+mod tokens;
+
+pub use engine::{
+    ParaformerEngine, ParaformerInferenceParams, ParaformerModelParams, QuantizationType,
+};

--- a/src/engines/paraformer/model.rs
+++ b/src/engines/paraformer/model.rs
@@ -1,0 +1,450 @@
+use std::path::Path;
+
+use ndarray::{Array1, Array2, Array3, ArrayView2};
+use ort::execution_providers::CPUExecutionProvider;
+use ort::inputs;
+use ort::session::builder::GraphOptimizationLevel;
+use ort::session::Session;
+use ort::value::TensorRef;
+
+use super::features::{apply_lfr, apply_mean_cmvn, compute_fbank, FbankConfig};
+use super::tokens::SymbolTable;
+
+#[derive(thiserror::Error, Debug)]
+pub enum ParaformerError {
+    #[error("ORT error: {0}")]
+    Ort(#[from] ort::Error),
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("Shape error: {0}")]
+    Shape(#[from] ndarray::ShapeError),
+    #[error("Model file not found: {0}")]
+    ModelNotFound(String),
+    #[error("Tokens file not found: {0}")]
+    TokensNotFound(String),
+    #[error("Invalid model: {0}")]
+    InvalidModel(String),
+    #[error("Model output not found: {0}")]
+    OutputNotFound(String),
+}
+
+#[derive(Debug, Clone)]
+pub struct ParaformerMetadata {
+    pub lfr_window_size: usize,
+    pub lfr_window_shift: usize,
+    pub blank_id: i32,
+    pub sos_id: i32,
+    pub eos_id: i32,
+}
+
+impl Default for ParaformerMetadata {
+    fn default() -> Self {
+        Self {
+            lfr_window_size: 7,
+            lfr_window_shift: 6,
+            blank_id: 0,
+            sos_id: 1,
+            eos_id: 2,
+        }
+    }
+}
+
+pub struct ParaformerModel {
+    session: Session,
+    symbol_table: SymbolTable,
+    metadata: ParaformerMetadata,
+    cmvn_mean: Option<Array1<f32>>,
+    speech_input_name: String,
+    speech_lengths_input_name: String,
+    logits_output_name: String,
+    token_num_output_name: Option<String>,
+}
+
+impl Drop for ParaformerModel {
+    fn drop(&mut self) {
+        log::debug!("Dropping ParaformerModel");
+    }
+}
+
+impl ParaformerModel {
+    pub fn new(model_dir: &Path, quantized: bool) -> Result<Self, ParaformerError> {
+        let model_path = if quantized {
+            let int8_path = model_dir.join("model.int8.onnx");
+            if int8_path.exists() {
+                int8_path
+            } else {
+                log::warn!("Quantized model not found, falling back to model.onnx");
+                model_dir.join("model.onnx")
+            }
+        } else {
+            model_dir.join("model.onnx")
+        };
+        let tokens_path = model_dir.join("tokens.txt");
+        let cmvn_path = model_dir.join("am.mvn");
+
+        if !model_path.exists() {
+            return Err(ParaformerError::ModelNotFound(
+                model_path.display().to_string(),
+            ));
+        }
+        if !tokens_path.exists() {
+            return Err(ParaformerError::TokensNotFound(
+                tokens_path.display().to_string(),
+            ));
+        }
+
+        log::info!("Loading Paraformer model from {:?}...", model_path);
+        let session = Self::init_session(&model_path)?;
+        let symbol_table = SymbolTable::load(&tokens_path)?;
+        let metadata = Self::parse_metadata(&session)?;
+
+        let input_names: Vec<String> = session.inputs.iter().map(|i| i.name.clone()).collect();
+        let output_names: Vec<String> = session.outputs.iter().map(|o| o.name.clone()).collect();
+
+        if input_names.is_empty() || output_names.is_empty() {
+            return Err(ParaformerError::InvalidModel(
+                "Model has no inputs or outputs".to_string(),
+            ));
+        }
+
+        let speech_input_name = input_names
+            .iter()
+            .find(|n| n.as_str() == "speech")
+            .or_else(|| input_names.iter().find(|n| n.contains("speech")))
+            .cloned()
+            .unwrap_or_else(|| input_names[0].clone());
+
+        let speech_lengths_input_name = input_names
+            .iter()
+            .find(|n| n.as_str() == "speech_lengths")
+            .or_else(|| input_names.iter().find(|n| n.contains("length")))
+            .cloned()
+            .unwrap_or_else(|| {
+                if input_names.len() > 1 {
+                    input_names[1].clone()
+                } else {
+                    input_names[0].clone()
+                }
+            });
+
+        let logits_output_name = output_names
+            .iter()
+            .find(|n| n.as_str() == "logits")
+            .or_else(|| output_names.iter().find(|n| n.contains("logit")))
+            .cloned()
+            .unwrap_or_else(|| output_names[0].clone());
+
+        let token_num_output_name = output_names
+            .iter()
+            .find(|n| n.as_str() == "token_num")
+            .or_else(|| output_names.iter().find(|n| n.contains("token_num")))
+            .cloned();
+
+        log::info!(
+            "Paraformer I/O: speech='{}', speech_lengths='{}', logits='{}', token_num={:?}",
+            speech_input_name,
+            speech_lengths_input_name,
+            logits_output_name,
+            token_num_output_name
+        );
+        log::info!(
+            "Metadata: lfr_window_size={}, lfr_window_shift={}, blank_id={}, sos_id={}, eos_id={}",
+            metadata.lfr_window_size,
+            metadata.lfr_window_shift,
+            metadata.blank_id,
+            metadata.sos_id,
+            metadata.eos_id
+        );
+
+        let expected_dim = 80 * metadata.lfr_window_size;
+        let cmvn_mean = match Self::read_meta_float_vec(&session, "neg_mean") {
+            Ok(Some(v)) if v.len() >= expected_dim => {
+                let mean = Array1::from_vec(v.into_iter().take(expected_dim).collect());
+                log::info!("Loaded CMVN mean from ONNX metadata, dims={}", mean.len());
+                Some(mean)
+            }
+            Ok(Some(v)) => {
+                log::warn!(
+                    "ONNX metadata neg_mean dims={} < expected {}, fallback to am.mvn",
+                    v.len(),
+                    expected_dim
+                );
+                Self::load_cmvn_from_file(&cmvn_path, expected_dim)
+            }
+            Ok(None) | Err(_) => Self::load_cmvn_from_file(&cmvn_path, expected_dim),
+        };
+
+        Ok(Self {
+            session,
+            symbol_table,
+            metadata,
+            cmvn_mean,
+            speech_input_name,
+            speech_lengths_input_name,
+            logits_output_name,
+            token_num_output_name,
+        })
+    }
+
+    fn init_session(path: &Path) -> Result<Session, ParaformerError> {
+        let session = Session::builder()?
+            .with_optimization_level(GraphOptimizationLevel::Level3)?
+            .with_execution_providers([CPUExecutionProvider::default().build()])?
+            .with_parallel_execution(true)?
+            .commit_from_file(path)?;
+
+        for input in &session.inputs {
+            log::info!(
+                "Model input: name={}, type={:?}",
+                input.name,
+                input.input_type
+            );
+        }
+        for output in &session.outputs {
+            log::info!(
+                "Model output: name={}, type={:?}",
+                output.name,
+                output.output_type
+            );
+        }
+        Ok(session)
+    }
+
+    fn read_meta_i32(
+        session: &Session,
+        key: &str,
+        default: Option<i32>,
+    ) -> Result<i32, ParaformerError> {
+        let meta = session.metadata()?;
+        let value = meta.custom(key)?;
+        match value {
+            Some(v) => v.parse::<i32>().map_err(|e| {
+                ParaformerError::InvalidModel(format!("Failed to parse metadata '{}' : {}", key, e))
+            }),
+            None => default.ok_or_else(|| {
+                ParaformerError::InvalidModel(format!("Missing required metadata key: {}", key))
+            }),
+        }
+    }
+
+    fn read_meta_float_vec(
+        session: &Session,
+        key: &str,
+    ) -> Result<Option<Vec<f32>>, ParaformerError> {
+        let meta = session.metadata()?;
+        let value = meta.custom(key)?;
+        let Some(v) = value else {
+            return Ok(None);
+        };
+
+        let mut out = Vec::new();
+        for item in v.split(',') {
+            let item = item.trim();
+            if item.is_empty() {
+                continue;
+            }
+            out.push(item.parse::<f32>().map_err(|e| {
+                ParaformerError::InvalidModel(format!(
+                    "Failed to parse metadata float '{}' in key '{}': {}",
+                    item, key, e
+                ))
+            })?);
+        }
+        Ok(Some(out))
+    }
+
+    fn parse_metadata(session: &Session) -> Result<ParaformerMetadata, ParaformerError> {
+        // Most public paraformer exports do not include these keys. Keep defaults.
+        let mut meta = ParaformerMetadata::default();
+
+        if let Ok(v) = Self::read_meta_i32(
+            session,
+            "lfr_window_size",
+            Some(meta.lfr_window_size as i32),
+        ) {
+            meta.lfr_window_size = v.max(1) as usize;
+        }
+        if let Ok(v) = Self::read_meta_i32(
+            session,
+            "lfr_window_shift",
+            Some(meta.lfr_window_shift as i32),
+        ) {
+            meta.lfr_window_shift = v.max(1) as usize;
+        }
+        if let Ok(v) = Self::read_meta_i32(session, "blank_id", Some(meta.blank_id)) {
+            meta.blank_id = v;
+        }
+        if let Ok(v) = Self::read_meta_i32(session, "sos_id", Some(meta.sos_id)) {
+            meta.sos_id = v;
+        }
+        if let Ok(v) = Self::read_meta_i32(session, "eos_id", Some(meta.eos_id)) {
+            meta.eos_id = v;
+        }
+
+        Ok(meta)
+    }
+
+    fn load_cmvn_mean(
+        path: &Path,
+        target_dim: usize,
+    ) -> Result<Option<Array1<f32>>, std::io::Error> {
+        let content = std::fs::read_to_string(path)?;
+        let Some(start_idx) = content.find("<LearnRateCoef>") else {
+            return Ok(None);
+        };
+        let rest = &content[start_idx..];
+        let Some(lb_rel) = rest.find('[') else {
+            return Ok(None);
+        };
+        let Some(rb_rel) = rest.find(']') else {
+            return Ok(None);
+        };
+        if rb_rel <= lb_rel {
+            return Ok(None);
+        }
+
+        let body = &rest[lb_rel + 1..rb_rel];
+        let mut values = Vec::new();
+        for tok in body.split_whitespace() {
+            if let Ok(v) = tok.parse::<f32>() {
+                values.push(v);
+            }
+        }
+
+        if values.len() < target_dim {
+            return Ok(None);
+        }
+
+        Ok(Some(Array1::from_vec(
+            values.into_iter().take(target_dim).collect(),
+        )))
+    }
+
+    fn load_cmvn_from_file(cmvn_path: &Path, expected_dim: usize) -> Option<Array1<f32>> {
+        if cmvn_path.exists() {
+            match Self::load_cmvn_mean(cmvn_path, expected_dim) {
+                Ok(Some(mean)) => {
+                    log::info!("Loaded CMVN mean from am.mvn, dims={}", mean.len());
+                    Some(mean)
+                }
+                Ok(None) => {
+                    log::warn!("CMVN file exists but no usable mean parsed");
+                    None
+                }
+                Err(e) => {
+                    log::warn!("Failed to parse CMVN from {:?}: {}", cmvn_path, e);
+                    None
+                }
+            }
+        } else {
+            log::warn!("CMVN file not found: {:?}", cmvn_path);
+            None
+        }
+    }
+
+    fn compute_features(&self, samples: &[f32]) -> Array2<f32> {
+        let fbank = compute_fbank(samples, &FbankConfig::default());
+        let mut features = apply_lfr(
+            &fbank,
+            self.metadata.lfr_window_size,
+            self.metadata.lfr_window_shift,
+        );
+
+        if let Some(mean) = &self.cmvn_mean {
+            apply_mean_cmvn(&mut features, mean);
+        }
+
+        features
+    }
+
+    fn forward(
+        &mut self,
+        features: &ArrayView2<f32>,
+    ) -> Result<(Array3<f32>, Option<i32>), ParaformerError> {
+        let feat_3d =
+            features
+                .to_owned()
+                .into_shape_with_order((1, features.nrows(), features.ncols()))?;
+        let speech_len = ndarray::arr1(&[features.nrows() as i32]);
+
+        let feat_dyn = feat_3d.into_dyn();
+        let len_dyn = speech_len.into_dyn();
+
+        let inputs = inputs![
+            self.speech_input_name.as_str() => TensorRef::from_array_view(feat_dyn.view())?,
+            self.speech_lengths_input_name.as_str() => TensorRef::from_array_view(len_dyn.view())?,
+        ];
+
+        let outputs = self.session.run(inputs)?;
+
+        let logits = outputs
+            .get(self.logits_output_name.as_str())
+            .ok_or_else(|| ParaformerError::OutputNotFound(self.logits_output_name.clone()))?
+            .try_extract_array::<f32>()?
+            .to_owned()
+            .into_dimensionality::<ndarray::Ix3>()?;
+
+        let token_num = if let Some(name) = &self.token_num_output_name {
+            if let Some(v) = outputs.get(name.as_str()) {
+                let arr = v.try_extract_array::<i32>()?;
+                arr.as_slice().and_then(|s| s.first().copied())
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
+        Ok((logits, token_num))
+    }
+
+    fn decode_logits(&self, logits: &Array3<f32>, token_num: Option<i32>) -> Vec<i32> {
+        let seq_len = logits.shape()[1];
+        let vocab_size = logits.shape()[2];
+        let max_steps = token_num.unwrap_or(seq_len as i32).max(0) as usize;
+        let mut token_ids = Vec::with_capacity(max_steps.min(seq_len));
+
+        for t in 0..max_steps.min(seq_len) {
+            let mut max_id = 0i32;
+            let mut max_val = f32::NEG_INFINITY;
+            for v in 0..vocab_size {
+                let val = logits[[0, t, v]];
+                if val > max_val {
+                    max_val = val;
+                    max_id = v as i32;
+                }
+            }
+
+            if max_id == self.metadata.eos_id {
+                break;
+            }
+            if max_id == self.metadata.blank_id || max_id == self.metadata.sos_id {
+                continue;
+            }
+            token_ids.push(max_id);
+        }
+
+        token_ids
+    }
+
+    pub fn transcribe(&mut self, samples: &[f32]) -> Result<ParaformerResult, ParaformerError> {
+        let features = self.compute_features(samples);
+        if features.nrows() == 0 {
+            return Ok(ParaformerResult {
+                text: String::new(),
+                token_ids: Vec::new(),
+            });
+        }
+
+        let (logits, token_num) = self.forward(&features.view())?;
+        let token_ids = self.decode_logits(&logits, token_num);
+        let text = self.symbol_table.decode(&token_ids);
+
+        Ok(ParaformerResult { text, token_ids })
+    }
+}
+
+pub struct ParaformerResult {
+    pub text: String,
+    pub token_ids: Vec<i32>,
+}

--- a/src/engines/paraformer/tokens.rs
+++ b/src/engines/paraformer/tokens.rs
@@ -1,0 +1,117 @@
+use std::collections::HashMap;
+use std::fs;
+use std::path::Path;
+
+pub struct SymbolTable {
+    id_to_sym: HashMap<i32, String>,
+}
+
+impl SymbolTable {
+    pub fn load(path: &Path) -> Result<Self, std::io::Error> {
+        let contents = fs::read_to_string(path)?;
+        let mut id_to_sym = HashMap::new();
+
+        for line in contents.lines() {
+            let line = line.trim_end();
+            if line.is_empty() {
+                continue;
+            }
+
+            // Format: "token id" and keeps support for whitespace-like tokens.
+            let parts: Vec<&str> = line.rsplitn(2, |c: char| c.is_whitespace()).collect();
+            if parts.len() != 2 {
+                continue;
+            }
+
+            if let Ok(id) = parts[0].parse::<i32>() {
+                id_to_sym.insert(id, parts[1].to_string());
+            }
+        }
+
+        Ok(Self { id_to_sym })
+    }
+
+    pub fn get(&self, id: i32) -> Option<&str> {
+        self.id_to_sym.get(&id).map(|s| s.as_str())
+    }
+
+    pub fn decode(&self, token_ids: &[i32]) -> String {
+        let mut text = String::new();
+        let mut prev_join_to_next = false;
+
+        for &id in token_ids {
+            let Some(sym) = self.get(id) else {
+                continue;
+            };
+
+            if is_special_symbol(sym) {
+                continue;
+            }
+
+            let joins_next = sym.ends_with("@@");
+            let clean = sym.trim_end_matches("@@");
+
+            if clean.is_empty() {
+                prev_join_to_next = joins_next;
+                continue;
+            }
+
+            if clean.starts_with('▁') {
+                let piece = clean.trim_start_matches('▁');
+                if !piece.is_empty() {
+                    if !text.is_empty() && !text.ends_with(' ') {
+                        text.push(' ');
+                    }
+                    text.push_str(piece);
+                }
+                prev_join_to_next = joins_next;
+                continue;
+            }
+
+            if !text.is_empty() && !prev_join_to_next {
+                let prev_char = text.chars().last();
+                let curr_is_ascii_word = is_ascii_word_piece(clean);
+                let prev_is_ascii_word = prev_char.map(is_ascii_word_char).unwrap_or(false);
+                let prev_is_cjk = prev_char.map(is_cjk).unwrap_or(false);
+
+                // For mixed Chinese-English output, restore missing word boundaries.
+                if curr_is_ascii_word && (prev_is_ascii_word || prev_is_cjk) && !text.ends_with(' ')
+                {
+                    text.push(' ');
+                }
+            }
+
+            text.push_str(clean);
+            prev_join_to_next = joins_next;
+        }
+
+        text.trim().to_string()
+    }
+}
+
+fn is_special_symbol(sym: &str) -> bool {
+    sym == "<blank>"
+        || sym == "<s>"
+        || sym == "</s>"
+        || sym == "<unk>"
+        || sym == "<OOV>"
+        || (sym.starts_with('<') && sym.ends_with('>'))
+}
+
+fn is_ascii_word_piece(s: &str) -> bool {
+    !s.is_empty() && s.chars().all(is_ascii_word_char)
+}
+
+fn is_ascii_word_char(c: char) -> bool {
+    c.is_ascii_alphanumeric()
+}
+
+fn is_cjk(c: char) -> bool {
+    let code = c as u32;
+    (0x4E00..=0x9FFF).contains(&code)
+        || (0x3400..=0x4DBF).contains(&code)
+        || (0x20000..=0x2A6DF).contains(&code)
+        || (0x2A700..=0x2B73F).contains(&code)
+        || (0x2B740..=0x2B81F).contains(&code)
+        || (0x2B820..=0x2CEAF).contains(&code)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,6 +65,11 @@ pub mod itn;
 #[cfg(feature = "itn")]
 pub use itn::apply_itn;
 
+#[cfg(feature = "punct")]
+pub mod punct;
+#[cfg(feature = "punct")]
+pub use punct::{add_punctuation, add_punctuation_with_model};
+
 use std::path::Path;
 
 /// The result of a transcription operation.

--- a/src/punct.rs
+++ b/src/punct.rs
@@ -1,0 +1,722 @@
+//! Neural network-based Chinese punctuation restoration.
+//!
+//! Uses a CT-Transformer model to add punctuation to Chinese text.
+
+use std::collections::HashMap;
+use std::fs::File;
+use std::path::Path;
+
+use ndarray::{Array1, Array2};
+use ort::execution_providers::CPUExecutionProvider;
+use ort::inputs;
+use ort::session::builder::GraphOptimizationLevel;
+use ort::session::Session;
+use ort::value::TensorRef;
+
+#[derive(thiserror::Error, Debug)]
+pub enum PunctError {
+    #[error("ORT error: {0}")]
+    Ort(#[from] ort::Error),
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("JSON error: {0}")]
+    Json(#[from] serde_json::Error),
+    #[error("Model file not found: {0}")]
+    ModelNotFound(String),
+    #[error("Tokens file not found: {0}")]
+    TokensNotFound(String),
+    #[error("Model not loaded")]
+    ModelNotLoaded,
+    #[error("Inference error: {0}")]
+    Inference(String),
+}
+
+/// Punctuation types
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PunctType {
+    Underscore = 0, // 无标点
+    Comma = 2,      // ，
+    Dot = 3,        // 。
+    Quest = 4,      // ？
+    Pause = 5,      // 、 (shuanghao)
+}
+
+impl PunctType {
+    fn from_id(id: usize) -> Option<Self> {
+        match id {
+            0 => Some(PunctType::Underscore),
+            2 => Some(PunctType::Comma),
+            3 => Some(PunctType::Dot),
+            4 => Some(PunctType::Quest),
+            5 => Some(PunctType::Pause),
+            _ => None,
+        }
+    }
+
+    fn to_char(self) -> Option<char> {
+        match self {
+            PunctType::Underscore => None,
+            PunctType::Comma => Some('，'),
+            PunctType::Dot => Some('。'),
+            PunctType::Quest => Some('？'),
+            PunctType::Pause => Some('、'),
+        }
+    }
+
+    fn to_ascii_char(self) -> Option<char> {
+        match self {
+            PunctType::Underscore => None,
+            PunctType::Comma => Some(','),
+            PunctType::Dot => Some('.'),
+            PunctType::Quest => Some('?'),
+            PunctType::Pause => Some(','),
+        }
+    }
+}
+
+/// Neural punctuation model
+pub struct PunctModel {
+    session: Session,
+    token2id: HashMap<String, i32>,
+    id2token: Vec<String>,
+    unk_id: i32,
+    input_name: String,
+    length_name: String,
+}
+
+/// Token information for reconstruction
+#[derive(Debug, Clone)]
+enum TokenInfo {
+    Word(String), // English word or digit sequence
+    Char(char),   // Chinese character
+    Space,        // Space
+    Punct(char),  // Punctuation
+}
+
+impl PunctModel {
+    /// Load a punctuation model from a directory
+    pub fn new(model_dir: &Path) -> Result<Self, PunctError> {
+        let model_path = model_dir.join("model.int8.onnx");
+        let model_path = if !model_path.exists() {
+            model_dir.join("model.onnx")
+        } else {
+            model_path
+        };
+
+        let tokens_path = model_dir.join("tokens.json");
+
+        if !model_path.exists() {
+            return Err(PunctError::ModelNotFound(model_path.display().to_string()));
+        }
+        if !tokens_path.exists() {
+            return Err(PunctError::TokensNotFound(
+                tokens_path.display().to_string(),
+            ));
+        }
+
+        log::info!("Loading punctuation model from {:?}...", model_path);
+
+        let session = Self::init_session(&model_path)?;
+        let (token2id, id2token, unk_id) = Self::load_tokens(&tokens_path)?;
+
+        // Get input names
+        let input_name = session.inputs[0].name.clone();
+        let length_name = session.inputs[1].name.clone();
+
+        log::info!(
+            "Punct model input names: {} and {}",
+            input_name,
+            length_name
+        );
+
+        Ok(Self {
+            session,
+            token2id,
+            id2token,
+            unk_id,
+            input_name,
+            length_name,
+        })
+    }
+
+    fn init_session(path: &Path) -> Result<Session, PunctError> {
+        let providers = vec![CPUExecutionProvider::default().build()];
+
+        let session = Session::builder()?
+            .with_optimization_level(GraphOptimizationLevel::Level3)?
+            .with_execution_providers(providers)?
+            .with_parallel_execution(true)?
+            .commit_from_file(path)?;
+
+        for input in &session.inputs {
+            log::info!(
+                "Punct model input: name={}, type={:?}",
+                input.name,
+                input.input_type
+            );
+        }
+        for output in &session.outputs {
+            log::info!(
+                "Punct model output: name={}, type={:?}",
+                output.name,
+                output.output_type
+            );
+        }
+
+        Ok(session)
+    }
+
+    fn load_tokens(path: &Path) -> Result<(HashMap<String, i32>, Vec<String>, i32), PunctError> {
+        let file = File::open(path)?;
+        let tokens: Vec<String> = serde_json::from_reader(file)?;
+
+        let mut token2id = HashMap::new();
+        for (id, token) in tokens.iter().enumerate() {
+            token2id.insert(token.clone(), id as i32);
+        }
+
+        // Find unk token
+        let unk_id = *token2id.get("<unk>").unwrap_or(&0);
+
+        log::info!("Loaded {} tokens, unk_id={}", tokens.len(), unk_id);
+
+        Ok((token2id, tokens, unk_id))
+    }
+
+    /// Tokenize input text
+    /// Chinese characters are tokenized individually
+    /// English words are tokenized using BPE
+    /// Spaces are preserved as separate tokens
+    fn tokenize(&self, text: &str) -> (Vec<i32>, Vec<TokenInfo>) {
+        let mut ids = Vec::new();
+        let mut token_infos = Vec::new();
+        let mut current_word = String::new();
+
+        fn is_cjk(c: char) -> bool {
+            // CJK Unified Ideographs, CJK Extension A, etc.
+            let code = c as u32;
+            (0x4E00..=0x9FFF).contains(&code) ||  // CJK Unified Ideographs
+            (0x3400..=0x4DBF).contains(&code) ||   // CJK Extension A
+            (0x3000..=0x303F).contains(&code) // CJK Symbols
+        }
+
+        fn is_ascii_letter(c: char) -> bool {
+            c.is_ascii_alphabetic()
+        }
+
+        fn is_ascii_digit(c: char) -> bool {
+            c.is_ascii_digit()
+        }
+
+        // Collect all characters and process
+        let chars: Vec<char> = text.chars().collect();
+        let n = chars.len();
+
+        let mut i = 0;
+        while i < n {
+            let c = chars[i];
+            let is_c = is_cjk(c);
+            let is_a = is_ascii_letter(c);
+            let is_d = is_ascii_digit(c);
+
+            if is_c {
+                // Flush current word if any
+                if !current_word.is_empty() {
+                    if let Some(id) = self.token2id.get(&current_word) {
+                        ids.push(*id);
+                        token_infos.push(TokenInfo::Word(current_word.clone()));
+                    } else {
+                        ids.push(self.unk_id);
+                        token_infos.push(TokenInfo::Word(current_word.clone()));
+                    }
+                    current_word.clear();
+                }
+                // Add Chinese character
+                let char_str = c.to_string();
+                if let Some(id) = self.token2id.get(&char_str) {
+                    ids.push(*id);
+                    token_infos.push(TokenInfo::Char(c));
+                } else {
+                    ids.push(self.unk_id);
+                    token_infos.push(TokenInfo::Char(c));
+                }
+            } else if is_a || is_d {
+                // Collect English word or digit
+                current_word.push(c);
+            } else if c == ' ' {
+                // Flush current word if any
+                if !current_word.is_empty() {
+                    if let Some(id) = self.token2id.get(&current_word) {
+                        ids.push(*id);
+                        token_infos.push(TokenInfo::Word(current_word.clone()));
+                    } else {
+                        ids.push(self.unk_id);
+                        token_infos.push(TokenInfo::Word(current_word.clone()));
+                    }
+                    current_word.clear();
+                }
+                // Add space as a token
+                if let Some(id) = self.token2id.get(" ") {
+                    ids.push(*id);
+                    token_infos.push(TokenInfo::Space);
+                }
+            } else {
+                // Flush current word if any
+                if !current_word.is_empty() {
+                    if let Some(id) = self.token2id.get(&current_word) {
+                        ids.push(*id);
+                        token_infos.push(TokenInfo::Word(current_word.clone()));
+                    } else {
+                        ids.push(self.unk_id);
+                        token_infos.push(TokenInfo::Word(current_word.clone()));
+                    }
+                    current_word.clear();
+                }
+                // Handle punctuation - treat as separate token
+                let char_str = c.to_string();
+                if let Some(id) = self.token2id.get(&char_str) {
+                    ids.push(*id);
+                    token_infos.push(TokenInfo::Punct(c));
+                }
+            }
+            i += 1;
+        }
+
+        // Flush remaining word
+        if !current_word.is_empty() {
+            if let Some(id) = self.token2id.get(&current_word) {
+                ids.push(*id);
+                token_infos.push(TokenInfo::Word(current_word.clone()));
+            } else {
+                ids.push(self.unk_id);
+                token_infos.push(TokenInfo::Word(current_word.clone()));
+            }
+        }
+
+        (ids, token_infos)
+    }
+
+    /// Add punctuation to text
+    pub fn add_punctuation(&mut self, text: &str) -> String {
+        if text.is_empty() {
+            return String::new();
+        }
+
+        let (ids, token_infos) = self.tokenize(text);
+        if ids.is_empty() {
+            return text.to_string();
+        }
+
+        let segment_size = 20;
+        let max_len = 200;
+
+        let num_segments = (ids.len() + segment_size - 1) / segment_size;
+
+        let mut punctuations: Vec<usize> = Vec::new();
+        let mut last_end = 0;
+
+        for seg_idx in 0..num_segments {
+            let this_start = if seg_idx == 0 { 0 } else { last_end };
+            let this_end = std::cmp::min(this_start + segment_size, ids.len());
+
+            let inputs_ids: Vec<i32> = ids[this_start..this_end].to_vec();
+
+            // Create input tensors
+            let input_array = Array2::from_shape_vec((1, inputs_ids.len()), inputs_ids.clone())
+                .unwrap()
+                .mapv(|v| v as i32);
+            let length_array = Array1::from_vec(vec![inputs_ids.len() as i32]);
+
+            // Run inference
+            let inputs = inputs![
+                self.input_name.as_str() => TensorRef::from_array_view(input_array.view()).unwrap(),
+                self.length_name.as_str() => TensorRef::from_array_view(length_array.view()).unwrap(),
+            ];
+
+            let outputs = match self.session.run(inputs) {
+                Ok(o) => o,
+                Err(e) => {
+                    log::warn!("Inference failed: {:?}", e);
+                    // Fallback: no punctuation
+                    for _ in 0..inputs_ids.len() {
+                        punctuations.push(0);
+                    }
+                    continue;
+                }
+            };
+
+            let logits = outputs[0].try_extract_array::<f32>().unwrap();
+
+            // Get argmax along the last dimension (punctuation class)
+            let shape = logits.shape();
+            let mut seg_puncts = Vec::with_capacity(shape[1]);
+
+            for t in 0..shape[1] {
+                // Find argmax for each position
+                let mut max_idx = 0;
+                let mut max_val = f32::MIN;
+                for c in 0..shape[2] {
+                    let val = logits[[0, t, c]];
+                    if val > max_val {
+                        max_val = val;
+                        max_idx = c;
+                    }
+                }
+                seg_puncts.push(max_idx);
+            }
+
+            // Find the last punctuation position
+            let mut dot_index = -1;
+            let mut comma_index = -1;
+
+            for k in (2..seg_puncts.len()).rev() {
+                let p = seg_puncts[k];
+                if p == 3 || p == 4 {
+                    // Dot or Quest
+                    dot_index = k as isize;
+                    break;
+                }
+                if comma_index == -1 && p == 2 {
+                    comma_index = k as isize;
+                }
+            }
+
+            // Handle long segment
+            if dot_index == -1 && inputs_ids.len() >= max_len && comma_index != -1 {
+                dot_index = comma_index;
+                seg_puncts[dot_index as usize] = 3; // dot
+            }
+
+            // Handle end of text
+            if dot_index == -1 {
+                if seg_idx == 0 {
+                    last_end = this_start;
+                }
+                if seg_idx == num_segments - 1 {
+                    dot_index = (inputs_ids.len() - 1) as isize;
+                }
+            } else {
+                last_end = this_start + (dot_index as usize) + 1;
+            }
+
+            if dot_index != -1 {
+                punctuations.extend_from_slice(&seg_puncts[..=dot_index as usize]);
+            }
+        }
+
+        // Reconstruct text with punctuation, preserving spaces
+        self.reconstruct_with_punctuation(&token_infos, &punctuations)
+    }
+
+    /// Reconstruct text with punctuation
+    fn reconstruct_with_punctuation(
+        &self,
+        token_infos: &[TokenInfo],
+        punctuations: &[usize],
+    ) -> String {
+        let mut result = String::new();
+
+        for (i, info) in token_infos.iter().enumerate() {
+            // Determine if we need space before this token
+            if i > 0 {
+                let need_space = match (&token_infos[i - 1], info) {
+                    // Word to Word: add space (English words)
+                    (TokenInfo::Word(_), TokenInfo::Word(_)) => true,
+                    // Word to Char: add space (English to Chinese)
+                    (TokenInfo::Word(_), TokenInfo::Char(_)) => true,
+                    // Char to Word: add space (Chinese to English)
+                    (TokenInfo::Char(_), TokenInfo::Word(_)) => true,
+                    // After punctuation: add space
+                    (TokenInfo::Punct(_), _) => true,
+                    // After space: no extra space
+                    (TokenInfo::Space, _) => false,
+                    // Char to Char (Chinese): no space
+                    (TokenInfo::Char(_), TokenInfo::Char(_)) => false,
+                    _ => false,
+                };
+
+                if need_space && !result.ends_with(' ') {
+                    result.push(' ');
+                }
+            }
+
+            match info {
+                TokenInfo::Word(w) => result.push_str(w),
+                TokenInfo::Char(c) => result.push(*c),
+                TokenInfo::Space => {
+                    if !result.ends_with(' ') {
+                        result.push(' ');
+                    }
+                }
+                TokenInfo::Punct(c) => result.push(*c),
+            }
+
+            // Add punctuation after the token
+            if i < punctuations.len() {
+                let p = punctuations[i];
+                let prev_info = Some(info);
+                let next_info = token_infos.get(i + 1);
+                if let Some(punct_char) =
+                    PunctType::from_id(p).and_then(|pt| choose_punct_char(pt, prev_info, next_info))
+                {
+                    result.push(punct_char);
+                }
+            }
+        }
+
+        result
+    }
+}
+
+fn choose_punct_char(
+    pt: PunctType,
+    prev: Option<&TokenInfo>,
+    next: Option<&TokenInfo>,
+) -> Option<char> {
+    let prev_is_en = prev.map(is_english_token).unwrap_or(false);
+    let next_is_en = next.map(is_english_token).unwrap_or(false);
+    let prev_is_cjk = prev.map(is_cjk_token).unwrap_or(false);
+
+    // Avoid awkward Chinese sentence break right before an English phrase.
+    if matches!(pt, PunctType::Dot | PunctType::Comma | PunctType::Pause)
+        && prev_is_cjk
+        && next_is_en
+    {
+        return None;
+    }
+
+    if prev_is_en || next_is_en {
+        pt.to_ascii_char()
+    } else {
+        pt.to_char()
+    }
+}
+
+fn is_english_token(info: &TokenInfo) -> bool {
+    match info {
+        TokenInfo::Word(w) => {
+            let w = w.trim();
+            !w.is_empty()
+                && w.chars()
+                    .all(|c| c.is_ascii_alphanumeric() || c == '\'' || c == '-' || c == '_')
+        }
+        _ => false,
+    }
+}
+
+fn is_cjk_token(info: &TokenInfo) -> bool {
+    match info {
+        TokenInfo::Char(c) => is_cjk(*c),
+        _ => false,
+    }
+}
+
+fn is_cjk(c: char) -> bool {
+    let code = c as u32;
+    (0x4E00..=0x9FFF).contains(&code)
+        || (0x3400..=0x4DBF).contains(&code)
+        || (0x20000..=0x2A6DF).contains(&code)
+        || (0x2A700..=0x2B73F).contains(&code)
+        || (0x2B740..=0x2B81F).contains(&code)
+        || (0x2B820..=0x2CEAF).contains(&code)
+}
+
+/// Add punctuation to text using neural model
+///
+/// This is a convenience function that loads the model from the default path
+/// and applies punctuation restoration.
+///
+/// Note: If the text already has punctuation (Chinese or English),
+/// it will be returned as-is to avoid duplicate punctuation.
+pub fn add_punctuation(text: &str) -> String {
+    add_punctuation_with_model(
+        text,
+        Path::new("models/sherpa-onnx-punct-ct-transformer-zh-en-vocab272727-2024-04-12-int8"),
+    )
+}
+
+/// Add punctuation to text using a specific punctuation model directory.
+///
+/// `model_dir` should contain `model.int8.onnx` (or `model.onnx`) and `tokens.json`.
+pub fn add_punctuation_with_model(text: &str, model_dir: &Path) -> String {
+    // Check if text already has punctuation
+    if has_punctuation(text) {
+        log::info!("Text already has punctuation, skipping");
+        return text.to_string();
+    }
+
+    if let Ok(mut model) = PunctModel::new(model_dir) {
+        // First add English spaces (for Sherpa output)
+        let text_with_spaces = add_english_spaces(text);
+        return model.add_punctuation(&text_with_spaces);
+    }
+
+    // Fallback to rule-based
+    log::warn!("Failed to load neural punctuation model, using rule-based fallback");
+    add_punctuation_fallback(text)
+}
+
+/// Rule-based fallback for punctuation
+fn add_punctuation_fallback(text: &str) -> String {
+    let mut result = text.to_string();
+
+    if !result.is_empty() {
+        let last_char = result.chars().last().unwrap();
+        if !is_punctuation(last_char) {
+            if is_question(&result) {
+                result.push('?');
+            } else {
+                result.push('.');
+            }
+        }
+    }
+
+    result
+}
+
+fn is_punctuation(c: char) -> bool {
+    matches!(
+        c,
+        '.' | ',' | '?' | '!' | ';' | ':' | '"' | '\'' | '(' | ')' | '[' | ']'
+    )
+}
+
+/// Check if text already has punctuation (Chinese or English)
+fn has_punctuation(text: &str) -> bool {
+    // Check for Chinese punctuation
+    let chinese_punct = [
+        '，', '。', '？', '！', '、', '；', '：', '"', '"', '\'', '\'',
+    ];
+    for c in text.chars() {
+        if chinese_punct.contains(&c) {
+            return true;
+        }
+    }
+
+    // Check for English punctuation (at least one)
+    let mut has_eng_punct = false;
+    for c in text.chars() {
+        if is_punctuation(c) {
+            has_eng_punct = true;
+            break;
+        }
+    }
+
+    has_eng_punct
+}
+
+/// Add spaces between English words
+/// E.g., "helloworld" -> "hello world"
+/// This is a simple heuristic based on capital letters or known words
+fn add_english_spaces(text: &str) -> String {
+    let mut result = String::new();
+    let chars: Vec<char> = text.chars().collect();
+    let n = chars.len();
+
+    let mut i = 0;
+    while i < n {
+        let c = chars[i];
+
+        if c.is_ascii_lowercase() {
+            // Start of a lowercase sequence
+            let mut word_end = i;
+            while word_end < n && chars[word_end].is_ascii_lowercase() {
+                word_end += 1;
+            }
+
+            // Check if next char is uppercase (likely new word like "hELLO")
+            let has_uppercase_after = word_end < n && chars[word_end].is_ascii_uppercase();
+
+            // Also check for digit patterns
+            let has_digit_after = word_end < n && chars[word_end].is_ascii_digit();
+
+            // Add the lowercase word
+            for j in i..word_end {
+                result.push(chars[j]);
+            }
+
+            // Add space if followed by uppercase or digit
+            if has_uppercase_after || has_digit_after {
+                result.push(' ');
+            }
+
+            i = word_end;
+        } else if c.is_ascii_uppercase() {
+            // Start of uppercase sequence (could be CamelCase or new word)
+            if i > 0 && !result.is_empty() && !result.ends_with(' ') && !result.ends_with('(') {
+                // Add space before uppercase (except after space or parenthesis)
+                result.push(' ');
+            }
+
+            let mut word_end = i;
+            while word_end < n
+                && (chars[word_end].is_ascii_uppercase() || chars[word_end].is_ascii_lowercase())
+            {
+                word_end += 1;
+            }
+
+            for j in i..word_end {
+                result.push(chars[j]);
+            }
+
+            // Add space after if followed by lowercase
+            if word_end < n && chars[word_end].is_ascii_lowercase() {
+                result.push(' ');
+            }
+
+            i = word_end;
+        } else {
+            result.push(c);
+            i += 1;
+        }
+    }
+
+    result
+}
+
+fn is_question(text: &str) -> bool {
+    let question_indicators = [
+        "吗",
+        "呢",
+        "吧",
+        "啊",
+        "?",
+        "是不是",
+        "有没有",
+        "能不能",
+        "会不会",
+    ];
+    for indicator in question_indicators {
+        if text.contains(indicator) {
+            return true;
+        }
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_punct_model_load() {
+        let model_dir = Path::new(
+            "../models/sherpa-onnx-punct-ct-transformer-zh-en-vocab272727-2024-04-12-int8",
+        );
+        let model = PunctModel::new(model_dir);
+        assert!(model.is_ok());
+    }
+
+    #[test]
+    fn test_punct_model_inference() {
+        let model_dir = Path::new(
+            "../models/sherpa-onnx-punct-ct-transformer-zh-en-vocab272727-2024-04-12-int8",
+        );
+        let mut model = PunctModel::new(model_dir).unwrap();
+
+        let text = "你好吗 how are you";
+        let result = model.add_punctuation(text);
+        println!("Input: {}", text);
+        println!("Output: {}", result);
+    }
+}


### PR DESCRIPTION
## Summary
- Add new **Paraformer** ONNX engine for speech recognition
- Support Chinese, English, and Cantonese (trilingual)
- Add **punctuation restoration** model for text post-processing

## Recommended models
- `sherpa-onnx-paraformer-zh-2025-10-07`: Chinese (latest)
- sherpa trilingual: Chinese, English, Cantonese

## Test plan
- [x] `cargo build --features paraformer` compiles
- [x] `cargo build --features paraformer,punct` compiles
- [x] Transcription output verified with Chinese test audio
- [x] Punctuation restoration works correctly

Releated:
https://github.com/cjpais/transcribe-rs/pull/42