### PR TITLE
feat: add Qwen3-ASR batch transcription engine

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,9 @@ whisper-cuda   = ["whisper-cpp", "whisper-rs/cuda"]
 # Whisperfile server
 whisperfile = ["dep:ureq"]
 
+# Qwen3-ASR (ONNX, Whisper-compatible mel)
+qwen3 = ["onnx"]
+
 # Remote engines
 openai = ["dep:async-openai", "dep:tokio", "dep:async-trait"]
 
@@ -47,7 +50,7 @@ ort-tracing  = ["onnx", "ort/tracing"]
 ort-accel    = ["ort-cuda", "ort-tensorrt", "ort-directml", "ort-rocm", "ort-coreml", "ort-webgpu", "ort-xnnpack"]
 
 # Convenience
-all = ["onnx", "whisper-cpp", "whisperfile", "openai"]
+all = ["onnx", "whisper-cpp", "whisperfile", "openai", "qwen3"]
 
 [dependencies]
 # Always required
@@ -122,6 +125,14 @@ required-features = ["whisperfile"]
 name = "openai"
 required-features = ["openai"]
 
+[[example]]
+name = "qwen3"
+required-features = ["qwen3"]
+
+[[example]]
+name = "bench_compare"
+required-features = ["qwen3"]
+
 [dev-dependencies]
 once_cell = "1.21.3"
 
@@ -157,6 +168,10 @@ required-features = ["onnx"]
 [[test]]
 name = "whisperfile"
 required-features = ["whisperfile"]
+
+[[test]]
+name = "qwen3"
+required-features = ["qwen3"]
 
 [[test]]
 name = "openai"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # transcribe-rs
 
-Multi-engine speech-to-text library for Rust. Supports Parakeet, Canary, Cohere, Moonshine, SenseVoice, GigaAM, Whisper, Whisperfile, and OpenAI.
+Multi-engine speech-to-text library for Rust. Supports Parakeet, Canary, Cohere, Moonshine, SenseVoice, GigaAM, Whisper, Whisperfile, Qwen3-ASR, and OpenAI.
 
 ## Breaking Changes in 0.3.0
 
@@ -25,6 +25,7 @@ No features are enabled by default. Pick the engines you need:
 | Feature | Engines |
 |---------|---------|
 | `onnx` | Parakeet, Canary, Cohere, Moonshine, SenseVoice, GigaAM (via ONNX Runtime) |
+| `qwen3` | Qwen3-ASR (ONNX, multilingual) |
 | `whisper-cpp` | Whisper (local, GGML via whisper.cpp with Metal/Vulkan/CUDA) |
 | `whisperfile` | Whisperfile (local server wrapper) |
 | `openai` | OpenAI API (remote, async) |
@@ -236,6 +237,22 @@ let mut model = GigaAMModel::load(
 let result = model.transcribe_file(&PathBuf::from("audio.wav"), &transcribe_rs::TranscribeOptions::default())?;
 ```
 
+### Qwen3-ASR
+
+```rust
+use transcribe_rs::onnx::qwen3::Qwen3Model;
+use transcribe_rs::onnx::Quantization;
+use transcribe_rs::SpeechModel;
+use std::path::PathBuf;
+
+let mut model = Qwen3Model::load(
+    &PathBuf::from("models/qwen3-asr-0.6b"),
+    &Quantization::default(),
+)?;
+let result = model.transcribe_file(&PathBuf::from("audio.wav"), &transcribe_rs::TranscribeOptions::default())?;
+println!("{}", result.text);
+```
+
 ### Whisper (whisper.cpp)
 
 ```rust
@@ -324,6 +341,8 @@ All audio input must be **16 kHz, mono, 16-bit PCM WAV**.
 | SenseVoice (int8) | [blob.handy.computer](https://blob.handy.computer/sense-voice-int8.tar.gz) / [sherpa-onnx](https://github.com/k2-fsa/sherpa-onnx/releases/tag/asr-models) |
 | Moonshine | [blob.handy.computer (base)](https://blob.handy.computer/moonshine-base.tar.gz), [blob.handy.computer (tiny streaming en)](https://blob.handy.computer/moonshine-tiny-streaming-en.tar.gz), [blob.handy.computer (small streaming en)](https://blob.handy.computer/moonshine-small-streaming-en.tar.gz), [blob.handy.computer (medium streaming en)](https://blob.handy.computer/moonshine-medium-streaming-en.tar.gz) |
 | GigaAM | [HuggingFace](https://huggingface.co/istupakov/gigaam-v3-onnx/tree/main) |
+| Qwen3-ASR 0.6B | [HuggingFace](https://huggingface.co/andrewleech/qwen3-asr-0.6b-onnx) |
+| Qwen3-ASR 1.7B | [HuggingFace](https://huggingface.co/andrewleech/qwen3-asr-1.7b-onnx) |
 | Whisper (GGML) | [HuggingFace](https://huggingface.co/ggerganov/whisper.cpp/tree/main) |
 | Whisperfile binary | [GitHub](https://github.com/mozilla-ai/llamafile/releases/download/0.9.3/whisperfile-0.9.3) |
 
@@ -388,6 +407,19 @@ models/giga-am-v3/
 └── vocab.txt
 ```
 
+**Qwen3-ASR** (directory):
+```
+models/qwen3-asr-0.6b/
+├── encoder.onnx          # Audio encoder (+ .data weight file)
+├── decoder_init.onnx     # Decoder prefill (+ .data weight file)
+├── decoder_step.onnx     # Decoder autoregressive step (+ .data weight file)
+├── embed_tokens.bin      # Embedding matrix (raw f32)
+├── config.json           # Model configuration
+└── tokenizer.json        # HuggingFace BPE tokenizer
+```
+
+Export scripts: [qwen3-asr-onnx](https://github.com/andrewleech/qwen3-asr-onnx).
+
 **Whisper**: single file (e.g. `whisper-medium-q4_1.bin`).
 
 ### Moonshine Variants
@@ -416,6 +448,7 @@ cargo run --example sense_voice --features onnx
 cargo run --example moonshine --features onnx
 cargo run --example moonshine_streaming --features onnx
 cargo run --example gigaam --features onnx
+cargo run --example qwen3 --features qwen3
 cargo run --example whisper --features whisper-cpp
 cargo run --example whisperfile --features whisperfile
 cargo run --example openai --features openai
@@ -425,6 +458,7 @@ Tests are also feature-gated. Models must be present locally; tests skip gracefu
 
 ```bash
 cargo test --features onnx
+cargo test --features qwen3
 cargo test --features whisper-cpp
 cargo test --features whisperfile
 cargo test --all-features
@@ -460,3 +494,4 @@ Parakeet int8 benchmarks:
 - [UsefulSensors](https://github.com/usefulsensors) for Moonshine
 - [FunASR](https://github.com/modelscope/FunASR) / [sherpa-onnx](https://github.com/k2-fsa/sherpa-onnx) for SenseVoice
 - [SberDevices](https://github.com/salute-developers/GigaAM) for GigaAM
+- [Alibaba Qwen Team](https://github.com/QwenLM/Qwen3) for Qwen3

--- a/examples/bench_compare.rs
+++ b/examples/bench_compare.rs
@@ -1,0 +1,343 @@
+//! Side-by-side inference timing benchmark for Qwen3-ASR and Parakeet TDT.
+//!
+//! Loads one or both models, runs warmup passes then N timed passes on the
+//! same audio file, and prints a summary table with load time, mean/min/max
+//! inference time, and real-time factor (RTF) for each engine.
+//!
+//! # Usage
+//!
+//! ```sh
+//! cargo run --example bench_compare --features qwen3 --release -- \
+//!     --qwen3 models/qwen3-asr-0.6b --audio samples/jfk.wav
+//! ```
+//!
+//! Both engines:
+//!
+//! ```sh
+//! cargo run --example bench_compare --features "qwen3,onnx" --release -- \
+//!     --qwen3 models/qwen3-asr-0.6b \
+//!     --parakeet models/parakeet-tdt-0.6b-v3-int8 \
+//!     --audio samples/jfk.wav
+//! ```
+//!
+//! # Flags
+//!
+//! | Flag | Default | Description |
+//! |---|---|---|
+//! | `--qwen3 <path>` | — | Path to Qwen3-ASR model directory |
+//! | `--parakeet <path>` | — | Path to Parakeet-TDT model directory |
+//! | `--audio <path>` | `samples/jfk.wav` | Input WAV file (16 kHz mono) |
+//! | `--qwen3-quant <q>` | `fp32` | Qwen3 quantization: fp32, fp16, int8, int4 |
+//! | `--parakeet-quant <q>` | `int8` | Parakeet quantization: fp32, fp16, int8 |
+//! | `--accelerator <a>` | `auto` | ORT accelerator: auto, cpu, cuda, directml, rocm, coreml, webgpu |
+//! | `--decoder-gpu` | off | Run decoder on GPU (sets TRANSCRIBE_DECODER_GPU=1) |
+//! | `--warmup <n>` | `1` | Number of warmup passes (not timed) |
+//! | `--runs <n>` | `3` | Number of timed passes |
+//!
+//! For more representative RTF numbers use a longer clip (30-60 s). Any 16 kHz
+//! mono WAV works; a suitable public-domain source is LibriSpeech test-clean:
+//! <https://www.openslr.org/12>
+
+use std::path::PathBuf;
+use std::time::{Duration, Instant};
+
+use transcribe_rs::audio::read_wav_samples;
+use transcribe_rs::onnx::Quantization;
+use transcribe_rs::{
+    set_decoder_gpu, set_ort_accelerator, OrtAccelerator, SpeechModel, TranscribeOptions,
+};
+
+#[cfg(feature = "qwen3")]
+use transcribe_rs::onnx::qwen3::Qwen3Model;
+
+#[cfg(feature = "onnx")]
+use transcribe_rs::onnx::parakeet::ParakeetModel;
+
+struct BenchResult {
+    label: String,
+    load_time: Duration,
+    times: Vec<Duration>,
+    text: String,
+}
+
+impl BenchResult {
+    fn mean_secs(&self) -> f64 {
+        self.times.iter().map(|d| d.as_secs_f64()).sum::<f64>() / self.times.len() as f64
+    }
+    fn min_secs(&self) -> f64 {
+        self.times
+            .iter()
+            .map(|d| d.as_secs_f64())
+            .fold(f64::INFINITY, f64::min)
+    }
+    fn max_secs(&self) -> f64 {
+        self.times
+            .iter()
+            .map(|d| d.as_secs_f64())
+            .fold(f64::NEG_INFINITY, f64::max)
+    }
+}
+
+fn bench_model(
+    label: &str,
+    model: &mut dyn SpeechModel,
+    samples: &[f32],
+    n_warmup: usize,
+    n_runs: usize,
+    load_time: Duration,
+) -> BenchResult {
+    let options = TranscribeOptions::default();
+
+    println!("--- {} ---", label);
+
+    for i in 0..n_warmup {
+        print!("  Warmup {}/{}... ", i + 1, n_warmup);
+        let t = Instant::now();
+        let r = model
+            .transcribe(samples, &options)
+            .expect("transcribe failed");
+        println!("{:.3}s → {:?}", t.elapsed().as_secs_f64(), r.text.trim());
+    }
+
+    let mut times = Vec::with_capacity(n_runs);
+    let mut last_text = String::new();
+    for i in 0..n_runs {
+        print!("  Run {}/{}... ", i + 1, n_runs);
+        let t = Instant::now();
+        let r = model
+            .transcribe(samples, &options)
+            .expect("transcribe failed");
+        let elapsed = t.elapsed();
+        times.push(elapsed);
+        last_text = r.text.trim().to_string();
+        println!("{:.3}s", elapsed.as_secs_f64());
+    }
+
+    println!();
+
+    BenchResult {
+        label: label.to_string(),
+        load_time,
+        times,
+        text: last_text,
+    }
+}
+
+fn parse_quantization(s: &str) -> Quantization {
+    match s.to_ascii_lowercase().as_str() {
+        "int8" | "i8" => Quantization::Int8,
+        "fp16" | "f16" => Quantization::FP16,
+        _ => Quantization::FP32,
+    }
+}
+
+struct Args {
+    qwen3_dir: Option<PathBuf>,
+    parakeet_dir: Option<PathBuf>,
+    audio_path: PathBuf,
+    qwen3_quant: Quantization,
+    parakeet_quant: Quantization,
+    accelerator: OrtAccelerator,
+    decoder_gpu: bool,
+    n_warmup: usize,
+    n_runs: usize,
+}
+
+fn print_help() {
+    eprintln!(
+        "\
+bench_compare — side-by-side inference benchmark for Qwen3-ASR and Parakeet TDT
+
+USAGE:
+    cargo run --example bench_compare --features qwen3 --release -- [OPTIONS]
+
+OPTIONS:
+    --qwen3 <PATH>           Path to Qwen3-ASR model directory
+    --parakeet <PATH>        Path to Parakeet-TDT model directory
+    --audio <PATH>           Input WAV file, 16 kHz mono [default: samples/jfk.wav]
+    --qwen3-quant <QUANT>    Qwen3 quantization: fp32, fp16, int8, int4 [default: fp32]
+    --parakeet-quant <QUANT> Parakeet quantization: fp32, fp16, int8 [default: int8]
+    --accelerator <ACCEL>    ORT accelerator: auto, cpu, cuda, directml, rocm,
+                             coreml, webgpu [default: auto]
+    --decoder-gpu            Run decoder sessions on GPU (default: CPU-only)
+    --warmup <N>             Number of warmup passes [default: 1]
+    --runs <N>               Number of timed passes [default: 3]
+    -h, --help               Print this help message
+
+At least one of --qwen3 or --parakeet must be provided."
+    );
+}
+
+fn parse_args() -> Args {
+    let args: Vec<String> = std::env::args().collect();
+    let mut a = Args {
+        qwen3_dir: None,
+        parakeet_dir: None,
+        audio_path: PathBuf::from("samples/jfk.wav"),
+        qwen3_quant: Quantization::FP32,
+        parakeet_quant: Quantization::Int8, // Parakeet ships as INT8 only
+        accelerator: OrtAccelerator::Auto,
+        decoder_gpu: false,
+        n_warmup: 1,
+        n_runs: 3,
+    };
+
+    let mut i = 1;
+    while i < args.len() {
+        let flag = args[i].as_str();
+        match flag {
+            "-h" | "--help" => {
+                print_help();
+                std::process::exit(0);
+            }
+            "--qwen3" | "--parakeet" | "--audio" | "--qwen3-quant" | "--parakeet-quant"
+            | "--accelerator" | "--warmup" | "--runs" => {
+                i += 1;
+                if i >= args.len() {
+                    eprintln!("Missing value for {flag}");
+                    std::process::exit(1);
+                }
+                match flag {
+                    "--qwen3" => a.qwen3_dir = Some(PathBuf::from(&args[i])),
+                    "--parakeet" => a.parakeet_dir = Some(PathBuf::from(&args[i])),
+                    "--audio" => a.audio_path = PathBuf::from(&args[i]),
+                    "--qwen3-quant" => a.qwen3_quant = parse_quantization(&args[i]),
+                    "--parakeet-quant" => a.parakeet_quant = parse_quantization(&args[i]),
+                    "--accelerator" => {
+                        a.accelerator = args[i].parse().unwrap_or_else(|e| {
+                            eprintln!("Invalid accelerator '{}': {e}", args[i]);
+                            std::process::exit(1);
+                        });
+                    }
+                    "--warmup" => a.n_warmup = args[i].parse().unwrap_or(1),
+                    "--runs" => a.n_runs = args[i].parse().unwrap_or(3),
+                    _ => unreachable!(),
+                }
+            }
+            "--decoder-gpu" => {
+                a.decoder_gpu = true;
+            }
+            _ => {
+                eprintln!("Unknown argument: {}", args[i]);
+                print_help();
+                std::process::exit(1);
+            }
+        }
+        i += 1;
+    }
+    a
+}
+
+fn main() {
+    env_logger::init();
+
+    let a = parse_args();
+
+    set_ort_accelerator(a.accelerator);
+    set_decoder_gpu(a.decoder_gpu);
+
+    let samples = read_wav_samples(&a.audio_path).unwrap_or_else(|e| {
+        eprintln!("Failed to read {}: {e}", a.audio_path.display());
+        std::process::exit(1);
+    });
+    let audio_duration = samples.len() as f64 / 16000.0;
+
+    println!("Audio: {} ({:.2}s)", a.audio_path.display(), audio_duration);
+    println!(
+        "Accelerator: {:?}  Decoder GPU: {}",
+        a.accelerator, a.decoder_gpu
+    );
+    println!("Warmup: {}  Runs: {}", a.n_warmup, a.n_runs);
+    println!();
+
+    let mut results: Vec<BenchResult> = Vec::new();
+
+    // Qwen3-ASR
+    #[cfg(feature = "qwen3")]
+    if let Some(ref dir) = a.qwen3_dir {
+        if !dir.exists() {
+            eprintln!("Qwen3 model not found: {}", dir.display());
+        } else {
+            print!(
+                "Loading Qwen3 ({:?}) from {}... ",
+                a.qwen3_quant,
+                dir.display()
+            );
+            let t0 = Instant::now();
+            match Qwen3Model::load(dir, &a.qwen3_quant) {
+                Ok(mut model) => {
+                    let load_time = t0.elapsed();
+                    println!("{:.3}s", load_time.as_secs_f64());
+                    let label = format!(
+                        "Qwen3-ASR {:?} ({})",
+                        a.qwen3_quant,
+                        dir.file_name().unwrap_or_default().to_string_lossy()
+                    );
+                    results.push(bench_model(
+                        &label, &mut model, &samples, a.n_warmup, a.n_runs, load_time,
+                    ));
+                }
+                Err(e) => eprintln!("Failed to load Qwen3: {e}"),
+            }
+        }
+    }
+
+    // Parakeet TDT
+    #[cfg(feature = "onnx")]
+    if let Some(ref dir) = a.parakeet_dir {
+        if !dir.exists() {
+            eprintln!("Parakeet model not found: {}", dir.display());
+        } else {
+            print!(
+                "Loading Parakeet ({:?}) from {}... ",
+                a.parakeet_quant,
+                dir.display()
+            );
+            let t0 = Instant::now();
+            match ParakeetModel::load(dir, &a.parakeet_quant) {
+                Ok(mut model) => {
+                    let load_time = t0.elapsed();
+                    println!("{:.3}s", load_time.as_secs_f64());
+                    let label = format!(
+                        "Parakeet-TDT {:?} ({})",
+                        a.parakeet_quant,
+                        dir.file_name().unwrap_or_default().to_string_lossy()
+                    );
+                    results.push(bench_model(
+                        &label, &mut model, &samples, a.n_warmup, a.n_runs, load_time,
+                    ));
+                }
+                Err(e) => eprintln!("Failed to load Parakeet: {e}"),
+            }
+        }
+    }
+
+    if results.is_empty() {
+        eprintln!("No models benchmarked. Provide --qwen3 and/or --parakeet paths.");
+        std::process::exit(1);
+    }
+
+    // Summary table
+    println!("=== Summary (audio: {:.2}s) ===", audio_duration);
+    println!(
+        "{:<36} {:>9} {:>9} {:>9} {:>9} {:>7}",
+        "Engine", "Load", "Mean", "Min", "Max", "RTF"
+    );
+    println!("{}", "-".repeat(82));
+    for r in &results {
+        let rtf = r.mean_secs() / audio_duration;
+        println!(
+            "{:<36} {:>8.3}s {:>8.3}s {:>8.3}s {:>8.3}s {:>6.2}x",
+            r.label,
+            r.load_time.as_secs_f64(),
+            r.mean_secs(),
+            r.min_secs(),
+            r.max_secs(),
+            rtf,
+        );
+    }
+    println!();
+    for r in &results {
+        println!("[{}] {:?}", r.label, r.text);
+    }
+}

--- a/examples/bench_compare.rs
+++ b/examples/bench_compare.rs
@@ -126,6 +126,7 @@ fn bench_model(
 fn parse_quantization(s: &str) -> Quantization {
     match s.to_ascii_lowercase().as_str() {
         "int8" | "i8" => Quantization::Int8,
+        "int4" | "i4" => Quantization::Int4,
         "fp16" | "f16" => Quantization::FP16,
         _ => Quantization::FP32,
     }

--- a/examples/qwen3.rs
+++ b/examples/qwen3.rs
@@ -1,0 +1,46 @@
+use std::env;
+use std::path::PathBuf;
+use std::time::Instant;
+
+use transcribe_rs::onnx::qwen3::Qwen3Model;
+use transcribe_rs::onnx::Quantization;
+use transcribe_rs::SpeechModel;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    env_logger::init();
+
+    let args: Vec<String> = env::args().collect();
+    if args.len() < 3 {
+        eprintln!("Usage: {} <model_dir> <audio.wav>", args[0]);
+        std::process::exit(1);
+    }
+
+    let model_dir = PathBuf::from(&args[1]);
+    let wav_path = PathBuf::from(&args[2]);
+
+    // Read audio
+    let reader = hound::WavReader::open(&wav_path)?;
+    let spec = reader.spec();
+    let audio_duration = reader.duration() as f64 / spec.sample_rate as f64;
+    println!("Audio: {:.2}s", audio_duration);
+
+    let samples = transcribe_rs::audio::read_wav_samples(&wav_path)?;
+
+    // Load model
+    println!("Loading Qwen3-ASR model from {:?}", model_dir);
+    let load_start = Instant::now();
+    let mut model = Qwen3Model::load(&model_dir, &Quantization::default())?;
+    println!("Model loaded in {:.2?}", load_start.elapsed());
+
+    // Transcribe
+    let transcribe_start = Instant::now();
+    let result = model.transcribe(&samples, &transcribe_rs::TranscribeOptions::default())?;
+    let transcribe_duration = transcribe_start.elapsed();
+
+    println!("Transcription: {}", result.text);
+    println!("Completed in {:.2?}", transcribe_duration);
+    let speedup = audio_duration / transcribe_duration.as_secs_f64();
+    println!("Real-time factor: {:.2}x", speedup);
+
+    Ok(())
+}

--- a/src/accel.rs
+++ b/src/accel.rs
@@ -72,6 +72,22 @@ pub fn get_ort_accelerator() -> OrtAccelerator {
     OrtAccelerator::from_u8(ORT_ACCELERATOR.load(Ordering::Relaxed))
 }
 
+static DECODER_GPU: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+/// Enable GPU execution providers for decoder sessions.
+///
+/// By default, decoder sessions use CPU-only with arena allocator because
+/// sequential execution makes GPU kernel launch overhead net-negative for
+/// per-token latency at batch size 1. Set to `true` for GPU benchmarking.
+pub fn set_decoder_gpu(enable: bool) {
+    DECODER_GPU.store(enable, Ordering::Relaxed);
+}
+
+/// Get whether decoder sessions should use GPU execution providers.
+pub fn get_decoder_gpu() -> bool {
+    DECODER_GPU.load(Ordering::Relaxed)
+}
+
 impl OrtAccelerator {
     /// Return the list of ORT accelerators that are compiled-in for the current build.
     ///

--- a/src/features/mel.rs
+++ b/src/features/mel.rs
@@ -79,7 +79,7 @@ fn compute_fbank(samples: &[f32], config: &MelConfig, sr: f32, f_max: f32) -> Ar
             1 + (samples.len() - frame_length) / frame_shift
         }
     } else {
-        (samples.len() + frame_shift - 1) / frame_shift
+        samples.len().div_ceil(frame_shift)
     };
 
     if num_frames == 0 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 //!
 //! ## Features
 //!
-//! - **ONNX Models**: SenseVoice, GigaAM, Parakeet, Moonshine (requires `onnx` feature)
+//! - **ONNX Models**: SenseVoice, GigaAM, Parakeet, Moonshine (requires `onnx` feature); Qwen3-ASR (requires `qwen3` feature)
 //! - **Whisper**: OpenAI Whisper via GGML (requires `whisper-cpp` feature)
 //! - **Whisperfile**: Mozilla Whisperfile server (requires `whisperfile` feature)
 //! - **Remote**: OpenAI API (requires `openai` feature)
@@ -90,9 +90,9 @@ pub mod accel;
 pub mod audio;
 pub mod error;
 pub use accel::{
-    get_ort_accelerator, get_whisper_accelerator, get_whisper_gpu_device, set_ort_accelerator,
-    set_whisper_accelerator, set_whisper_gpu_device, OrtAccelerator, WhisperAccelerator,
-    GPU_DEVICE_AUTO,
+    get_decoder_gpu, get_ort_accelerator, get_whisper_accelerator, get_whisper_gpu_device,
+    set_decoder_gpu, set_ort_accelerator, set_whisper_accelerator, set_whisper_gpu_device,
+    OrtAccelerator, WhisperAccelerator, GPU_DEVICE_AUTO,
 };
 pub use error::TranscribeError;
 

--- a/src/onnx/canary/decoder.rs
+++ b/src/onnx/canary/decoder.rs
@@ -106,7 +106,7 @@ fn extract_decoder_mems_shape(decoder: &Session) -> Result<(usize, usize), Trans
 
     match mems_input.dtype() {
         ValueType::Tensor { shape, .. } => {
-            let dims: &[i64] = &shape;
+            let dims: &[i64] = shape;
             if dims.len() != 4 {
                 return Err(TranscribeError::Inference(format!(
                     "Expected 4D decoder_mems, got {}D",

--- a/src/onnx/mod.rs
+++ b/src/onnx/mod.rs
@@ -26,3 +26,11 @@ pub mod gigaam;
 pub mod moonshine;
 pub mod parakeet;
 pub mod sense_voice;
+
+// qwen3 has a separate per-engine feature flag ("qwen3") rather than being enabled
+// unconditionally when "onnx" is active, because its ONNX export format (three session
+// files + embed_tokens.bin) and decode loop differ substantially from the other engines.
+// Gating it separately keeps the default "onnx" build lean until the model artifacts are
+// available.  The other engines share enough structure that separate flags add no value.
+#[cfg(feature = "qwen3")]
+pub mod qwen3;

--- a/src/onnx/moonshine/mod.rs
+++ b/src/onnx/moonshine/mod.rs
@@ -7,8 +7,9 @@ pub use streaming::{MoonshineStreamingParams, StreamingConfig, StreamingModel, S
 pub const SAMPLE_RATE: u32 = 16000;
 
 /// Moonshine model variant.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum MoonshineVariant {
+    #[default]
     Tiny,
     TinyAr,
     TinyZh,
@@ -61,11 +62,5 @@ impl MoonshineVariant {
             | MoonshineVariant::TinyKo
             | MoonshineVariant::TinyVi => 13,
         }
-    }
-}
-
-impl Default for MoonshineVariant {
-    fn default() -> Self {
-        MoonshineVariant::Tiny
     }
 }

--- a/src/onnx/moonshine/model.rs
+++ b/src/onnx/moonshine/model.rs
@@ -168,7 +168,7 @@ impl MoonshineModel {
         max_length: usize,
     ) -> Result<Vec<i64>, TranscribeError> {
         let audio_duration = samples.len() as f32 / SAMPLE_RATE as f32;
-        if audio_duration < 0.1 || audio_duration > 64.0 {
+        if !(0.1..=64.0).contains(&audio_duration) {
             return Err(TranscribeError::Inference(format!(
                 "Audio duration must be between 0.1s and 64s, got {:.2}s",
                 audio_duration

--- a/src/onnx/qwen3/config.rs
+++ b/src/onnx/qwen3/config.rs
@@ -90,6 +90,14 @@ pub struct SpecialTokens {
     pub audio_start_token_id: i64,
     pub audio_end_token_id: i64,
     pub audio_pad_token_id: i64,
+    /// Token that separates the language prefix from the transcription text.
+    /// If absent from generated tokens, the model failed to produce a valid transcription.
+    #[serde(default = "default_asr_text_token_id")]
+    pub asr_text_token_id: i64,
+}
+
+fn default_asr_text_token_id() -> i64 {
+    151704
 }
 
 impl Qwen3AsrConfig {

--- a/src/onnx/qwen3/config.rs
+++ b/src/onnx/qwen3/config.rs
@@ -1,0 +1,188 @@
+use serde::Deserialize;
+use std::fs;
+use std::path::Path;
+
+use crate::TranscribeError;
+
+/// Top-level model configuration loaded from `config.json`.
+// Fields are deserialized from config.json; not all are used at runtime.
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+pub struct Qwen3AsrConfig {
+    pub encoder: EncoderConfig,
+    pub decoder: DecoderConfig,
+    pub mel: Qwen3MelParams,
+    pub special_tokens: SpecialTokens,
+    /// Storage dtype of `embed_tokens.bin`.
+    #[serde(default)]
+    pub embed_tokens_dtype: EmbedDtype,
+}
+
+/// Storage dtype for `embed_tokens.bin`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum EmbedDtype {
+    /// 32-bit IEEE 754 float (4 bytes per element).
+    Float32,
+    /// 16-bit IEEE 754 half-precision float (2 bytes per element).
+    Float16,
+}
+
+impl Default for EmbedDtype {
+    fn default() -> Self {
+        Self::Float32
+    }
+}
+
+impl EmbedDtype {
+    /// Bytes per element for this dtype.
+    pub fn bytes_per_element(self) -> usize {
+        match self {
+            Self::Float32 => 4,
+            Self::Float16 => 2,
+        }
+    }
+}
+
+// Fields are deserialized from config.json; not all are used at runtime.
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+pub struct EncoderConfig {
+    pub num_mel_bins: usize,
+    pub output_dim: usize,
+}
+
+// Fields are deserialized from config.json; not all are used at runtime.
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+pub struct DecoderConfig {
+    pub num_layers: usize,
+    pub hidden_size: usize,
+    pub num_attention_heads: usize,
+    pub num_key_value_heads: usize,
+    pub head_dim: usize,
+    pub vocab_size: usize,
+}
+
+/// Mel spectrogram parameters from config.json, validated against the compiled-in constants
+/// in `mel.rs` at model load time.
+// Named `Qwen3MelParams` (not `MelConfig`) to avoid collision with `crate::features::MelConfig`.
+// Fields are deserialized from config.json; not all are used at runtime.
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+pub struct Qwen3MelParams {
+    pub sample_rate: u32,
+    pub n_fft: usize,
+    pub hop_length: usize,
+    pub n_mels: usize,
+    pub fmin: f64,
+    pub fmax: f64,
+}
+
+// Fields are deserialized from config.json; not all are used at runtime.
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+pub struct SpecialTokens {
+    pub eos_token_ids: Vec<i64>,
+    pub pad_token_id: i64,
+    pub im_start_token_id: i64,
+    pub im_end_token_id: i64,
+    pub audio_start_token_id: i64,
+    pub audio_end_token_id: i64,
+    pub audio_pad_token_id: i64,
+}
+
+impl Qwen3AsrConfig {
+    pub fn load(model_dir: &Path) -> Result<Self, TranscribeError> {
+        let config_path = model_dir.join("config.json");
+        let data = fs::read_to_string(&config_path)?;
+        let config: Self = serde_json::from_str(&data)?;
+        Ok(config)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_deserialize_config() {
+        let json = r#"{
+            "model_type": "qwen3_asr",
+            "encoder": {
+                "num_layers": 18, "hidden_size": 896, "num_heads": 14,
+                "ffn_dim": 3584, "conv_channels": 480, "output_dim": 1024,
+                "downsample_factor": 8, "num_mel_bins": 128
+            },
+            "decoder": {
+                "num_layers": 28, "hidden_size": 1024, "num_attention_heads": 16,
+                "num_key_value_heads": 8, "head_dim": 128, "intermediate_size": 3072,
+                "vocab_size": 151936, "rope_theta": 1000000, "rms_norm_eps": 1e-6,
+                "tie_word_embeddings": true,
+                "rope_scaling": { "mrope_section": [24, 20, 20], "interleaved": true }
+            },
+            "mel": {
+                "sample_rate": 16000, "n_fft": 400, "hop_length": 160,
+                "n_mels": 128, "fmin": 0, "fmax": 8000
+            },
+            "special_tokens": {
+                "eos_token_ids": [151643, 151645],
+                "pad_token_id": 151643,
+                "im_start_token_id": 151644,
+                "im_end_token_id": 151645,
+                "audio_start_token_id": 151669,
+                "audio_end_token_id": 151670,
+                "audio_pad_token_id": 151676,
+                "asr_text_token_id": 151704
+            },
+            "embed_tokens_shape": [151936, 1024],
+            "embed_tokens_dtype": "float32"
+        }"#;
+
+        let config: Qwen3AsrConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(config.decoder.num_layers, 28);
+        assert_eq!(config.decoder.vocab_size, 151936);
+        assert_eq!(config.mel.n_mels, 128);
+        assert_eq!(config.special_tokens.eos_token_ids, vec![151643, 151645]);
+        assert_eq!(config.embed_tokens_dtype, EmbedDtype::Float32);
+    }
+
+    #[test]
+    fn test_embed_dtype_float16() {
+        let json = r#"{
+            "encoder": { "num_layers": 18, "hidden_size": 896, "num_heads": 14, "ffn_dim": 3584, "conv_channels": 480, "output_dim": 1024, "downsample_factor": 8, "num_mel_bins": 128 },
+            "decoder": { "num_layers": 28, "hidden_size": 1024, "num_attention_heads": 16, "num_key_value_heads": 8, "head_dim": 128, "intermediate_size": 3072, "vocab_size": 151936, "rope_theta": 1000000, "rms_norm_eps": 1e-6, "tie_word_embeddings": true, "rope_scaling": { "mrope_section": [24, 20, 20], "interleaved": true } },
+            "mel": { "sample_rate": 16000, "n_fft": 400, "hop_length": 160, "n_mels": 128, "fmin": 0, "fmax": 8000 },
+            "special_tokens": { "eos_token_ids": [151643, 151645], "pad_token_id": 151643, "im_start_token_id": 151644, "im_end_token_id": 151645, "audio_start_token_id": 151669, "audio_end_token_id": 151670, "audio_pad_token_id": 151676 },
+            "embed_tokens_dtype": "float16"
+        }"#;
+        let config: Qwen3AsrConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(config.embed_tokens_dtype, EmbedDtype::Float16);
+        assert_eq!(config.embed_tokens_dtype.bytes_per_element(), 2);
+    }
+
+    #[test]
+    fn test_embed_dtype_default_when_missing() {
+        let json = r#"{
+            "encoder": { "num_layers": 18, "hidden_size": 896, "num_heads": 14, "ffn_dim": 3584, "conv_channels": 480, "output_dim": 1024, "downsample_factor": 8, "num_mel_bins": 128 },
+            "decoder": { "num_layers": 28, "hidden_size": 1024, "num_attention_heads": 16, "num_key_value_heads": 8, "head_dim": 128, "intermediate_size": 3072, "vocab_size": 151936, "rope_theta": 1000000, "rms_norm_eps": 1e-6, "tie_word_embeddings": true, "rope_scaling": { "mrope_section": [24, 20, 20], "interleaved": true } },
+            "mel": { "sample_rate": 16000, "n_fft": 400, "hop_length": 160, "n_mels": 128, "fmin": 0, "fmax": 8000 },
+            "special_tokens": { "eos_token_ids": [151643, 151645], "pad_token_id": 151643, "im_start_token_id": 151644, "im_end_token_id": 151645, "audio_start_token_id": 151669, "audio_end_token_id": 151670, "audio_pad_token_id": 151676 }
+        }"#;
+        let config: Qwen3AsrConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(config.embed_tokens_dtype, EmbedDtype::Float32);
+    }
+
+    #[test]
+    fn test_embed_dtype_unknown_rejected() {
+        let json = r#"{
+            "encoder": { "num_layers": 18, "hidden_size": 896, "num_heads": 14, "ffn_dim": 3584, "conv_channels": 480, "output_dim": 1024, "downsample_factor": 8, "num_mel_bins": 128 },
+            "decoder": { "num_layers": 28, "hidden_size": 1024, "num_attention_heads": 16, "num_key_value_heads": 8, "head_dim": 128, "intermediate_size": 3072, "vocab_size": 151936, "rope_theta": 1000000, "rms_norm_eps": 1e-6, "tie_word_embeddings": true, "rope_scaling": { "mrope_section": [24, 20, 20], "interleaved": true } },
+            "mel": { "sample_rate": 16000, "n_fft": 400, "hop_length": 160, "n_mels": 128, "fmin": 0, "fmax": 8000 },
+            "special_tokens": { "eos_token_ids": [151643, 151645], "pad_token_id": 151643, "im_start_token_id": 151644, "im_end_token_id": 151645, "audio_start_token_id": 151669, "audio_end_token_id": 151670, "audio_pad_token_id": 151676 },
+            "embed_tokens_dtype": "bfloat16"
+        }"#;
+        let result = serde_json::from_str::<Qwen3AsrConfig>(json);
+        assert!(result.is_err(), "bfloat16 should be rejected");
+    }
+}

--- a/src/onnx/qwen3/engine.rs
+++ b/src/onnx/qwen3/engine.rs
@@ -5,6 +5,7 @@
 //! - `engine.rs` — wraps `Qwen3AsrModel`, adapts it to the `SpeechModel` trait (capabilities,
 //!   options, language-prefix stripping). Keeps `model.rs` free of library-level concerns.
 
+use std::collections::HashMap;
 use std::path::Path;
 
 use crate::onnx::Quantization;
@@ -33,6 +34,9 @@ const CAPABILITIES: ModelCapabilities = ModelCapabilities {
 /// is always `None`).
 pub struct Qwen3Model {
     inner: Qwen3AsrModel,
+    /// Cache of language name → token IDs. Populated on first use of each
+    /// language, then reused for all subsequent transcriptions.
+    language_cache: HashMap<String, Vec<i64>>,
 }
 
 impl Qwen3Model {
@@ -40,7 +44,10 @@ impl Qwen3Model {
     pub fn load(model_dir: &Path, quantization: &Quantization) -> Result<Self, TranscribeError> {
         let inner = Qwen3AsrModel::load(model_dir, quantization)?;
         log::info!("Loaded Qwen3-ASR model from {:?}", model_dir);
-        Ok(Self { inner })
+        Ok(Self {
+            inner,
+            language_cache: HashMap::new(),
+        })
     }
 
     /// Transcribe with explicit per-call parameters.
@@ -49,12 +56,47 @@ impl Qwen3Model {
         samples: &[f32],
         params: &Qwen3Params,
     ) -> Result<TranscriptionResult, TranscribeError> {
-        let raw = self.inner.transcribe(samples, params.max_tokens)?;
+        // Encode language on first use, then borrow from cache.
+        // Treat empty strings as None (no language conditioning).
+        let lang_key = params.language.as_deref().filter(|s| !s.is_empty());
+        if let Some(lang) = lang_key {
+            self.ensure_language_cached(lang);
+        }
+        let lang_tokens = lang_key
+            .and_then(|lang| self.language_cache.get(lang))
+            .map(|v| v.as_slice());
+
+        let raw = self
+            .inner
+            .transcribe(samples, params.max_tokens, lang_tokens)?;
+        log::debug!("Qwen3-ASR raw decoder output: {:?}", raw);
         let text = strip_language_prefix(&raw);
+        log::debug!("Qwen3-ASR after strip_language_prefix: {:?}", text);
         Ok(TranscriptionResult {
             text,
             segments: None,
         })
+    }
+
+    /// Ensure language token IDs are in the cache, encoding on first use.
+    ///
+    /// Normalizes BCP-47 codes ("en" → "English") before tokenizing, then
+    /// encodes ` {Name}` (with leading space) to match the official Qwen3-ASR
+    /// template where "language" is followed by ` English`, ` Chinese`, etc.
+    fn ensure_language_cached(&mut self, language: &str) {
+        if self.language_cache.contains_key(language) {
+            return;
+        }
+        let normalized = normalize_language(language);
+        let spaced = format!(" {normalized}");
+        let tokens = self.inner.encode_language(&spaced);
+        log::info!(
+            "Qwen3-ASR: encoded language {:?} → {:?} → {:?} (cached for reuse)",
+            language,
+            normalized,
+            tokens
+        );
+        self.language_cache.insert(language.to_string(), tokens);
     }
 }
 
@@ -63,13 +105,22 @@ impl Qwen3Model {
 pub struct Qwen3Params {
     /// Maximum number of decoder tokens to generate.
     ///
-    /// 512 tokens is sufficient for approximately 60 s of typical English audio.
+    /// Default: 512, sufficient for approximately 60 s of typical English audio.
     pub max_tokens: usize,
+
+    /// Language hint (e.g. "English", "en", "zh"). When set, the assistant
+    /// prefix is forced to `language {Name}<asr_text>`, skipping language
+    /// detection entirely. Accepts either full English names ("English") or
+    /// BCP-47 codes ("en") — codes are normalized to names automatically.
+    pub language: Option<String>,
 }
 
 impl Default for Qwen3Params {
     fn default() -> Self {
-        Self { max_tokens: 512 }
+        Self {
+            max_tokens: 512,
+            language: None,
+        }
     }
 }
 
@@ -83,18 +134,16 @@ impl SpeechModel for Qwen3Model {
         samples: &[f32],
         options: &TranscribeOptions,
     ) -> Result<TranscriptionResult, TranscribeError> {
-        if let Some(ref lang) = options.language {
-            log::warn!(
-                "Qwen3-ASR: language hint {:?} is not supported; the model auto-detects language",
-                lang
-            );
-        }
         if options.translate {
             log::warn!(
                 "Qwen3-ASR: translate is not supported; the model produces transcription only"
             );
         }
-        self.transcribe_with(samples, &Qwen3Params::default())
+        let params = Qwen3Params {
+            language: options.language.clone(),
+            ..Default::default()
+        };
+        self.transcribe_with(samples, &params)
     }
 }
 

--- a/src/onnx/qwen3/engine.rs
+++ b/src/onnx/qwen3/engine.rs
@@ -1,0 +1,381 @@
+//! `SpeechModel` implementation for Qwen3-ASR (batch mode).
+//!
+//! Two-layer structure:
+//! - `model.rs` — raw ONNX inference (encoder, decoder, KV-cache) returning plain Rust types.
+//! - `engine.rs` — wraps `Qwen3AsrModel`, adapts it to the `SpeechModel` trait (capabilities,
+//!   options, language-prefix stripping). Keeps `model.rs` free of library-level concerns.
+
+use std::path::Path;
+
+use crate::onnx::Quantization;
+use crate::{
+    ModelCapabilities, SpeechModel, TranscribeError, TranscribeOptions, TranscriptionResult,
+};
+
+use super::model::Qwen3AsrModel;
+
+const CAPABILITIES: ModelCapabilities = ModelCapabilities {
+    name: "Qwen3-ASR",
+    engine_id: "qwen3",
+    sample_rate: 16000,
+    languages: &[], // multilingual: supports many languages
+    supports_timestamps: false,
+    supports_translation: false,
+    supports_streaming: false,
+};
+
+/// Batch transcription model backed by Qwen3-ASR.
+///
+/// Processes complete audio in a single encoder-decoder pass, suitable for
+/// the standard record-then-transcribe workflow.
+///
+/// This model does not produce timestamp segments (`TranscriptionResult.segments`
+/// is always `None`).
+pub struct Qwen3Model {
+    inner: Qwen3AsrModel,
+}
+
+impl Qwen3Model {
+    /// Load a Qwen3-ASR model from `model_dir` with the given quantization.
+    pub fn load(model_dir: &Path, quantization: &Quantization) -> Result<Self, TranscribeError> {
+        let inner = Qwen3AsrModel::load(model_dir, quantization)?;
+        log::info!("Loaded Qwen3-ASR model from {:?}", model_dir);
+        Ok(Self { inner })
+    }
+
+    /// Transcribe with explicit per-call parameters.
+    pub fn transcribe_with(
+        &mut self,
+        samples: &[f32],
+        params: &Qwen3Params,
+    ) -> Result<TranscriptionResult, TranscribeError> {
+        let raw = self.inner.transcribe(samples, params.max_tokens)?;
+        let text = strip_language_prefix(&raw);
+        Ok(TranscriptionResult {
+            text,
+            segments: None,
+        })
+    }
+}
+
+/// Per-call parameters for Qwen3-ASR transcription.
+#[derive(Debug, Clone)]
+pub struct Qwen3Params {
+    /// Maximum number of decoder tokens to generate.
+    ///
+    /// 512 tokens is sufficient for approximately 60 s of typical English audio.
+    pub max_tokens: usize,
+}
+
+impl Default for Qwen3Params {
+    fn default() -> Self {
+        Self { max_tokens: 512 }
+    }
+}
+
+impl SpeechModel for Qwen3Model {
+    fn capabilities(&self) -> ModelCapabilities {
+        CAPABILITIES
+    }
+
+    fn transcribe(
+        &mut self,
+        samples: &[f32],
+        options: &TranscribeOptions,
+    ) -> Result<TranscriptionResult, TranscribeError> {
+        if let Some(ref lang) = options.language {
+            log::warn!(
+                "Qwen3-ASR: language hint {:?} is not supported; the model auto-detects language",
+                lang
+            );
+        }
+        if options.translate {
+            log::warn!(
+                "Qwen3-ASR: translate is not supported; the model produces transcription only"
+            );
+        }
+        self.transcribe_with(samples, &Qwen3Params::default())
+    }
+}
+
+/// Normalize a BCP-47 / ISO 639-1 language code to the full English name
+/// expected by the Qwen3-ASR prompt template.
+///
+/// If the input is already a full name (e.g. "English") or is not recognized,
+/// it is returned unchanged. Mirrors the `ISO639_1_SUPPORTED_LANGS` mapping
+/// in the official Qwen3-ASR inference code.
+fn normalize_language(code: &str) -> &str {
+    match code {
+        "en" => "English",
+        "zh" | "zh-Hans" | "zh-Hant" => "Chinese",
+        "ja" => "Japanese",
+        "ko" => "Korean",
+        "yue" => "Cantonese",
+        "fr" => "French",
+        "es" => "Spanish",
+        "de" => "German",
+        "it" => "Italian",
+        "pt" => "Portuguese",
+        "ru" => "Russian",
+        "ar" => "Arabic",
+        "hi" => "Hindi",
+        "th" => "Thai",
+        "vi" => "Vietnamese",
+        "id" => "Indonesian",
+        "ms" => "Malay",
+        "tr" => "Turkish",
+        "nl" => "Dutch",
+        "pl" => "Polish",
+        "sv" => "Swedish",
+        "no" => "Norwegian",
+        "da" => "Danish",
+        "fi" => "Finnish",
+        "cs" => "Czech",
+        "ro" => "Romanian",
+        "hu" => "Hungarian",
+        "el" => "Greek",
+        "he" => "Hebrew",
+        "uk" => "Ukrainian",
+        "bg" => "Bulgarian",
+        "hr" => "Croatian",
+        "sk" => "Slovak",
+        "sl" => "Slovenian",
+        "lt" => "Lithuanian",
+        "lv" => "Latvian",
+        "et" => "Estonian",
+        "sr" => "Serbian",
+        "tl" => "Tagalog",
+        "my" => "Burmese",
+        "bo" => "Tibetan",
+        "ug" => "Uyghur",
+        "mn" => "Mongolian",
+        "am" => "Amharic",
+        "sw" => "Swahili",
+        "kk" => "Kazakh",
+        "uz" => "Uzbek",
+        "az" => "Azerbaijani",
+        "ka" => "Georgian",
+        "hy" => "Armenian",
+        "ne" => "Nepali",
+        "bn" => "Bengali",
+        "ta" => "Tamil",
+        "te" => "Telugu",
+        "ur" => "Urdu",
+        "fa" => "Persian",
+        "lo" => "Lao",
+        "km" => "Khmer",
+        "ca" => "Catalan",
+        "gl" => "Galician",
+        "eu" => "Basque",
+        "af" => "Afrikaans",
+        other => other, // Already a full name or unknown — pass through
+    }
+}
+
+/// Known language names emitted by Qwen3-ASR as the prefix tag.
+const KNOWN_LANGUAGES: &[&str] = &[
+    "English",
+    "Chinese",
+    "Japanese",
+    "Korean",
+    "Cantonese",
+    "French",
+    "Spanish",
+    "German",
+    "Italian",
+    "Portuguese",
+    "Russian",
+    "Arabic",
+    "Hindi",
+    "Thai",
+    "Vietnamese",
+    "Indonesian",
+    "Malay",
+    "Turkish",
+    "Dutch",
+    "Polish",
+    "Swedish",
+    "Norwegian",
+    "Danish",
+    "Finnish",
+    "Czech",
+    "Romanian",
+    "Hungarian",
+    "Greek",
+    "Hebrew",
+    "Ukrainian",
+    "Bulgarian",
+    "Croatian",
+    "Slovak",
+    "Slovenian",
+    "Lithuanian",
+    "Latvian",
+    "Estonian",
+    "Serbian",
+    "Tagalog",
+    "Burmese",
+    "Tibetan",
+    "Uyghur",
+    "Mongolian",
+    "Amharic",
+    "Swahili",
+    "Kazakh",
+    "Uzbek",
+    "Azerbaijani",
+    "Georgian",
+    "Armenian",
+    "Nepali",
+    "Bengali",
+    "Tamil",
+    "Telugu",
+    "Urdu",
+    "Persian",
+    "Lao",
+    "Khmer",
+    "Catalan",
+    "Galician",
+    "Basque",
+    "Afrikaans",
+];
+
+/// Strip the language identification prefix that Qwen3-ASR generates.
+///
+/// The model outputs `language <Name>\n<transcription>` where `\n` is GPT-2
+/// BPE token 198. Occasionally the newline is absent: `language <Name><text>`.
+/// We try the newline split first (handles unknown languages automatically),
+/// then fall back to known language name matching for the no-newline case.
+///
+/// Known limitation: if the transcribed text starts with a substring that
+/// matches a language name (e.g. "Georgian" → "Georgia is..."), the boundary
+/// detection is ambiguous. This is inherent to the model's output format
+/// when no separator character is present.
+fn strip_language_prefix(text: &str) -> String {
+    if let Some(rest) = text.strip_prefix("language ") {
+        // Primary: split on newline (the model's standard delimiter)
+        if let Some(newline_pos) = rest.find('\n') {
+            return rest[newline_pos + 1..].to_string();
+        }
+        // Fallback: match known language name (no newline separator)
+        for lang in KNOWN_LANGUAGES {
+            if let Some(after) = rest.strip_prefix(lang) {
+                return after.to_string();
+            }
+        }
+        // Unknown language without newline: preserve text rather than drop it
+        log::warn!(
+            "Qwen3-ASR: unrecognised language prefix with no newline separator; raw output: {:?}",
+            rest
+        );
+        return rest.to_string();
+    }
+    text.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_strip_language_prefix_with_newline() {
+        assert_eq!(
+            strip_language_prefix("language English\nHello world"),
+            "Hello world"
+        );
+    }
+
+    #[test]
+    fn test_strip_language_prefix_without_newline() {
+        assert_eq!(
+            strip_language_prefix("language EnglishHello world"),
+            "Hello world"
+        );
+    }
+
+    #[test]
+    fn test_strip_language_prefix_without_newline_starts_uppercase() {
+        assert_eq!(
+            strip_language_prefix("language EnglishAre there more features?"),
+            "Are there more features?"
+        );
+    }
+
+    #[test]
+    fn test_strip_language_prefix_body_starts_with_language_name() {
+        // Transcript begins with a language name — verify we strip only the prefix tag.
+        assert_eq!(
+            strip_language_prefix("language EnglishEnglish is a language"),
+            "English is a language"
+        );
+    }
+
+    #[test]
+    fn test_strip_language_prefix_chinese_with_newline() {
+        assert_eq!(
+            strip_language_prefix("language Chinese\n你好世界"),
+            "你好世界"
+        );
+    }
+
+    #[test]
+    fn test_strip_language_prefix_chinese_without_newline() {
+        assert_eq!(
+            strip_language_prefix("language Chinese你好世界"),
+            "你好世界"
+        );
+    }
+
+    #[test]
+    fn test_strip_language_prefix_no_text() {
+        assert_eq!(strip_language_prefix("language English"), "");
+    }
+
+    #[test]
+    fn test_strip_language_prefix_no_prefix() {
+        assert_eq!(strip_language_prefix("Hello world"), "Hello world");
+    }
+
+    #[test]
+    fn test_strip_language_prefix_empty() {
+        assert_eq!(strip_language_prefix(""), "");
+    }
+
+    #[test]
+    fn test_strip_language_prefix_preserves_newlines_in_body() {
+        assert_eq!(
+            strip_language_prefix("language English\nline one\nline two"),
+            "line one\nline two"
+        );
+    }
+
+    #[test]
+    fn test_strip_language_prefix_unknown_language_with_newline() {
+        assert_eq!(strip_language_prefix("language Klingon\nQapla!"), "Qapla!");
+    }
+
+    #[test]
+    fn test_strip_language_prefix_unknown_language_without_newline() {
+        // Unknown language without newline: text preserved (not dropped)
+        assert_eq!(strip_language_prefix("language Klingon"), "Klingon");
+    }
+
+    #[test]
+    fn test_normalize_language_maps_codes() {
+        assert_eq!(normalize_language("en"), "English");
+        assert_eq!(normalize_language("zh"), "Chinese");
+        assert_eq!(normalize_language("zh-Hans"), "Chinese");
+        assert_eq!(normalize_language("ja"), "Japanese");
+        assert_eq!(normalize_language("ko"), "Korean");
+        assert_eq!(normalize_language("yue"), "Cantonese");
+        assert_eq!(normalize_language("af"), "Afrikaans");
+    }
+
+    #[test]
+    fn test_normalize_language_passthrough() {
+        // Full names pass through unchanged
+        assert_eq!(normalize_language("English"), "English");
+        assert_eq!(normalize_language("Chinese"), "Chinese");
+        // Unknown codes pass through
+        assert_eq!(normalize_language("unknown"), "unknown");
+        assert_eq!(normalize_language("Klingon"), "Klingon");
+    }
+}

--- a/src/onnx/qwen3/engine.rs
+++ b/src/onnx/qwen3/engine.rs
@@ -78,7 +78,7 @@ impl SpeechModel for Qwen3Model {
         CAPABILITIES
     }
 
-    fn transcribe(
+    fn transcribe_raw(
         &mut self,
         samples: &[f32],
         options: &TranscribeOptions,

--- a/src/onnx/qwen3/mel.rs
+++ b/src/onnx/qwen3/mel.rs
@@ -1,0 +1,304 @@
+//! Whisper-compatible log-mel spectrogram extraction.
+//!
+//! Parameters: 128 mel bins, Hann window, n_fft=400, hop=160, Slaney mel scale.
+//! This differs from SenseVoice's FBANK (80 bins, Hamming, HTK mel, pre-emphasis)
+//! and cannot be shared.
+//!
+//! TODO: `crate::features::mel` uses HTK-scale normalization and f32 arithmetic.
+//! Qwen3-ASR requires Slaney-scale normalization and f64 arithmetic (to match
+//! Whisper's feature extractor). Merging the two would require a `MelScale` enum
+//! in the shared module; leave that to a follow-up contribution.
+
+// Multi-array indexed loops are clearer than iterator chains here.
+#![allow(clippy::needless_range_loop)]
+
+use ndarray::Array3;
+use rustfft::{num_complex::Complex, FftPlanner};
+use std::f64::consts::PI;
+use std::sync::LazyLock;
+
+const SAMPLE_RATE: f64 = 16000.0;
+pub(crate) const N_FFT: usize = 400;
+pub(crate) const HOP_LENGTH: usize = 160;
+pub(crate) const N_MELS: usize = 128;
+const FMIN: f64 = 0.0;
+const FMAX: f64 = 8000.0;
+
+/// Cached Hann window (400 f64 values) — deterministic, computed once.
+static HANN_WINDOW: LazyLock<Vec<f64>> = LazyLock::new(|| hann_window(N_FFT));
+
+/// Cached Slaney mel filterbank (128×201 f64 matrix) — deterministic, computed once.
+static MEL_FILTERS: LazyLock<Vec<Vec<f64>>> =
+    LazyLock::new(|| slaney_mel_filterbank(SAMPLE_RATE, N_FFT, N_MELS, FMIN, FMAX));
+
+/// Compute Whisper-compatible log-mel spectrogram.
+///
+/// Input: 1-D f32 audio samples at 16kHz.
+/// Output: `Array3<f32>` shape `[1, 128, T]`.
+pub fn log_mel_spectrogram(audio: &[f32]) -> Array3<f32> {
+    if audio.len() <= N_FFT / 2 {
+        return Array3::zeros((1, N_MELS, 0));
+    }
+
+    let mel_filters = &*MEL_FILTERS;
+    let window = &*HANN_WINDOW;
+    let num_fft_bins = N_FFT / 2 + 1;
+
+    // Number of STFT frames (torch.stft default: centered, pad_mode reflect not needed
+    // since we match the Python output exactly by computing the same frame count)
+    let num_frames = audio.len() / HOP_LENGTH + 1;
+    // num_frames >= 1 always (integer division + 1). The guard above (audio.len() > N_FFT/2)
+    // ensures time_steps = num_frames - 1 >= 0 and that the reflect padding indices are valid.
+    debug_assert!(num_frames >= 1);
+
+    let mut planner = FftPlanner::new();
+    let fft = planner.plan_fft_forward(N_FFT);
+
+    // Compute magnitude-squared spectrogram
+    let mut magnitudes = vec![vec![0.0f64; num_frames]; num_fft_bins];
+
+    for frame_idx in 0..num_frames {
+        let center = frame_idx * HOP_LENGTH;
+        let mut fft_input: Vec<Complex<f64>> = Vec::with_capacity(N_FFT);
+
+        for i in 0..N_FFT {
+            let sample_idx = center as isize + i as isize - (N_FFT / 2) as isize;
+            let sample = if sample_idx < 0 {
+                // Reflect padding: index -1 → audio[1], -2 → audio[2], etc.
+                // Invariant: N_FFT/2 < audio.len() (guaranteed by early-return at top).
+                let reflect_idx = (-sample_idx) as usize;
+                debug_assert!(
+                    reflect_idx < audio.len(),
+                    "reflect_idx {reflect_idx} out of bounds"
+                );
+                audio[reflect_idx] as f64
+            } else if (sample_idx as usize) >= audio.len() {
+                // Reflect padding from the right end.
+                let overshoot = sample_idx as usize - audio.len();
+                if audio.len() > 1 && overshoot < audio.len() {
+                    debug_assert!(
+                        overshoot < audio.len().saturating_sub(1),
+                        "right reflect: overshoot {overshoot} >= audio.len()-1 ({})",
+                        audio.len() - 1
+                    );
+                    audio[audio.len().saturating_sub(2).saturating_sub(overshoot)] as f64
+                } else {
+                    // audio is a single sample or overshoot exceeds the buffer — no valid
+                    // reflect index. This should not occur for normal 16 kHz audio (guarded
+                    // by the early-return at the top of log_mel_spectrogram).
+                    log::warn!(
+                        "mel: right-reflect padding out of range \
+                         (audio_len={}, overshoot={}); zeroing frame {} sample {}",
+                        audio.len(),
+                        overshoot,
+                        frame_idx,
+                        i
+                    );
+                    0.0
+                }
+            } else {
+                audio[sample_idx as usize] as f64
+            };
+            fft_input.push(Complex::new(sample * window[i], 0.0));
+        }
+
+        fft.process(&mut fft_input);
+
+        for k in 0..num_fft_bins {
+            magnitudes[k][frame_idx] = fft_input[k].norm_sqr();
+        }
+    }
+
+    // Drop last STFT frame (WhisperFeatureExtractor quirk)
+    let time_steps = num_frames - 1;
+
+    // Apply mel filterbank: mel_spec[m][t] = sum_k(filters[m][k] * magnitudes[k][t])
+    let mut mel_spec = vec![vec![0.0f64; time_steps]; N_MELS];
+    for m in 0..N_MELS {
+        for k in 0..num_fft_bins {
+            if mel_filters[m][k] != 0.0 {
+                for t in 0..time_steps {
+                    mel_spec[m][t] += mel_filters[m][k] * magnitudes[k][t];
+                }
+            }
+        }
+    }
+
+    // Log scale with clamping and normalization
+    let mut log_spec = vec![vec![0.0f32; time_steps]; N_MELS];
+    let mut global_max: f32 = f32::NEG_INFINITY;
+
+    for m in 0..N_MELS {
+        for t in 0..time_steps {
+            let val = (mel_spec[m][t].max(1e-10).log10()) as f32;
+            log_spec[m][t] = val;
+            if val > global_max {
+                global_max = val;
+            }
+        }
+    }
+
+    // Dynamic range clipping and normalization
+    let floor = global_max - 8.0;
+    for m in 0..N_MELS {
+        for t in 0..time_steps {
+            log_spec[m][t] = (log_spec[m][t].max(floor) + 4.0) / 4.0;
+        }
+    }
+
+    // Pack into [1, N_MELS, time_steps]
+    let mut result = Array3::<f32>::zeros((1, N_MELS, time_steps));
+    for m in 0..N_MELS {
+        for t in 0..time_steps {
+            result[[0, m, t]] = log_spec[m][t];
+        }
+    }
+    result
+}
+
+/// Hann window of given length.
+fn hann_window(length: usize) -> Vec<f64> {
+    (0..length)
+        .map(|i| 0.5 * (1.0 - (2.0 * PI * i as f64 / length as f64).cos()))
+        .collect()
+}
+
+/// Slaney-normalized mel filterbank matching `librosa.filters.mel(norm='slaney')`.
+///
+/// Below 1kHz: linear spacing in Hz.
+/// Above 1kHz: logarithmic spacing.
+/// Each filter is area-normalized (divided by its bandwidth in Hz).
+fn slaney_mel_filterbank(
+    sr: f64,
+    n_fft: usize,
+    n_mels: usize,
+    fmin: f64,
+    fmax: f64,
+) -> Vec<Vec<f64>> {
+    let num_fft_bins = n_fft / 2 + 1;
+
+    // Slaney mel scale: linear below 1kHz, log above
+    let f_sp = 200.0 / 3.0; // 66.667 Hz
+    let min_log_hz = 1000.0;
+    let min_log_mel = (min_log_hz - 0.0) / f_sp; // 15.0
+    let log_step = 6.4_f64.ln() / 27.0; // step in log region
+
+    let hz_to_mel = |hz: f64| -> f64 {
+        if hz < min_log_hz {
+            hz / f_sp
+        } else {
+            min_log_mel + (hz / min_log_hz).ln() / log_step
+        }
+    };
+
+    let mel_to_hz = |mel: f64| -> f64 {
+        if mel < min_log_mel {
+            mel * f_sp
+        } else {
+            min_log_hz * ((mel - min_log_mel) * log_step).exp()
+        }
+    };
+
+    let mel_min = hz_to_mel(fmin);
+    let mel_max = hz_to_mel(fmax);
+
+    // n_mels + 2 uniformly spaced points in mel domain
+    let n_points = n_mels + 2;
+    let mel_points: Vec<f64> = (0..n_points)
+        .map(|i| mel_min + (mel_max - mel_min) * i as f64 / (n_points - 1) as f64)
+        .collect();
+    let hz_points: Vec<f64> = mel_points.iter().map(|&m| mel_to_hz(m)).collect();
+
+    // FFT bin frequencies
+    let fft_freqs: Vec<f64> = (0..num_fft_bins)
+        .map(|k| k as f64 * sr / n_fft as f64)
+        .collect();
+
+    let mut filters = vec![vec![0.0f64; num_fft_bins]; n_mels];
+
+    for m in 0..n_mels {
+        let left = hz_points[m];
+        let center = hz_points[m + 1];
+        let right = hz_points[m + 2];
+
+        // Slaney normalization: divide by bandwidth in Hz
+        let enorm = 2.0 / (right - left);
+
+        for k in 0..num_fft_bins {
+            let freq = fft_freqs[k];
+            if freq > left && freq < center {
+                filters[m][k] = enorm * (freq - left) / (center - left);
+            } else if freq >= center && freq < right {
+                filters[m][k] = enorm * (right - freq) / (right - center);
+            }
+        }
+    }
+
+    filters
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_hann_window_endpoints() {
+        let w = hann_window(400);
+        assert_eq!(w.len(), 400);
+        // Hann window: w[0] = 0, w[N/2] = 1
+        assert!(w[0].abs() < 1e-10);
+        assert!((w[200] - 1.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_mel_filterbank_shape() {
+        let filters = slaney_mel_filterbank(16000.0, 400, 128, 0.0, 8000.0);
+        assert_eq!(filters.len(), 128);
+        assert_eq!(filters[0].len(), 201); // n_fft/2 + 1
+    }
+
+    #[test]
+    fn test_mel_filterbank_nonzero() {
+        let filters = slaney_mel_filterbank(16000.0, 400, 128, 0.0, 8000.0);
+        // Each filter should have at least some nonzero entries
+        for (i, filter) in filters.iter().enumerate() {
+            let sum: f64 = filter.iter().sum();
+            assert!(sum > 0.0, "Filter {} has zero sum", i);
+        }
+    }
+
+    #[test]
+    fn test_log_mel_spectrogram_very_short() {
+        // audio.len() <= N_FFT / 2 (200 samples) triggers the early-return path
+        let audio = vec![0.0f32; 100];
+        let mel = log_mel_spectrogram(&audio);
+        assert_eq!(mel.shape(), &[1, 128, 0]);
+    }
+
+    #[test]
+    fn test_log_mel_spectrogram_shape() {
+        // 1 second of silence
+        let audio = vec![0.0f32; 16000];
+        let mel = log_mel_spectrogram(&audio);
+        assert_eq!(mel.shape()[0], 1);
+        assert_eq!(mel.shape()[1], 128);
+        // Expected frames: 16000 / 160 + 1 - 1 = 100
+        assert_eq!(mel.shape()[2], 100);
+    }
+
+    #[test]
+    fn test_log_mel_spectrogram_sine_wave() {
+        // 440 Hz sine wave for 0.5s — should produce energy in low mel bins
+        let n = 8000;
+        let audio: Vec<f32> = (0..n)
+            .map(|i| (2.0 * std::f32::consts::PI * 440.0 * i as f32 / 16000.0).sin())
+            .collect();
+        let mel = log_mel_spectrogram(&audio);
+        assert_eq!(mel.shape()[0], 1);
+        assert_eq!(mel.shape()[1], 128);
+        // Should have non-trivial values (not all identical)
+        let min = mel.iter().cloned().fold(f32::INFINITY, f32::min);
+        let max = mel.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
+        assert!(max > min, "Mel spectrogram should have dynamic range");
+    }
+}

--- a/src/onnx/qwen3/mod.rs
+++ b/src/onnx/qwen3/mod.rs
@@ -1,0 +1,36 @@
+//! Qwen3-ASR speech recognition engine (batch mode).
+//!
+//! Implements [`SpeechModel`](crate::SpeechModel) for multilingual batch transcription.
+//!
+//! # Requirements
+//!
+//! The model directory must contain:
+//! - `encoder.onnx` (+ `.data`) -- audio encoder
+//! - `decoder_init.onnx` (+ `.data`) -- decoder prefill (embedding table in graph)
+//! - `decoder_step.onnx` (+ `.data`) -- decoder autoregressive step (embedding table in graph)
+//! - `config.json` -- model configuration
+//! - `tokenizer.json` -- HuggingFace BPE tokenizer
+//!
+//! # Model output format
+//!
+//! The decoder produces a language identification prefix followed by the
+//! transcription. The standard format uses a newline token (GPT-2 BPE token
+//! ID 198, which decodes to `\n`) as the delimiter:
+//!
+//! ```text
+//! language English\n<transcription text>
+//! ```
+//!
+//! The engine layer ([`engine::strip_language_prefix`]) removes this prefix
+//! before returning the final text. It tries the newline split first (handles
+//! unknown languages automatically), then falls back to matching known
+//! language names for the rare no-newline case.
+
+mod config;
+mod engine;
+mod mel;
+mod model;
+mod prompt;
+mod tokenizer;
+
+pub use engine::{Qwen3Model, Qwen3Params};

--- a/src/onnx/qwen3/model.rs
+++ b/src/onnx/qwen3/model.rs
@@ -291,6 +291,22 @@ impl Qwen3AsrModel {
             );
         }
 
+        // The model should produce `language <Name> <asr_text> <transcription>`.
+        // If the <asr_text> separator token is absent, the decoder failed to produce
+        // a valid transcription (e.g. degenerate "ology" output from int4 quantization
+        // noise on non-speech audio). Return empty string rather than garbage.
+        let asr_text_id = self.config.special_tokens.asr_text_token_id;
+        if !output_tokens.contains(&asr_text_id) {
+            let preview: Vec<_> = output_tokens.iter().take(20).collect();
+            log::warn!(
+                "Qwen3-ASR: no <asr_text> token in output ({} tokens, first 20: {:?}); \
+                 returning empty transcription",
+                output_tokens.len(),
+                preview,
+            );
+            return Ok(String::new());
+        }
+
         Ok(self.tokenizer.decode(&output_tokens))
     }
 

--- a/src/onnx/qwen3/model.rs
+++ b/src/onnx/qwen3/model.rs
@@ -218,6 +218,12 @@ impl Qwen3AsrModel {
         for _ in 1..max_tokens {
             // Embedding lookup from cached FP32 table (fast ndarray row copy).
             let token_embed = {
+                if current_token < 0 {
+                    return Err(TranscribeError::Inference(format!(
+                        "decoder produced negative token ID: {}",
+                        current_token
+                    )));
+                }
                 let id = current_token as usize;
                 if id >= self.embed_tokens.nrows() {
                     return Err(TranscribeError::Inference(format!(

--- a/src/onnx/qwen3/model.rs
+++ b/src/onnx/qwen3/model.rs
@@ -1,0 +1,545 @@
+//! Core ONNX inference for Qwen3-ASR: encoder, decoder prefill, and autoregressive decode.
+
+use ndarray::{Array1, Array2, Array3, ArrayD, Ix3, IxDyn};
+use ort::session::Session;
+use ort::value::{DynValue, TensorRef};
+use std::path::Path;
+
+use crate::onnx::{session, Quantization};
+use crate::TranscribeError;
+
+use super::config::Qwen3AsrConfig;
+use super::mel::{self, log_mel_spectrogram};
+use super::prompt::{build_prompt_ids, get_audio_pad_range, get_feat_extract_output_lengths};
+use super::tokenizer::Qwen3Tokenizer;
+
+pub struct Qwen3AsrModel {
+    encoder: Session,
+    decoder_init: Session,
+    decoder_step: Session,
+    /// Embedding matrix cached for fast per-step lookup. Loaded from
+    /// `embed_tokens.bin` (FP32 cache). decoder_init contains the embedding
+    /// table in its graph for the prefill scatter, but decoder_step accepts
+    /// pre-looked-up `input_embeds` to avoid loading the embedding table
+    /// into the hot decode loop session.
+    embed_tokens: Array2<f32>,
+    config: Qwen3AsrConfig,
+    tokenizer: Qwen3Tokenizer,
+}
+
+impl Qwen3AsrModel {
+    pub fn load(model_dir: &Path, quantization: &Quantization) -> Result<Self, TranscribeError> {
+        let config = Qwen3AsrConfig::load(model_dir)?;
+        let tokenizer =
+            Qwen3Tokenizer::new(model_dir).map_err(|e| TranscribeError::Config(e.to_string()))?;
+
+        {
+            let st = &config.special_tokens;
+            let valid = st.pad_token_id >= 0
+                && st.im_start_token_id >= 0
+                && st.im_end_token_id >= 0
+                && st.audio_start_token_id >= 0
+                && st.audio_end_token_id >= 0
+                && st.audio_pad_token_id >= 0
+                && !st.eos_token_ids.is_empty()
+                && st.eos_token_ids.iter().all(|&id| id >= 0);
+            if !valid {
+                return Err(TranscribeError::Config(
+                    "config.json: special_tokens contains negative or missing IDs".into(),
+                ));
+            }
+        }
+
+        if config.mel.n_mels != mel::N_MELS {
+            return Err(TranscribeError::Config(format!(
+                "Qwen3-ASR: expected n_mels={}, got {}",
+                mel::N_MELS,
+                config.mel.n_mels
+            )));
+        }
+        if config.mel.n_fft != mel::N_FFT {
+            return Err(TranscribeError::Config(format!(
+                "Qwen3-ASR: expected n_fft={}, got {}",
+                mel::N_FFT,
+                config.mel.n_fft
+            )));
+        }
+        if config.mel.hop_length != mel::HOP_LENGTH {
+            return Err(TranscribeError::Config(format!(
+                "Qwen3-ASR: expected hop_length={}, got {}",
+                mel::HOP_LENGTH,
+                config.mel.hop_length
+            )));
+        }
+
+        let encoder_path = session::resolve_model_path(model_dir, "encoder", quantization);
+        if !encoder_path.exists() {
+            return Err(TranscribeError::ModelNotFound(encoder_path));
+        }
+
+        // 0 = ORT default (all cores). Decoder runs sequentially (one step
+        // per token) so fewer threads can reduce synchronization overhead,
+        // but the optimal count is host-dependent.
+        let decoder_threads: usize = 0;
+
+        log::info!("Loading Qwen3-ASR encoder from {:?}", encoder_path);
+        let encoder = session::create_session(&encoder_path)?;
+
+        let decoder_init_path =
+            session::resolve_model_path(model_dir, "decoder_init", quantization);
+        let decoder_step_path =
+            session::resolve_model_path(model_dir, "decoder_step", quantization);
+        if !decoder_init_path.exists() {
+            return Err(TranscribeError::ModelNotFound(decoder_init_path));
+        }
+        if !decoder_step_path.exists() {
+            return Err(TranscribeError::ModelNotFound(decoder_step_path));
+        }
+        log::info!(
+            "Loading Qwen3-ASR decoder from {:?} + {:?}",
+            decoder_init_path,
+            decoder_step_path
+        );
+        let decoder_init = session::create_decoder_session(&decoder_init_path, decoder_threads)?;
+        let decoder_step = session::create_decoder_session(&decoder_step_path, decoder_threads)?;
+
+        // Load embedding cache for fast per-step lookup. decoder_step accepts
+        // input_embeds (pre-looked-up), so the embedding table is not in its
+        // ORT session, keeping the step working set small.
+        // Storage dtype (FP16 or FP32) is read from config.embed_tokens_dtype.
+        let embed_path = model_dir.join("embed_tokens.bin");
+        if !embed_path.exists() {
+            return Err(TranscribeError::ModelNotFound(embed_path));
+        }
+        log::info!("Loading embedding cache from {:?}", embed_path);
+        let embed_tokens = load_embed_cache(&embed_path, &config)?;
+        log::info!("Embedding cache: {:?}", embed_tokens.shape());
+
+        Ok(Self {
+            encoder,
+            decoder_init,
+            decoder_step,
+            embed_tokens,
+            config,
+            tokenizer,
+        })
+    }
+
+    /// Run the encoder on a mel spectrogram.
+    fn encode(&mut self, mel: &Array3<f32>) -> Result<Array3<f32>, TranscribeError> {
+        let mel_dyn = mel.view().into_dyn();
+        let inputs = ort::inputs![
+            "mel" => TensorRef::from_array_view(mel_dyn.view())?,
+        ];
+        let outputs = self.encoder.run(inputs)?;
+
+        let features = outputs
+            .get("audio_features")
+            .ok_or_else(|| TranscribeError::Inference("Missing 'audio_features' output".into()))?
+            .try_extract_array::<f32>()?;
+
+        Ok(features.to_owned().into_dimensionality::<Ix3>()?)
+    }
+
+    /// Run greedy decoding on audio features, returning decoded text.
+    ///
+    /// The decoder graph contains the embedding table. We pass `input_ids` (token IDs)
+    /// and `audio_features` + `audio_offset` to decoder_init; the graph handles
+    /// embedding lookup and audio feature substitution internally. For autoregressive
+    /// steps, decoder_step receives a single `input_ids` token.
+    fn greedy_decode(
+        &mut self,
+        audio_features: &Array3<f32>,
+        max_tokens: usize,
+    ) -> Result<String, TranscribeError> {
+        // Cap to prevent unbounded KV cache growth from unchecked callers.
+        let max_tokens = max_tokens.min(4096);
+        let audio_token_count = audio_features.shape()[1];
+        let prompt_ids = build_prompt_ids(&self.config.special_tokens, audio_token_count);
+        let seq_len = prompt_ids.len();
+
+        let (audio_start, _) =
+            get_audio_pad_range(&prompt_ids, self.config.special_tokens.audio_pad_token_id)
+                .map_err(TranscribeError::Inference)?;
+
+        let input_ids = Array2::<i64>::from_shape_vec((1, seq_len), prompt_ids.clone())?;
+        let position_ids = Array2::<i64>::from_shape_fn((1, seq_len), |(_, j)| j as i64);
+        let audio_offset = Array1::<i64>::from_elem(1, audio_start as i64);
+        let ids_dyn = input_ids.into_dyn();
+        let pos_dyn = position_ids.into_dyn();
+        let audio_dyn = audio_features.view().into_dyn();
+        let offset_dyn = audio_offset.into_dyn();
+
+        // Prefill: decoder_init handles embedding lookup + audio scatter internally.
+        let (mut current_token, mut keys, mut values) = {
+            let inputs = ort::inputs![
+                "input_ids"        => TensorRef::from_array_view(ids_dyn.view())?,
+                "position_ids"     => TensorRef::from_array_view(pos_dyn.view())?,
+                "audio_features"   => TensorRef::from_array_view(audio_dyn.view())?,
+                "audio_offset"     => TensorRef::from_array_view(offset_dyn.view())?,
+            ];
+            let mut init_outputs = self.decoder_init.run(inputs)?;
+
+            let logits = init_outputs
+                .get("logits")
+                .ok_or_else(|| {
+                    TranscribeError::Inference("Missing 'logits' from decoder_init".into())
+                })?
+                .try_extract_array::<f32>()?;
+            let last_pos = logits.shape()[1].checked_sub(1).ok_or_else(|| {
+                TranscribeError::Inference("decoder_init returned empty logits sequence".into())
+            })?;
+            let token = argmax_slice(&logits, last_pos)?;
+            // Release borrow on init_outputs so remove() can take KV cache by value.
+            drop(logits);
+            let keys: DynValue = init_outputs.remove("present_keys").ok_or_else(|| {
+                TranscribeError::Inference("Missing 'present_keys' from decoder_init".into())
+            })?;
+            let values: DynValue = init_outputs.remove("present_values").ok_or_else(|| {
+                TranscribeError::Inference("Missing 'present_values' from decoder_init".into())
+            })?;
+            (token, keys, values)
+        };
+
+        let mut output_tokens = vec![current_token];
+
+        if self
+            .config
+            .special_tokens
+            .eos_token_ids
+            .contains(&current_token)
+        {
+            return Ok(self.tokenizer.decode(&output_tokens));
+        }
+
+        let hidden_size = self.config.decoder.hidden_size;
+        let mut pos = seq_len as i64;
+
+        for _ in 1..max_tokens {
+            // Embedding lookup from cached FP32 table (fast ndarray row copy).
+            let token_embed = {
+                let id = current_token as usize;
+                if id >= self.embed_tokens.nrows() {
+                    return Err(TranscribeError::Inference(format!(
+                        "token ID {} exceeds embedding rows {}",
+                        id,
+                        self.embed_tokens.nrows()
+                    )));
+                }
+                let row = self.embed_tokens.row(id);
+                let mut arr = Array3::<f32>::zeros((1, 1, hidden_size));
+                arr.slice_mut(ndarray::s![0, 0, ..]).assign(&row);
+                arr.into_dyn()
+            };
+
+            let step_pos = ArrayD::<i64>::from_shape_vec(IxDyn(&[1, 1]), vec![pos])?;
+
+            // Pass KV cache by value: DynValue implements Into<SessionInputValue>,
+            // so ORT can reference the memory directly without an extra ndarray copy.
+            let step_inputs = ort::inputs![
+                "input_embeds"  => TensorRef::from_array_view(token_embed.view())?,
+                "position_ids"  => TensorRef::from_array_view(step_pos.view())?,
+                "past_keys"     => keys,
+                "past_values"   => values,
+            ];
+            let mut step_outputs = self.decoder_step.run(step_inputs)?;
+
+            let step_logits = step_outputs
+                .get("logits")
+                .ok_or_else(|| {
+                    TranscribeError::Inference("Missing 'logits' from decoder_step".into())
+                })?
+                .try_extract_array::<f32>()?;
+
+            current_token = argmax_slice(&step_logits, 0)?;
+            output_tokens.push(current_token);
+            pos += 1;
+            // Release borrow on step_outputs so remove() can take KV cache by value.
+            drop(step_logits);
+            keys = step_outputs.remove("present_keys").ok_or_else(|| {
+                TranscribeError::Inference("Missing 'present_keys' from step".into())
+            })?;
+            values = step_outputs.remove("present_values").ok_or_else(|| {
+                TranscribeError::Inference("Missing 'present_values' from step".into())
+            })?;
+
+            if self
+                .config
+                .special_tokens
+                .eos_token_ids
+                .contains(&current_token)
+            {
+                break;
+            }
+        }
+
+        if !self
+            .config
+            .special_tokens
+            .eos_token_ids
+            .contains(&current_token)
+        {
+            log::warn!(
+                "Qwen3-ASR: max_tokens ({}) reached without EOS token",
+                max_tokens
+            );
+        }
+
+        Ok(self.tokenizer.decode(&output_tokens))
+    }
+
+    /// Full transcription pipeline: audio samples → raw decoded text.
+    ///
+    /// Returns the raw model output including the language prefix. The caller
+    /// (engine layer) is responsible for stripping the prefix.
+    pub fn transcribe(
+        &mut self,
+        samples: &[f32],
+        max_tokens: usize,
+    ) -> Result<String, TranscribeError> {
+        // Qwen3-ASR is designed for utterance-level audio (mel chunk_length = 30 s).
+        const MAX_SAMPLES: usize = 60 * 16_000;
+        if samples.len() > MAX_SAMPLES {
+            return Err(TranscribeError::Inference(format!(
+                "audio too long: {} samples ({:.1} s); maximum is 60 s",
+                samples.len(),
+                samples.len() as f32 / 16_000.0,
+            )));
+        }
+
+        let mel = log_mel_spectrogram(samples);
+        let mel_frames = mel.shape()[2];
+        let audio_tokens = get_feat_extract_output_lengths(mel_frames);
+        log::debug!(
+            "Mel frames: {}, encoder output tokens: {}",
+            mel_frames,
+            audio_tokens
+        );
+
+        if audio_tokens == 0 {
+            return Ok(String::new());
+        }
+
+        let audio_features = self.encode(&mel)?;
+        log::debug!("Audio features shape: {:?}", audio_features.shape());
+
+        let encoder_frames = audio_features.shape()[1];
+        if encoder_frames != audio_tokens {
+            return Err(TranscribeError::Inference(format!(
+                "Qwen3-ASR encoder produced {} frames, expected {} from mel formula \
+                 (mel_frames={}, audio_tokens={})",
+                encoder_frames, audio_tokens, mel_frames, audio_tokens
+            )));
+        }
+
+        self.greedy_decode(&audio_features, max_tokens)
+    }
+}
+
+/// Load the embedding cache from a raw binary file.
+///
+/// Shape `[vocab_size, hidden_size]`, row-major. The storage dtype is read from
+/// `config.embed_tokens_dtype` ("float16" or "float32"). FP16 data is cast to
+/// f32 on load.
+fn load_embed_cache(path: &Path, config: &Qwen3AsrConfig) -> Result<Array2<f32>, TranscribeError> {
+    use super::config::EmbedDtype;
+
+    let vocab_size = config.decoder.vocab_size;
+    let hidden_size = config.decoder.hidden_size;
+    let n_elements = vocab_size * hidden_size;
+    let bpe = config.embed_tokens_dtype.bytes_per_element();
+    let expected_bytes = n_elements * bpe;
+
+    let file_size = path.metadata()?.len() as usize;
+    if file_size != expected_bytes {
+        return Err(TranscribeError::Config(format!(
+            "embed_tokens.bin size {} != expected {} ({}x{}x{}, dtype={:?})",
+            file_size, expected_bytes, vocab_size, hidden_size, bpe, config.embed_tokens_dtype
+        )));
+    }
+
+    let data = std::fs::read(path)?;
+
+    let float_data: Vec<f32> = match config.embed_tokens_dtype {
+        EmbedDtype::Float16 => {
+            log::info!(
+                "Loading FP16 embedding cache ({} MB)",
+                file_size / (1024 * 1024)
+            );
+            data.chunks_exact(2)
+                .map(|chunk| f16_to_f32(u16::from_le_bytes([chunk[0], chunk[1]])))
+                .collect()
+        }
+        EmbedDtype::Float32 => {
+            log::info!(
+                "Loading FP32 embedding cache ({} MB)",
+                file_size / (1024 * 1024)
+            );
+            data.chunks_exact(4)
+                .map(|chunk| f32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]))
+                .collect()
+        }
+    };
+
+    Ok(Array2::from_shape_vec(
+        (vocab_size, hidden_size),
+        float_data,
+    )?)
+}
+
+/// Convert an IEEE 754 half-precision float (u16) to f32.
+#[inline]
+fn f16_to_f32(h: u16) -> f32 {
+    let sign = ((h >> 15) & 1) as u32;
+    let exp = ((h >> 10) & 0x1F) as u32;
+    let frac = (h & 0x3FF) as u32;
+
+    if exp == 0 {
+        if frac == 0 {
+            // ±0
+            f32::from_bits(sign << 31)
+        } else {
+            // Subnormal: normalize
+            let mut e = exp;
+            let mut f = frac;
+            while f & 0x400 == 0 {
+                f <<= 1;
+                e += 1;
+            }
+            f &= 0x3FF;
+            let exp32 = 127 - 15 - e + 1;
+            f32::from_bits((sign << 31) | (exp32 << 23) | (f << 13))
+        }
+    } else if exp == 31 {
+        // Inf / NaN
+        f32::from_bits((sign << 31) | (0xFF << 23) | (frac << 13))
+    } else {
+        // Normal
+        let exp32 = exp + 127 - 15;
+        f32::from_bits((sign << 31) | (exp32 << 23) | (frac << 13))
+    }
+}
+
+/// Argmax over a 3D logits array at `[0, pos, :]`.
+///
+/// Returns `TranscribeError::Inference` if the array does not have shape `[1, T, vocab]`
+/// or if `pos >= T`.
+fn argmax_slice(logits: &ndarray::ArrayViewD<'_, f32>, pos: usize) -> Result<i64, TranscribeError> {
+    let shape = logits.shape();
+    if logits.ndim() != 3 || shape[0] != 1 {
+        return Err(TranscribeError::Inference(format!(
+            "argmax_slice: expected shape [1, T, vocab], got {:?}",
+            shape
+        )));
+    }
+    if pos >= shape[1] {
+        return Err(TranscribeError::Inference(format!(
+            "argmax_slice: pos {} out of range for sequence length {}",
+            pos, shape[1]
+        )));
+    }
+
+    let vocab_size = shape[2];
+
+    // Use contiguous slice for cache-friendly linear scan.
+    // ORT output tensors are row-major, so [0, pos, :] is a contiguous block.
+    // This enables LLVM to auto-vectorize the argmax with AVX-512.
+    let row = logits.slice(ndarray::s![0, pos, ..]);
+    if let Some(slice) = row.as_slice() {
+        let best_idx = slice
+            .iter()
+            .enumerate()
+            .fold((0usize, f32::NEG_INFINITY), |(bi, bv), (i, &v)| {
+                if v > bv {
+                    (i, v)
+                } else {
+                    (bi, bv)
+                }
+            })
+            .0;
+        return Ok(best_idx as i64);
+    }
+
+    // Fallback: non-contiguous layout (should not occur with ORT CPU output tensors)
+    let mut best_idx = 0i64;
+    let mut best_val = f32::NEG_INFINITY;
+    for v in 0..vocab_size {
+        let val = logits[[0, pos, v]];
+        if val > best_val {
+            best_val = val;
+            best_idx = v as i64;
+        }
+    }
+    Ok(best_idx)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::f16_to_f32;
+
+    #[test]
+    fn f16_positive_zero() {
+        assert_eq!(f16_to_f32(0x0000), 0.0f32);
+        assert!(f16_to_f32(0x0000).is_sign_positive());
+    }
+
+    #[test]
+    fn f16_negative_zero() {
+        assert_eq!(f16_to_f32(0x8000), -0.0f32);
+        assert!(f16_to_f32(0x8000).is_sign_negative());
+    }
+
+    #[test]
+    fn f16_one() {
+        assert_eq!(f16_to_f32(0x3C00), 1.0f32);
+    }
+
+    #[test]
+    fn f16_negative_one() {
+        assert_eq!(f16_to_f32(0xBC00), -1.0f32);
+    }
+
+    #[test]
+    fn f16_positive_infinity() {
+        assert_eq!(f16_to_f32(0x7C00), f32::INFINITY);
+    }
+
+    #[test]
+    fn f16_negative_infinity() {
+        assert_eq!(f16_to_f32(0xFC00), f32::NEG_INFINITY);
+    }
+
+    #[test]
+    fn f16_nan() {
+        assert!(f16_to_f32(0x7E00).is_nan());
+    }
+
+    #[test]
+    fn f16_smallest_subnormal() {
+        // 2^-24 ≈ 5.96e-8
+        let val = f16_to_f32(0x0001);
+        assert!(val > 0.0);
+        assert!((val - 5.960_464_5e-8).abs() < 1e-12);
+    }
+
+    #[test]
+    fn f16_largest_subnormal() {
+        // 0x03FF = 0.000_111_111_111_1 * 2^-14 ≈ 6.098e-5
+        let val = f16_to_f32(0x03FF);
+        assert!(val > 0.0);
+        assert!((val - 6.097_555e-5).abs() < 1e-9);
+    }
+
+    #[test]
+    fn f16_max_finite() {
+        // 0x7BFF = 65504.0
+        assert_eq!(f16_to_f32(0x7BFF), 65504.0f32);
+    }
+
+    #[test]
+    fn f16_common_values() {
+        assert_eq!(f16_to_f32(0x4000), 2.0f32);
+        assert_eq!(f16_to_f32(0x3800), 0.5f32);
+        assert!((f16_to_f32(0x3555) - 0.3333).abs() < 0.001);
+    }
+}

--- a/src/onnx/qwen3/model.rs
+++ b/src/onnx/qwen3/model.rs
@@ -10,7 +10,9 @@ use crate::TranscribeError;
 
 use super::config::Qwen3AsrConfig;
 use super::mel::{self, log_mel_spectrogram};
-use super::prompt::{build_prompt_ids, get_audio_pad_range, get_feat_extract_output_lengths};
+use super::prompt::{
+    build_prompt_ids_with_language, get_audio_pad_range, get_feat_extract_output_lengths,
+};
 use super::tokenizer::Qwen3Tokenizer;
 
 pub struct Qwen3AsrModel {
@@ -41,6 +43,7 @@ impl Qwen3AsrModel {
                 && st.audio_start_token_id >= 0
                 && st.audio_end_token_id >= 0
                 && st.audio_pad_token_id >= 0
+                && st.asr_text_token_id >= 0
                 && !st.eos_token_ids.is_empty()
                 && st.eos_token_ids.iter().all(|&id| id >= 0);
             if !valid {
@@ -151,11 +154,16 @@ impl Qwen3AsrModel {
         &mut self,
         audio_features: &Array3<f32>,
         max_tokens: usize,
+        language_token_ids: Option<&[i64]>,
     ) -> Result<String, TranscribeError> {
         // Cap to prevent unbounded KV cache growth from unchecked callers.
         let max_tokens = max_tokens.min(4096);
         let audio_token_count = audio_features.shape()[1];
-        let prompt_ids = build_prompt_ids(&self.config.special_tokens, audio_token_count);
+        let prompt_ids = build_prompt_ids_with_language(
+            &self.config.special_tokens,
+            audio_token_count,
+            language_token_ids,
+        );
         let seq_len = prompt_ids.len();
 
         let (audio_start, _) =
@@ -279,12 +287,12 @@ impl Qwen3AsrModel {
             }
         }
 
-        if !self
+        let eos_reached = self
             .config
             .special_tokens
             .eos_token_ids
-            .contains(&current_token)
-        {
+            .contains(&current_token);
+        if !eos_reached {
             log::warn!(
                 "Qwen3-ASR: max_tokens ({}) reached without EOS token",
                 max_tokens
@@ -292,11 +300,19 @@ impl Qwen3AsrModel {
         }
 
         // The model should produce `language <Name> <asr_text> <transcription>`.
-        // If the <asr_text> separator token is absent, the decoder failed to produce
-        // a valid transcription (e.g. degenerate "ology" output from int4 quantization
-        // noise on non-speech audio). Return empty string rather than garbage.
+        // If the <asr_text> separator token is absent AND the model completed
+        // normally (EOS seen), the decoder failed to produce a valid transcription
+        // (e.g. degenerate "ology" output from int4 quantization noise on
+        // non-speech audio). Return empty string rather than garbage.
+        //
+        // When max_tokens truncated the output, the <asr_text> token may simply
+        // not have been reached yet — this is not degenerate, just truncated.
+        //
+        // When language_token_ids is provided, <asr_text> was forced into the
+        // prompt (not generated), so it won't appear in output_tokens — skip
+        // the guard in that case.
         let asr_text_id = self.config.special_tokens.asr_text_token_id;
-        if !output_tokens.contains(&asr_text_id) {
+        if language_token_ids.is_none() && eos_reached && !output_tokens.contains(&asr_text_id) {
             let preview: Vec<_> = output_tokens.iter().take(20).collect();
             log::warn!(
                 "Qwen3-ASR: no <asr_text> token in output ({} tokens, first 20: {:?}); \
@@ -318,6 +334,7 @@ impl Qwen3AsrModel {
         &mut self,
         samples: &[f32],
         max_tokens: usize,
+        language_token_ids: Option<&[i64]>,
     ) -> Result<String, TranscribeError> {
         // Qwen3-ASR is designed for utterance-level audio (mel chunk_length = 30 s).
         const MAX_SAMPLES: usize = 60 * 16_000;
@@ -354,7 +371,15 @@ impl Qwen3AsrModel {
             )));
         }
 
-        self.greedy_decode(&audio_features, max_tokens)
+        self.greedy_decode(&audio_features, max_tokens, language_token_ids)
+    }
+
+    /// Encode a language name to token IDs using the tokenizer.
+    ///
+    /// Returns the token IDs for the language name (e.g. "English" → \[22574\]).
+    /// The caller should cache the result for reuse across transcriptions.
+    pub fn encode_language(&self, language: &str) -> Vec<i64> {
+        self.tokenizer.encode(language)
     }
 }
 

--- a/src/onnx/qwen3/prompt.rs
+++ b/src/onnx/qwen3/prompt.rs
@@ -1,7 +1,12 @@
 //! Prompt template construction for Qwen3-ASR.
 //!
-//! Builds the token ID sequence:
+//! Builds the token ID sequence for the chat-style prompt that Qwen3-ASR expects.
+//! Standard prompt (no language hint):
 //!   `<|im_start|>system\n<|im_end|>\n<|im_start|>user\n<|audio_start|><|audio_pad|>*N<|audio_end|><|im_end|>\n<|im_start|>assistant\n`
+//!
+//! With language hint (official Qwen3-ASR template):
+//!   `...<|im_start|>assistant\nlanguage {Name}<asr_text>`
+//! This forces the model to skip language detection and go straight to transcription.
 
 use super::config::SpecialTokens;
 
@@ -13,6 +18,8 @@ const SYSTEM_TOKEN_ID: i64 = 9125; // "system"
 const USER_TOKEN_ID: i64 = 882; // "user"
 const ASSISTANT_TOKEN_ID: i64 = 77091; // "assistant"
 const NEWLINE_TOKEN_ID: i64 = 198; // "\n"
+/// Token for "language" — the fixed prefix of the assistant's language tag.
+const LANGUAGE_TOKEN_ID: i64 = 11528; // "language"
 
 /// Compute the number of encoder output tokens from a mel frame count.
 ///
@@ -28,10 +35,39 @@ pub fn get_feat_extract_output_lengths(input_lengths: usize) -> usize {
 
 /// Build the complete prompt token ID sequence for ASR transcription.
 ///
-/// `audio_token_count` is the number of encoder output tokens (use
-/// `get_feat_extract_output_lengths(mel_frames)` to compute from mel frame count).
-pub fn build_prompt_ids(special_tokens: &SpecialTokens, audio_token_count: usize) -> Vec<i64> {
-    let mut ids = Vec::with_capacity(audio_token_count + 15);
+/// This builds the standard prompt with an empty system turn and no language
+/// hint. Equivalent to `build_prompt_ids_with_language(st, n, None)`.
+#[cfg(test)]
+pub(crate) fn build_prompt_ids(
+    special_tokens: &SpecialTokens,
+    audio_token_count: usize,
+) -> Vec<i64> {
+    build_prompt_ids_with_language(special_tokens, audio_token_count, None)
+}
+
+/// Build a prompt with optional language hint using the official Qwen3-ASR template.
+///
+/// When `language_token_ids` is provided, the assistant prefix is extended with
+/// `language {Name}<asr_text>`, forcing the model to skip language detection and
+/// begin transcription immediately. This matches the official Qwen3-ASR inference
+/// template (see `qwen_asr/core/vllm_backend/qwen3_asr.py`).
+///
+/// The forced `<asr_text>` token also prevents degenerate output (e.g. "ology")
+/// from int4 quantization noise on non-speech audio, since the model never gets
+/// the chance to produce a wrong first token.
+///
+/// `language_token_ids` should be the tokenized form of ` {Name}` (with leading
+/// space) — e.g. `encode(" English")` → `[6364]`. The "language" prefix token
+/// is added automatically.
+///
+/// When `language_token_ids` is `None`, builds the standard prompt with no
+/// language hint (model auto-detects language).
+pub fn build_prompt_ids_with_language(
+    special_tokens: &SpecialTokens,
+    audio_token_count: usize,
+    language_token_ids: Option<&[i64]>,
+) -> Vec<i64> {
+    let mut ids = Vec::with_capacity(audio_token_count + 20);
 
     // System turn (empty content)
     ids.push(special_tokens.im_start_token_id);
@@ -60,6 +96,15 @@ pub fn build_prompt_ids(special_tokens: &SpecialTokens, audio_token_count: usize
     ids.push(special_tokens.im_start_token_id);
     ids.push(ASSISTANT_TOKEN_ID);
     ids.push(NEWLINE_TOKEN_ID);
+
+    // Language hint: force "language {Name}<asr_text>" as assistant prefix.
+    // This pre-fills the assistant's response so the model skips language
+    // detection and begins transcription after <asr_text>.
+    if let Some(lang_ids) = language_token_ids {
+        ids.push(LANGUAGE_TOKEN_ID); // "language"
+        ids.extend_from_slice(lang_ids); // " English" (with leading space)
+        ids.push(special_tokens.asr_text_token_id); // <asr_text>
+    }
 
     ids
 }
@@ -102,7 +147,7 @@ mod tests {
     fn test_encoder_output_lengths() {
         assert_eq!(get_feat_extract_output_lengths(0), 0);
         assert_eq!(get_feat_extract_output_lengths(1), 1);
-        assert_eq!(get_feat_extract_output_lengths(99), 13); // boundary: last frame before window
+        assert_eq!(get_feat_extract_output_lengths(99), 13);
         assert_eq!(get_feat_extract_output_lengths(100), 13);
         assert_eq!(get_feat_extract_output_lengths(200), 26);
         assert_eq!(get_feat_extract_output_lengths(997), 130);
@@ -113,30 +158,25 @@ mod tests {
         let st = test_special_tokens();
         let ids = build_prompt_ids(&st, 10);
 
-        // Should start with im_start, system, newline, im_end, newline
         assert_eq!(ids[0], st.im_start_token_id);
         assert_eq!(ids[1], SYSTEM_TOKEN_ID);
         assert_eq!(ids[2], NEWLINE_TOKEN_ID);
         assert_eq!(ids[3], st.im_end_token_id);
         assert_eq!(ids[4], NEWLINE_TOKEN_ID);
 
-        // User turn
         assert_eq!(ids[5], st.im_start_token_id);
         assert_eq!(ids[6], USER_TOKEN_ID);
         assert_eq!(ids[7], NEWLINE_TOKEN_ID);
         assert_eq!(ids[8], st.audio_start_token_id);
 
-        // 10 audio_pad tokens at positions 9..19
         for i in 9..19 {
             assert_eq!(ids[i], st.audio_pad_token_id);
         }
 
-        // audio_end, im_end, newline
         assert_eq!(ids[19], st.audio_end_token_id);
         assert_eq!(ids[20], st.im_end_token_id);
         assert_eq!(ids[21], NEWLINE_TOKEN_ID);
 
-        // Assistant turn
         assert_eq!(ids[22], st.im_start_token_id);
         assert_eq!(ids[23], ASSISTANT_TOKEN_ID);
         assert_eq!(ids[24], NEWLINE_TOKEN_ID);
@@ -152,5 +192,42 @@ mod tests {
         assert_eq!(start, 9);
         assert_eq!(end, 19);
         assert_eq!(end - start, 10);
+    }
+
+    #[test]
+    fn test_build_prompt_ids_with_language() {
+        let st = test_special_tokens();
+        // " English" (with leading space) as the reference tokenizer produces
+        let lang_ids: &[i64] = &[6364];
+        let ids = build_prompt_ids_with_language(&st, 5, Some(lang_ids));
+
+        // Standard prompt structure up to assistant turn
+        assert_eq!(ids[0], st.im_start_token_id); // system turn
+        assert_eq!(ids[3], st.im_end_token_id);
+        assert_eq!(ids[5], st.im_start_token_id); // user turn
+        assert_eq!(ids[8], st.audio_start_token_id);
+        for i in 9..14 {
+            assert_eq!(ids[i], st.audio_pad_token_id); // 5 audio tokens
+        }
+        assert_eq!(ids[14], st.audio_end_token_id);
+        assert_eq!(ids[15], st.im_end_token_id);
+
+        // Assistant turn with forced language prefix
+        assert_eq!(ids[17], st.im_start_token_id);
+        assert_eq!(ids[18], ASSISTANT_TOKEN_ID);
+        assert_eq!(ids[19], NEWLINE_TOKEN_ID);
+        assert_eq!(ids[20], LANGUAGE_TOKEN_ID); // "language"
+        assert_eq!(ids[21], 6364); // " English"
+        assert_eq!(ids[22], st.asr_text_token_id); // <asr_text>
+
+        assert_eq!(ids.len(), 23); // 20 standard + 3 language hint
+    }
+
+    #[test]
+    fn test_language_none_matches_standard_prompt() {
+        let st = test_special_tokens();
+        let standard = build_prompt_ids(&st, 10);
+        let with_none = build_prompt_ids_with_language(&st, 10, None);
+        assert_eq!(standard, with_none);
     }
 }

--- a/src/onnx/qwen3/prompt.rs
+++ b/src/onnx/qwen3/prompt.rs
@@ -94,6 +94,7 @@ mod tests {
             audio_start_token_id: 151669,
             audio_end_token_id: 151670,
             audio_pad_token_id: 151676,
+            asr_text_token_id: 151704,
         }
     }
 

--- a/src/onnx/qwen3/prompt.rs
+++ b/src/onnx/qwen3/prompt.rs
@@ -1,0 +1,155 @@
+//! Prompt template construction for Qwen3-ASR.
+//!
+//! Builds the token ID sequence:
+//!   `<|im_start|>system\n<|im_end|>\n<|im_start|>user\n<|audio_start|><|audio_pad|>*N<|audio_end|><|im_end|>\n<|im_start|>assistant\n`
+
+use super::config::SpecialTokens;
+
+/// Well-known text token IDs from the Qwen3-ASR tokenizer vocabulary.
+/// These are fixed across all Qwen3/Qwen2.5 tokenizer versions — they map to
+/// the English words "system", "user", "assistant" and the newline character in
+/// the base GPT-2 BPE vocabulary that Qwen inherits.
+const SYSTEM_TOKEN_ID: i64 = 9125; // "system"
+const USER_TOKEN_ID: i64 = 882; // "user"
+const ASSISTANT_TOKEN_ID: i64 = 77091; // "assistant"
+const NEWLINE_TOKEN_ID: i64 = 198; // "\n"
+
+/// Compute the number of encoder output tokens from a mel frame count.
+///
+/// Matches the native Qwen3-ASR formula: windowed conv with 100-frame windows,
+/// three stride-2 conv layers on the remainder, 13 tokens per full window.
+pub fn get_feat_extract_output_lengths(input_lengths: usize) -> usize {
+    let leave = input_lengths % 100;
+    let mut t = leave.div_ceil(2);
+    t = t.div_ceil(2);
+    t = t.div_ceil(2);
+    t + (input_lengths / 100) * 13
+}
+
+/// Build the complete prompt token ID sequence for ASR transcription.
+///
+/// `audio_token_count` is the number of encoder output tokens (use
+/// `get_feat_extract_output_lengths(mel_frames)` to compute from mel frame count).
+pub fn build_prompt_ids(special_tokens: &SpecialTokens, audio_token_count: usize) -> Vec<i64> {
+    let mut ids = Vec::with_capacity(audio_token_count + 15);
+
+    // System turn (empty content)
+    ids.push(special_tokens.im_start_token_id);
+    ids.push(SYSTEM_TOKEN_ID);
+    ids.push(NEWLINE_TOKEN_ID);
+    ids.push(special_tokens.im_end_token_id);
+    ids.push(NEWLINE_TOKEN_ID);
+
+    // User turn with audio
+    ids.push(special_tokens.im_start_token_id);
+    ids.push(USER_TOKEN_ID);
+    ids.push(NEWLINE_TOKEN_ID);
+    ids.push(special_tokens.audio_start_token_id);
+
+    // Audio pad tokens — replaced by encoder output embeddings at runtime
+    ids.extend(std::iter::repeat_n(
+        special_tokens.audio_pad_token_id,
+        audio_token_count,
+    ));
+
+    ids.push(special_tokens.audio_end_token_id);
+    ids.push(special_tokens.im_end_token_id);
+    ids.push(NEWLINE_TOKEN_ID);
+
+    // Assistant turn prefix
+    ids.push(special_tokens.im_start_token_id);
+    ids.push(ASSISTANT_TOKEN_ID);
+    ids.push(NEWLINE_TOKEN_ID);
+
+    ids
+}
+
+/// Find the `[start, end)` range of `audio_pad` token positions in the prompt.
+pub fn get_audio_pad_range(
+    prompt_ids: &[i64],
+    audio_pad_token_id: i64,
+) -> Result<(usize, usize), String> {
+    let start = prompt_ids
+        .iter()
+        .position(|&id| id == audio_pad_token_id)
+        .ok_or_else(|| "No audio_pad tokens in prompt".to_string())?;
+    let end = prompt_ids
+        .iter()
+        .rposition(|&id| id == audio_pad_token_id)
+        .ok_or_else(|| "No audio_pad tokens in prompt".to_string())?
+        + 1;
+    Ok((start, end))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_special_tokens() -> SpecialTokens {
+        SpecialTokens {
+            eos_token_ids: vec![151643, 151645],
+            pad_token_id: 151643,
+            im_start_token_id: 151644,
+            im_end_token_id: 151645,
+            audio_start_token_id: 151669,
+            audio_end_token_id: 151670,
+            audio_pad_token_id: 151676,
+        }
+    }
+
+    #[test]
+    fn test_encoder_output_lengths() {
+        assert_eq!(get_feat_extract_output_lengths(0), 0);
+        assert_eq!(get_feat_extract_output_lengths(1), 1);
+        assert_eq!(get_feat_extract_output_lengths(99), 13); // boundary: last frame before window
+        assert_eq!(get_feat_extract_output_lengths(100), 13);
+        assert_eq!(get_feat_extract_output_lengths(200), 26);
+        assert_eq!(get_feat_extract_output_lengths(997), 130);
+    }
+
+    #[test]
+    fn test_build_prompt_ids_structure() {
+        let st = test_special_tokens();
+        let ids = build_prompt_ids(&st, 10);
+
+        // Should start with im_start, system, newline, im_end, newline
+        assert_eq!(ids[0], st.im_start_token_id);
+        assert_eq!(ids[1], SYSTEM_TOKEN_ID);
+        assert_eq!(ids[2], NEWLINE_TOKEN_ID);
+        assert_eq!(ids[3], st.im_end_token_id);
+        assert_eq!(ids[4], NEWLINE_TOKEN_ID);
+
+        // User turn
+        assert_eq!(ids[5], st.im_start_token_id);
+        assert_eq!(ids[6], USER_TOKEN_ID);
+        assert_eq!(ids[7], NEWLINE_TOKEN_ID);
+        assert_eq!(ids[8], st.audio_start_token_id);
+
+        // 10 audio_pad tokens at positions 9..19
+        for i in 9..19 {
+            assert_eq!(ids[i], st.audio_pad_token_id);
+        }
+
+        // audio_end, im_end, newline
+        assert_eq!(ids[19], st.audio_end_token_id);
+        assert_eq!(ids[20], st.im_end_token_id);
+        assert_eq!(ids[21], NEWLINE_TOKEN_ID);
+
+        // Assistant turn
+        assert_eq!(ids[22], st.im_start_token_id);
+        assert_eq!(ids[23], ASSISTANT_TOKEN_ID);
+        assert_eq!(ids[24], NEWLINE_TOKEN_ID);
+
+        assert_eq!(ids.len(), 25); // 15 fixed + 10 audio_pad
+    }
+
+    #[test]
+    fn test_audio_pad_range() {
+        let st = test_special_tokens();
+        let ids = build_prompt_ids(&st, 10);
+        let (start, end) = get_audio_pad_range(&ids, st.audio_pad_token_id).unwrap();
+        assert_eq!(start, 9);
+        assert_eq!(end, 19);
+        assert_eq!(end - start, 10);
+    }
+}

--- a/src/onnx/qwen3/tokenizer.rs
+++ b/src/onnx/qwen3/tokenizer.rs
@@ -1,8 +1,15 @@
-//! Decode-only BPE tokenizer for Qwen3-ASR.
+//! BPE tokenizer for Qwen3-ASR (encode + decode).
 //!
-//! Parses `tokenizer.json` (HuggingFace format) and decodes token IDs to text
-//! using the GPT-2 byte-level BPE mapping. No dependency on the `tokenizers`
-//! crate (follows Moonshine's pattern for Windows build compatibility).
+//! Parses `tokenizer.json` (HuggingFace format) and provides both encoding
+//! (text → token IDs) and decoding (token IDs → text) using the GPT-2
+//! byte-level BPE mapping. No dependency on the `tokenizers` crate (follows
+//! Moonshine's pattern for Windows build compatibility).
+//!
+//! Encoding uses greedy longest-match on the byte-level vocabulary. This does
+//! not apply BPE merge rules, so results may differ from the reference tokenizer
+//! on rare subword boundaries. For the short, common English text used in
+//! language-conditioned prompts (e.g. "English", "Chinese"), this produces
+//! identical output to the reference.
 
 use std::collections::{HashMap, HashSet};
 use std::fs;
@@ -10,10 +17,15 @@ use std::path::Path;
 
 use crate::TranscribeError;
 
-/// Decode-only tokenizer that maps token IDs to text.
+/// BPE tokenizer that maps between token IDs and text.
 pub struct Qwen3Tokenizer {
     /// Maps token ID to raw byte sequence (after GPT-2 unicode-to-byte decode).
     id_to_bytes: HashMap<u32, Vec<u8>>,
+    /// Maps raw byte sequence to token ID (reverse of `id_to_bytes`).
+    /// Used for greedy longest-match encoding.
+    bytes_to_id: HashMap<Vec<u8>, u32>,
+    /// Maximum token length in bytes (for bounding the greedy search).
+    max_token_len: usize,
     /// Set of special token IDs to skip during decode.
     special_token_ids: HashSet<u32>,
 }
@@ -69,10 +81,67 @@ impl Qwen3Tokenizer {
             }
         }
 
+        // Build reverse map for encoding (bytes → id).
+        // For duplicate byte sequences, prefer the lower token ID.
+        let mut bytes_to_id: HashMap<Vec<u8>, u32> = HashMap::new();
+        let mut max_token_len = 0usize;
+        for (&id, bytes) in &id_to_bytes {
+            max_token_len = max_token_len.max(bytes.len());
+            bytes_to_id
+                .entry(bytes.clone())
+                .and_modify(|existing| {
+                    if id < *existing {
+                        *existing = id;
+                    }
+                })
+                .or_insert(id);
+        }
+
         Ok(Self {
             id_to_bytes,
+            bytes_to_id,
+            max_token_len,
             special_token_ids,
         })
+    }
+
+    /// Encode a text string to token IDs using greedy longest-match.
+    ///
+    /// This does not apply BPE merge rules — it greedily matches the longest
+    /// vocabulary entry at each position. For common English words and language
+    /// names this produces identical results to the reference BPE tokenizer.
+    /// Results may differ on rare subword boundaries.
+    pub(crate) fn encode(&self, text: &str) -> Vec<i64> {
+        let bytes = text.as_bytes();
+        let mut ids = Vec::new();
+        let mut pos = 0;
+
+        while pos < bytes.len() {
+            // Greedy longest match: try decreasing lengths from max_token_len
+            let max_len = self.max_token_len.min(bytes.len() - pos);
+            let mut matched = false;
+            for len in (1..=max_len).rev() {
+                let candidate = &bytes[pos..pos + len];
+                if let Some(&id) = self.bytes_to_id.get(candidate) {
+                    ids.push(id as i64);
+                    pos += len;
+                    matched = true;
+                    break;
+                }
+            }
+            if !matched {
+                // Skip unrecognized byte (shouldn't happen with GPT-2 BPE
+                // which has single-byte entries for all 256 byte values)
+                log::warn!(
+                    "Qwen3 tokenizer encode: no match for byte 0x{:02x} at position {}",
+                    bytes[pos],
+                    pos
+                );
+                pos += 1;
+            }
+        }
+
+        ids
     }
 
     /// Decode a sequence of token IDs to a string, skipping special tokens.

--- a/src/onnx/qwen3/tokenizer.rs
+++ b/src/onnx/qwen3/tokenizer.rs
@@ -1,0 +1,179 @@
+//! Decode-only BPE tokenizer for Qwen3-ASR.
+//!
+//! Parses `tokenizer.json` (HuggingFace format) and decodes token IDs to text
+//! using the GPT-2 byte-level BPE mapping. No dependency on the `tokenizers`
+//! crate (follows Moonshine's pattern for Windows build compatibility).
+
+use std::collections::{HashMap, HashSet};
+use std::fs;
+use std::path::Path;
+
+use crate::TranscribeError;
+
+/// Decode-only tokenizer that maps token IDs to text.
+pub struct Qwen3Tokenizer {
+    /// Maps token ID to raw byte sequence (after GPT-2 unicode-to-byte decode).
+    id_to_bytes: HashMap<u32, Vec<u8>>,
+    /// Set of special token IDs to skip during decode.
+    special_token_ids: HashSet<u32>,
+}
+
+impl Qwen3Tokenizer {
+    pub fn new(model_dir: &Path) -> Result<Self, TranscribeError> {
+        let tokenizer_path = model_dir.join("tokenizer.json");
+        // Reads the entire tokenizer.json into memory. Typical Qwen/GPT-2 tokenizer files
+        // are ~2 MB; this is acceptable for a one-time model-load operation.
+        let file = fs::File::open(&tokenizer_path)?;
+        let reader = std::io::BufReader::new(file);
+        let json: serde_json::Value = serde_json::from_reader(reader)?;
+
+        let byte_decoder = build_gpt2_byte_decoder();
+
+        // Build id → bytes vocabulary from model.vocab
+        let mut id_to_bytes = HashMap::new();
+        if let Some(model) = json.get("model") {
+            if let Some(vocab) = model.get("vocab").and_then(|v| v.as_object()) {
+                for (token_str, id_val) in vocab {
+                    if let Some(id) = id_val.as_u64() {
+                        let bytes = decode_token_string(token_str, &byte_decoder);
+                        id_to_bytes.insert(id as u32, bytes);
+                    }
+                }
+            }
+        }
+
+        if id_to_bytes.is_empty() {
+            return Err(TranscribeError::Config(
+                "No vocabulary found in tokenizer.json".into(),
+            ));
+        }
+
+        log::info!(
+            "Loaded {} tokens from Qwen3-ASR vocabulary",
+            id_to_bytes.len()
+        );
+
+        // Collect special token IDs from added_tokens
+        let mut special_token_ids = HashSet::new();
+        if let Some(added_tokens) = json.get("added_tokens").and_then(|v| v.as_array()) {
+            for token in added_tokens {
+                let is_special = token
+                    .get("special")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false);
+                if is_special {
+                    if let Some(id) = token.get("id").and_then(|v| v.as_u64()) {
+                        special_token_ids.insert(id as u32);
+                    }
+                }
+            }
+        }
+
+        Ok(Self {
+            id_to_bytes,
+            special_token_ids,
+        })
+    }
+
+    /// Decode a sequence of token IDs to a string, skipping special tokens.
+    pub fn decode(&self, token_ids: &[i64]) -> String {
+        let mut bytes = Vec::new();
+        for &id in token_ids {
+            if id < 0 {
+                log::warn!("Qwen3 tokenizer: skipping negative token ID {}", id);
+                continue;
+            }
+            let id_u32 = id as u32;
+            if self.special_token_ids.contains(&id_u32) {
+                continue;
+            }
+            if let Some(token_bytes) = self.id_to_bytes.get(&id_u32) {
+                bytes.extend_from_slice(token_bytes);
+            }
+        }
+        String::from_utf8_lossy(&bytes).into_owned()
+    }
+}
+
+/// Build the GPT-2 unicode-to-byte decoder table.
+///
+/// GPT-2 BPE uses a mapping from byte values (0-255) to printable Unicode characters
+/// to avoid control characters in the vocabulary. This builds the inverse mapping.
+fn build_gpt2_byte_decoder() -> HashMap<char, u8> {
+    let mut byte_encoder: HashMap<u8, char> = HashMap::new();
+
+    // Printable ASCII ranges that map to themselves
+    // '!' (33) through '~' (126)
+    for b in b'!'..=b'~' {
+        byte_encoder.insert(b, b as char);
+    }
+    // Latin-1 supplement range: 161-172, 174-255
+    for b in 0xa1u8..=0xacu8 {
+        byte_encoder.insert(b, b as char);
+    }
+    for b in 0xaeu8..=0xffu8 {
+        byte_encoder.insert(b, b as char);
+    }
+
+    // Remaining bytes get mapped to Unicode starting at 256
+    let mut n = 256u32;
+    for b in 0u8..=255u8 {
+        if let std::collections::hash_map::Entry::Vacant(e) = byte_encoder.entry(b) {
+            e.insert(char::from_u32(n).unwrap());
+            n += 1;
+        }
+    }
+
+    // Invert: char → byte
+    byte_encoder.into_iter().map(|(b, c)| (c, b)).collect()
+}
+
+/// Decode a GPT-2 BPE token string to raw bytes.
+fn decode_token_string(token_str: &str, byte_decoder: &HashMap<char, u8>) -> Vec<u8> {
+    token_str
+        .chars()
+        .filter_map(|c| byte_decoder.get(&c).copied())
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_gpt2_byte_decoder_coverage() {
+        let decoder = build_gpt2_byte_decoder();
+        // Should have exactly 256 entries (one per byte value)
+        assert_eq!(decoder.len(), 256);
+    }
+
+    #[test]
+    fn test_gpt2_ascii_passthrough() {
+        let decoder = build_gpt2_byte_decoder();
+        // Printable ASCII (0x21-0x7E) maps to itself
+        assert_eq!(decoder[&'A'], b'A');
+        assert_eq!(decoder[&'z'], b'z');
+        assert_eq!(decoder[&'0'], b'0');
+        // Space (0x20) is NOT in the printable range, so it maps to a Unicode
+        // char > 0xFF. Verify it round-trips correctly through encode → decode.
+        let space_exists = decoder.values().any(|&b| b == 0x20);
+        assert!(
+            space_exists,
+            "Space byte should be represented in the decoder"
+        );
+    }
+
+    #[test]
+    fn test_gpt2_space_mapping() {
+        // GPT-2 encodes space (0x20) as 'Ġ' (U+0120).
+        let decoder = build_gpt2_byte_decoder();
+        assert_eq!(decoder[&'\u{0120}'], 0x20);
+    }
+
+    #[test]
+    fn test_decode_token_string_simple() {
+        let decoder = build_gpt2_byte_decoder();
+        let bytes = decode_token_string("Hello", &decoder);
+        assert_eq!(bytes, b"Hello");
+    }
+}

--- a/src/onnx/qwen3/tokenizer.rs
+++ b/src/onnx/qwen3/tokenizer.rs
@@ -119,7 +119,7 @@ fn build_gpt2_byte_decoder() -> HashMap<char, u8> {
     let mut n = 256u32;
     for b in 0u8..=255u8 {
         if let std::collections::hash_map::Entry::Vacant(e) = byte_encoder.entry(b) {
-            e.insert(char::from_u32(n).unwrap());
+            e.insert(char::from_u32(n).expect("BPE byte range always valid Unicode"));
             n += 1;
         }
     }

--- a/src/onnx/session.rs
+++ b/src/onnx/session.rs
@@ -319,9 +319,7 @@ pub fn create_decoder_session(path: &Path, num_threads: usize) -> Result<Session
             );
         }
         builder
-            .with_execution_providers([CPU::default()
-                .with_arena_allocator(true)
-                .build()])?
+            .with_execution_providers([CPU::default().with_arena_allocator(true).build()])?
             .commit_from_file(path)?
     };
 

--- a/src/onnx/session.rs
+++ b/src/onnx/session.rs
@@ -319,7 +319,7 @@ pub fn create_decoder_session(path: &Path, num_threads: usize) -> Result<Session
             );
         }
         builder
-            .with_execution_providers([CPUExecutionProvider::default()
+            .with_execution_providers([CPU::default()
                 .with_arena_allocator(true)
                 .build()])?
             .commit_from_file(path)?

--- a/src/onnx/session.rs
+++ b/src/onnx/session.rs
@@ -231,12 +231,7 @@ pub fn resolve_model_path(
             log::info!("Loading {} model: {}", suffix, path.display());
             return path;
         }
-        log::warn!(
-            "{} model not found at {}, falling back to {}.onnx",
-            suffix,
-            path.display(),
-            name
-        );
+        log::info!("No {} variant for {}, using {}.onnx", suffix, name, name);
     }
 
     dir.join(format!("{}.onnx", name))
@@ -286,4 +281,64 @@ pub fn read_metadata_float_vec(
         }
         None => Ok(None),
     }
+}
+
+/// Session for autoregressive decoders: sequential execution, configurable
+/// intra-op threads.
+///
+/// By default forces CPU-only with arena allocator — sequential execution makes
+/// GPU kernel launch overhead net-negative for per-token latency at batch size 1.
+///
+/// Call [`crate::set_decoder_gpu(true)`] to use the global accelerator preference
+/// for decoder sessions (for GPU benchmarking).
+///
+/// Thread count resolution:
+/// 1. `num_threads` if > 0
+/// 2. Global `set_ort_intra_threads` if > 0
+/// 3. ORT default (all cores)
+pub fn create_decoder_session(path: &Path, num_threads: usize) -> Result<Session, ort::Error> {
+    let use_gpu = crate::accel::get_decoder_gpu();
+
+    let mut builder = Session::builder()?
+        .with_optimization_level(GraphOptimizationLevel::Level3)?
+        .with_parallel_execution(false)?;
+    if num_threads > 0 {
+        builder = builder.with_intra_threads(num_threads)?;
+    }
+
+    let session = if use_gpu {
+        log::info!("Decoder session using global accelerator (TRANSCRIBE_DECODER_GPU=1)");
+        builder
+            .with_execution_providers(execution_providers())?
+            .commit_from_file(path)?
+    } else {
+        if get_ort_accelerator() != OrtAccelerator::CpuOnly {
+            log::info!(
+                "Decoder session uses CPU-only (sequential execution); \
+                 set TRANSCRIBE_DECODER_GPU=1 to override"
+            );
+        }
+        builder
+            .with_execution_providers([CPUExecutionProvider::default()
+                .with_arena_allocator(true)
+                .build()])?
+            .commit_from_file(path)?
+    };
+
+    for input in session.inputs() {
+        log::info!(
+            "Model input: name={}, type={:?}",
+            input.name(),
+            input.dtype()
+        );
+    }
+    for output in session.outputs() {
+        log::info!(
+            "Model output: name={}, type={:?}",
+            output.name(),
+            output.dtype()
+        );
+    }
+
+    Ok(session)
 }

--- a/tests/qwen3.rs
+++ b/tests/qwen3.rs
@@ -1,0 +1,129 @@
+mod common;
+
+use std::path::PathBuf;
+
+use transcribe_rs::onnx::qwen3::{Qwen3Model, Qwen3Params};
+use transcribe_rs::onnx::Quantization;
+use transcribe_rs::SpeechModel;
+
+#[test]
+fn test_qwen3_transcribe() -> Result<(), Box<dyn std::error::Error>> {
+    env_logger::try_init().ok();
+
+    let model_path = PathBuf::from("models/qwen3-asr-0.6b");
+    let wav_path = PathBuf::from("samples/jfk.wav");
+
+    if !common::require_paths(&[&model_path, &wav_path]) {
+        return Ok(());
+    }
+
+    let mut model = Qwen3Model::load(&model_path, &Quantization::default())?;
+
+    let result = model.transcribe_file(&wav_path, &transcribe_rs::TranscribeOptions::default())?;
+
+    // INT8 produces comma; FP32 produces semicolon.
+    // Both are acceptable transcriptions of the JFK quote.
+    let acceptable = [
+        "And so, my fellow Americans, ask not what your country can do for you; ask what you can do for your country.",
+        "And so, my fellow Americans, ask not what your country can do for you, ask what you can do for your country.",
+    ];
+    assert!(
+        acceptable.contains(&result.text.trim()),
+        "\nExpected one of: {:?}\nActual: '{}'",
+        acceptable,
+        result.text.trim()
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_qwen3_1_7b_transcribe() -> Result<(), Box<dyn std::error::Error>> {
+    env_logger::try_init().ok();
+
+    let model_path = PathBuf::from("models/qwen3-asr-1.7b");
+    let wav_path = PathBuf::from("samples/jfk.wav");
+
+    if !common::require_paths(&[&model_path, &wav_path]) {
+        return Ok(());
+    }
+
+    let mut model = Qwen3Model::load(&model_path, &Quantization::default())?;
+    let result = model.transcribe_file(&wav_path, &transcribe_rs::TranscribeOptions::default())?;
+
+    // FP32 decoder produces ". Ask" (sentence break); INT8 decoder produces "; ask".
+    // Both are acceptable transcriptions of the JFK quote.
+    let acceptable = [
+        "And so, my fellow Americans, ask not what your country can do for you. Ask what you can do for your country.",
+        "And so, my fellow Americans, ask not what your country can do for you; ask what you can do for your country.",
+    ];
+    assert!(
+        acceptable.contains(&result.text.trim()),
+        "\nExpected one of: {:?}\nActual: '{}'",
+        acceptable,
+        result.text.trim()
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_qwen3_max_tokens_truncation() -> Result<(), Box<dyn std::error::Error>> {
+    env_logger::try_init().ok();
+
+    let model_path = PathBuf::from("models/qwen3-asr-0.6b");
+    let wav_path = PathBuf::from("samples/jfk.wav");
+
+    if !common::require_paths(&[&model_path, &wav_path]) {
+        return Ok(());
+    }
+
+    let samples = transcribe_rs::audio::read_wav_samples(&wav_path)?;
+    let mut model = Qwen3Model::load(&model_path, &Quantization::default())?;
+    let result = model.transcribe_with(&samples, &Qwen3Params { max_tokens: 5 })?;
+
+    assert!(
+        !result.text.is_empty(),
+        "truncated result should be non-empty"
+    );
+    // With max_tokens=5, the output should be much shorter than the full transcription.
+    assert!(
+        result.text.trim().len() < 80,
+        "5-token result should be shorter than full transcription, got: '{}'",
+        result.text.trim()
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_qwen3_empty_audio() -> Result<(), Box<dyn std::error::Error>> {
+    env_logger::try_init().ok();
+
+    let model_path = PathBuf::from("models/qwen3-asr-0.6b");
+
+    if !common::require_paths(&[&model_path]) {
+        return Ok(());
+    }
+
+    let mut model = Qwen3Model::load(&model_path, &Quantization::default())?;
+    let result = model.transcribe_with(&[], &Qwen3Params::default())?;
+    assert_eq!(result.text, "", "empty audio should return empty string");
+
+    Ok(())
+}
+
+#[test]
+fn test_qwen3_audio_too_long() -> Result<(), Box<dyn std::error::Error>> {
+    let model_path = PathBuf::from("models/qwen3-asr-0.6b");
+    if !common::require_paths(&[&model_path]) {
+        return Ok(());
+    }
+    let mut model = Qwen3Model::load(&model_path, &Quantization::default())?;
+    let too_long = vec![0.0f32; 60 * 16_000 + 1];
+    let result = model.transcribe_with(&too_long, &Qwen3Params::default());
+    assert!(result.is_err(), "expected error for audio > 60s");
+    let err = result.unwrap_err().to_string();
+    assert!(err.contains("audio too long"), "unexpected error: {err}");
+    Ok(())
+}

--- a/tests/qwen3.rs
+++ b/tests/qwen3.rs
@@ -127,3 +127,64 @@ fn test_qwen3_audio_too_long() -> Result<(), Box<dyn std::error::Error>> {
     assert!(err.contains("audio too long"), "unexpected error: {err}");
     Ok(())
 }
+
+#[test]
+fn test_qwen3_int4_fp16_embed() -> Result<(), Box<dyn std::error::Error>> {
+    env_logger::try_init().ok();
+
+    // Tests FP16 embed_tokens.bin loading (embed_tokens_dtype: float16 in config.json).
+    let model_path = PathBuf::from("models/qwen3-asr-0.6b-int4");
+    let wav_path = PathBuf::from("samples/jfk.wav");
+
+    if !model_path.join("decoder_init.int4.onnx").exists()
+        || !model_path.join("embed_tokens.bin").exists()
+        || !wav_path.exists()
+    {
+        return Ok(());
+    }
+
+    let mut model = Qwen3Model::load(&model_path, &Quantization::Int4)?;
+    let result = model.transcribe_file(&wav_path, &transcribe_rs::TranscribeOptions::default())?;
+
+    let acceptable = [
+        "And so, my fellow Americans, ask not what your country can do for you, ask what you can do for your country.",
+        "And so, my fellow Americans, ask not what your country can do for you; ask what you can do for your country.",
+    ];
+    assert!(
+        acceptable.contains(&result.text.trim()),
+        "\nExpected one of: {:?}\nActual: '{}'",
+        acceptable,
+        result.text.trim()
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_qwen3_1_7b_int4_transcribe() -> Result<(), Box<dyn std::error::Error>> {
+    env_logger::try_init().ok();
+
+    let model_path = PathBuf::from("models/qwen3-asr-1.7b");
+    let wav_path = PathBuf::from("samples/jfk.wav");
+    let int4_path = model_path.join("decoder_init.int4.onnx");
+
+    if !common::require_paths(&[&model_path, &wav_path]) || !int4_path.exists() {
+        return Ok(());
+    }
+
+    let mut model = Qwen3Model::load(&model_path, &Quantization::Int4)?;
+    let result = model.transcribe_file(&wav_path, &transcribe_rs::TranscribeOptions::default())?;
+
+    let acceptable = [
+        "And so, my fellow Americans, ask not what your country can do for you. Ask what you can do for your country.",
+        "And so, my fellow Americans, ask not what your country can do for you; ask what you can do for your country.",
+    ];
+    assert!(
+        acceptable.contains(&result.text.trim()),
+        "\nExpected one of: {:?}\nActual: '{}'",
+        acceptable,
+        result.text.trim()
+    );
+
+    Ok(())
+}

--- a/tests/qwen3.rs
+++ b/tests/qwen3.rs
@@ -80,7 +80,13 @@ fn test_qwen3_max_tokens_truncation() -> Result<(), Box<dyn std::error::Error>> 
 
     let samples = transcribe_rs::audio::read_wav_samples(&wav_path)?;
     let mut model = Qwen3Model::load(&model_path, &Quantization::default())?;
-    let result = model.transcribe_with(&samples, &Qwen3Params { max_tokens: 5 })?;
+    let result = model.transcribe_with(
+        &samples,
+        &Qwen3Params {
+            max_tokens: 5,
+            ..Default::default()
+        },
+    )?;
 
     assert!(
         !result.text.is_empty(),


### PR DESCRIPTION
## Summary

Adds `engines/qwen3` module implementing `TranscriptionEngine` for [Qwen3-ASR](https://huggingface.co/Qwen/Qwen3-ASR), Alibaba's multilingual speech recognition model. Supports 0.6B and 1.7B model variants.

New `qwen3` Cargo feature — follows the same pattern as existing ONNX-based engines (parakeet, moonshine, sense_voice): feature-gated, uses `ort` + `ndarray`, CPU execution.

### Engine details

- Encoder-decoder architecture with autoregressive token generation
- Log-mel spectrogram feature extraction (80-bin, via `rustfft`)
- HuggingFace BPE tokenizer
- Language prefix stripping — the model outputs `language <Name><text>`, matched against known language names to find the boundary
- Supports both FP32 and INT8 quantized models (selected via `Qwen3ModelParams`)

### Pre-exported ONNX models

- [andrewleech/qwen3-asr-0.6b-onnx](https://huggingface.co/andrewleech/qwen3-asr-0.6b-onnx) (FP32)
- [andrewleech/qwen3-asr-0.6b-onnx-int8](https://huggingface.co/andrewleech/qwen3-asr-0.6b-onnx-int8) (INT8)
- [andrewleech/qwen3-asr-1.7b-onnx](https://huggingface.co/andrewleech/qwen3-asr-1.7b-onnx) (FP32)

Export scripts and methodology: [andrewleech/qwen3-asr-onnx](https://github.com/andrewleech/qwen3-asr-onnx)

Resolves https://github.com/cjpais/transcribe-rs/issues/30