### PR TITLE
feat: add GPU execution provider support with runtime selection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1227,6 +1227,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2aba9f5c7c479925205799216e7e5d07cc1d4fa76ea8058c60a9a30f6a4e890"
 dependencies = [
  "flate2",
+ "glob",
  "pkg-config",
  "sha2",
  "tar",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,12 @@ openai = ["dep:async-openai", "dep:tokio", "dep:async-trait"]
 # Post-processing
 # itn = ["dep:nemo-text-processing"]  # TODO: re-enable when nemo-text-processing is published to crates.io
 
+# GPU execution providers (pass-through to ort)
+directml = ["dep:ort", "ort/directml"]
+cuda = ["dep:ort", "ort/cuda"]
+coreml = ["dep:ort", "ort/coreml"]
+webgpu = ["dep:ort", "ort/webgpu"]
+
 # Convenience
 all = ["whisper", "parakeet", "moonshine", "sense_voice", "gigaam", "whisperfile", "openai"]
 

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ This library was extracted from the [Handy](https://github.com/cjpais/handy) pro
 ## Features
 
 - **Multiple Transcription Engines**: Support for Whisper, Whisperfile, Parakeet, Moonshine, SenseVoice, and GigaAM models
-- **Cross-platform**: Works on macOS, Windows, and Linux with optimized backends
-- **Hardware Acceleration**: Metal on macOS, Vulkan on Windows/Linux
+- **Cross-platform**: Works on macOS, Windows, and Linux
+- **GPU Acceleration**: Optional GPU execution providers for ORT engines (DirectML, CUDA, CoreML, WebGPU)
 - **Flexible API**: Common interface for different transcription engines
 - **Multi-language Support**: SenseVoice supports Chinese, English, Japanese, Korean, and Cantonese; Moonshine supports English, Arabic, Chinese, Japanese, Korean, Ukrainian, Vietnamese, and Spanish; GigaAM supports Russian with punctuation and Latin characters
 - **Opt-in Dependencies**: Only compile and link the engines you need via Cargo features
@@ -39,7 +39,36 @@ transcribe-rs = { version = "0.1.5", features = ["all"] }
 | `openai` | OpenAI API (remote) | async-openai, tokio |
 | `all` | All engines enabled | All of the above |
 
-**Note**: By default, no features are enabled. You must explicitly choose which engines to include.
+**GPU Execution Providers** (optional, combine with engine features above):
+
+| Feature | Description | Dependencies |
+|---------|-------------|--------------|
+| `directml` | DirectML execution provider (Windows) | ort/directml |
+| `cuda` | CUDA execution provider (Linux) | ort/cuda |
+| `coreml` | CoreML execution provider (macOS) | ort/coreml |
+| `webgpu` | WebGPU execution provider (cross-platform) | ort/webgpu |
+
+**Note**: By default, no features are enabled. You must explicitly choose which engines to include. GPU features apply to ORT-based engines (Parakeet, Moonshine, SenseVoice, GigaAM). Whisper and Whisperfile use whisper.cpp and are unaffected. Without any GPU feature, all ORT engines run on CPU.
+
+## GPU Provider Selection
+
+The `GpuProvider` enum controls which execution provider ORT uses at runtime. Set it before creating any ORT sessions:
+
+```rust
+use transcribe_rs::{set_gpu_provider, get_gpu_provider, available_providers, GpuProvider};
+
+// Query which providers were compiled in
+let providers = available_providers(); // e.g. [Auto, CpuOnly, DirectMl]
+
+// Select a provider
+set_gpu_provider(GpuProvider::Auto);
+```
+
+| Variant | Behaviour |
+|---------|-----------|
+| `Auto` (default) | Tries all compiled-in GPU EPs, falls back to CPU |
+| `CpuOnly` | Forces CPU regardless of compiled features |
+| `DirectMl` / `Cuda` / `CoreMl` / `WebGpu` | Uses that EP with CPU fallback. Logs a warning and falls back to CPU if the feature was not compiled in |
 
 ## Parakeet Performance
 

--- a/src/engines/gigaam/model.rs
+++ b/src/engines/gigaam/model.rs
@@ -1,5 +1,4 @@
 use ndarray::Array2;
-use ort::execution_providers::CPUExecutionProvider;
 use ort::inputs;
 use ort::session::builder::GraphOptimizationLevel;
 use ort::session::Session;
@@ -333,7 +332,7 @@ impl GigaAMModel {
     }
 
     fn init_session(path: &Path) -> Result<Session, GigaAMError> {
-        let providers = vec![CPUExecutionProvider::default().build()];
+        let providers = crate::ort_providers::execution_providers();
 
         let session = Session::builder()?
             .with_optimization_level(GraphOptimizationLevel::Level3)?

--- a/src/engines/moonshine/model.rs
+++ b/src/engines/moonshine/model.rs
@@ -1,5 +1,4 @@
 use ndarray::{Array2, ArrayD};
-use ort::execution_providers::CPUExecutionProvider;
 use ort::inputs;
 use ort::session::builder::GraphOptimizationLevel;
 use ort::session::Session;
@@ -96,7 +95,7 @@ impl MoonshineModel {
     }
 
     fn init_session(path: &Path) -> Result<Session, MoonshineError> {
-        let providers = vec![CPUExecutionProvider::default().build()];
+        let providers = crate::ort_providers::execution_providers();
 
         let session = Session::builder()?
             .with_optimization_level(GraphOptimizationLevel::Level3)?

--- a/src/engines/moonshine/streaming_model.rs
+++ b/src/engines/moonshine/streaming_model.rs
@@ -1,5 +1,4 @@
 use ndarray::{ArrayD, ArrayViewD, IxDyn};
-use ort::execution_providers::CPUExecutionProvider;
 use ort::inputs;
 use ort::session::builder::GraphOptimizationLevel;
 use ort::session::Session;
@@ -80,8 +79,11 @@ impl StreamingModel {
             builder = builder.with_intra_threads(num_threads)?;
         }
 
+        // Streaming uses CPU-only: small per-chunk sessions where GPU launch
+        // overhead exceeds any compute benefit, and the 5 sessions would
+        // compete for GPU memory with the batch model.
         let session = builder
-            .with_execution_providers([CPUExecutionProvider::default().build()])?
+            .with_execution_providers(crate::ort_providers::cpu_execution_providers())?
             .commit_from_file(&path)?;
 
         Ok(session)

--- a/src/engines/parakeet/model.rs
+++ b/src/engines/parakeet/model.rs
@@ -1,6 +1,5 @@
 use ndarray::{Array, Array1, Array2, Array3, ArrayD, ArrayViewD, IxDyn};
 use once_cell::sync::Lazy;
-use ort::execution_providers::CPUExecutionProvider;
 use ort::inputs;
 use ort::session::builder::GraphOptimizationLevel;
 use ort::session::Session;
@@ -91,7 +90,7 @@ impl ParakeetModel {
         intra_threads: Option<usize>,
         try_quantized: bool,
     ) -> Result<Session, ParakeetError> {
-        let providers = vec![CPUExecutionProvider::default().build()];
+        let providers = crate::ort_providers::execution_providers();
 
         // Try quantized version first if requested, fallback to regular version
         let model_filename = if try_quantized {

--- a/src/engines/sense_voice/model.rs
+++ b/src/engines/sense_voice/model.rs
@@ -1,5 +1,4 @@
 use ndarray::{Array1, Array3, ArrayView2};
-use ort::execution_providers::CPUExecutionProvider;
 use ort::inputs;
 use ort::session::builder::GraphOptimizationLevel;
 use ort::session::Session;
@@ -122,7 +121,7 @@ impl SenseVoiceModel {
     }
 
     fn init_session(path: &Path) -> Result<Session, SenseVoiceError> {
-        let providers = vec![CPUExecutionProvider::default().build()];
+        let providers = crate::ort_providers::execution_providers();
 
         let session = Session::builder()?
             .with_optimization_level(GraphOptimizationLevel::Level3)?

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,24 @@
 pub mod audio;
 pub mod engines;
 
+#[cfg(any(
+    feature = "parakeet",
+    feature = "moonshine",
+    feature = "sense_voice",
+    feature = "gigaam",
+))]
+pub mod ort_providers;
+
+#[cfg(any(
+    feature = "parakeet",
+    feature = "moonshine",
+    feature = "sense_voice",
+    feature = "gigaam",
+))]
+pub use ort_providers::{
+    available_providers, cpu_execution_providers, get_gpu_provider, set_gpu_provider, GpuProvider,
+};
+
 #[cfg(feature = "openai")]
 pub mod remote;
 #[cfg(feature = "openai")]

--- a/src/ort_providers.rs
+++ b/src/ort_providers.rs
@@ -1,0 +1,313 @@
+use ort::execution_providers::{CPUExecutionProvider, ExecutionProviderDispatch};
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use std::str::FromStr;
+use std::sync::atomic::{AtomicU8, Ordering};
+
+#[cfg(feature = "cuda")]
+use ort::execution_providers::CUDAExecutionProvider;
+#[cfg(feature = "directml")]
+use ort::execution_providers::DirectMLExecutionProvider;
+#[cfg(feature = "coreml")]
+use ort::execution_providers::CoreMLExecutionProvider;
+#[cfg(feature = "webgpu")]
+use ort::execution_providers::WebGPUExecutionProvider;
+
+/// Runtime selection of which GPU execution provider to use.
+///
+/// Set once at startup (or when the user changes the setting) via
+/// [`set_gpu_provider`].  Read by [`execution_providers`] each time an
+/// ORT session is created.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+#[repr(u8)]
+pub enum GpuProvider {
+    /// Try all compiled-in GPU EPs, then CPU (default).
+    Auto = 0,
+    /// CPU only — no GPU acceleration.
+    #[serde(rename = "cpu")]
+    CpuOnly = 1,
+    /// DirectML (Windows).
+    #[serde(rename = "directml")]
+    DirectMl = 2,
+    /// CUDA (Linux).
+    Cuda = 3,
+    /// CoreML (macOS).
+    #[serde(rename = "coreml")]
+    CoreMl = 4,
+    /// WebGPU (cross-platform).
+    #[serde(rename = "webgpu")]
+    WebGpu = 5,
+}
+
+impl GpuProvider {
+    fn from_u8(v: u8) -> Self {
+        match v {
+            1 => GpuProvider::CpuOnly,
+            2 => GpuProvider::DirectMl,
+            3 => GpuProvider::Cuda,
+            4 => GpuProvider::CoreMl,
+            5 => GpuProvider::WebGpu,
+            _ => GpuProvider::Auto,
+        }
+    }
+}
+
+impl fmt::Display for GpuProvider {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            GpuProvider::Auto => write!(f, "auto"),
+            GpuProvider::CpuOnly => write!(f, "cpu"),
+            GpuProvider::DirectMl => write!(f, "directml"),
+            GpuProvider::Cuda => write!(f, "cuda"),
+            GpuProvider::CoreMl => write!(f, "coreml"),
+            GpuProvider::WebGpu => write!(f, "webgpu"),
+        }
+    }
+}
+
+impl FromStr for GpuProvider {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "auto" => Ok(GpuProvider::Auto),
+            "cpu" => Ok(GpuProvider::CpuOnly),
+            "directml" => Ok(GpuProvider::DirectMl),
+            "cuda" => Ok(GpuProvider::Cuda),
+            "coreml" => Ok(GpuProvider::CoreMl),
+            "webgpu" => Ok(GpuProvider::WebGpu),
+            _ => Err(format!("unknown GPU provider: {}", s)),
+        }
+    }
+}
+
+static GPU_PROVIDER: AtomicU8 = AtomicU8::new(GpuProvider::Auto as u8);
+
+/// Set the runtime GPU provider selection.
+///
+/// Must be called before any ORT sessions are created.  Changing the
+/// provider while models are loaded has no effect on existing sessions.
+pub fn set_gpu_provider(provider: GpuProvider) {
+    GPU_PROVIDER.store(provider as u8, Ordering::Release);
+}
+
+/// Read the current GPU provider selection.
+pub fn get_gpu_provider() -> GpuProvider {
+    GpuProvider::from_u8(GPU_PROVIDER.load(Ordering::Acquire))
+}
+
+/// Return which GPU providers are available in this build.
+///
+/// Always includes `Auto` and `CpuOnly`; GPU-specific variants are
+/// present only when the corresponding Cargo feature is compiled in.
+pub fn available_providers() -> Vec<GpuProvider> {
+    #[allow(unused_mut)]
+    let mut v = vec![GpuProvider::Auto, GpuProvider::CpuOnly];
+    #[cfg(feature = "directml")]
+    v.push(GpuProvider::DirectMl);
+    #[cfg(feature = "cuda")]
+    v.push(GpuProvider::Cuda);
+    #[cfg(feature = "coreml")]
+    v.push(GpuProvider::CoreMl);
+    #[cfg(feature = "webgpu")]
+    v.push(GpuProvider::WebGpu);
+    v
+}
+
+/// Return an ordered list of execution providers to try.
+///
+/// Respects the runtime [`GpuProvider`] selection.  When a specific
+/// provider is selected, only that provider + CPU fallback are returned.
+/// In `Auto` mode, all compiled-in GPU EPs are tried before CPU.
+pub fn execution_providers() -> Vec<ExecutionProviderDispatch> {
+    let selection = get_gpu_provider();
+
+    match selection {
+        GpuProvider::CpuOnly => {
+            return vec![CPUExecutionProvider::default().build()];
+        }
+        #[cfg(feature = "directml")]
+        GpuProvider::DirectMl => {
+            return vec![
+                DirectMLExecutionProvider::default().build(),
+                CPUExecutionProvider::default().build(),
+            ];
+        }
+        #[cfg(feature = "cuda")]
+        GpuProvider::Cuda => {
+            return vec![
+                CUDAExecutionProvider::default().build(),
+                CPUExecutionProvider::default().build(),
+            ];
+        }
+        #[cfg(feature = "coreml")]
+        GpuProvider::CoreMl => {
+            return vec![
+                CoreMLExecutionProvider::default().build(),
+                CPUExecutionProvider::default().build(),
+            ];
+        }
+        #[cfg(feature = "webgpu")]
+        GpuProvider::WebGpu => {
+            return vec![
+                WebGPUExecutionProvider::default().build(),
+                CPUExecutionProvider::default().build(),
+            ];
+        }
+        GpuProvider::Auto => {}
+        #[allow(unreachable_patterns)]
+        _ => {
+            // The selected provider wasn't compiled into this build.
+            // Fall back to CPU-only rather than silently trying other GPU EPs.
+            log::warn!(
+                "Selected GPU provider {:?} is not available in this build, falling back to CPU",
+                selection
+            );
+            return vec![CPUExecutionProvider::default().build()];
+        }
+    }
+
+    // Auto: all compiled-in GPU EPs + CPU
+    let mut providers = Vec::new();
+
+    #[cfg(feature = "cuda")]
+    providers.push(CUDAExecutionProvider::default().build());
+
+    #[cfg(feature = "directml")]
+    providers.push(DirectMLExecutionProvider::default().build());
+
+    #[cfg(feature = "coreml")]
+    providers.push(CoreMLExecutionProvider::default().build());
+
+    #[cfg(feature = "webgpu")]
+    providers.push(WebGPUExecutionProvider::default().build());
+
+    providers.push(CPUExecutionProvider::default().build());
+    providers
+}
+
+/// Return CPU-only execution providers.
+///
+/// Use this for models that contain operators with known GPU EP bugs
+/// (e.g. Conv2d on DirectML producing NaN).  This bypasses the global
+/// [`GpuProvider`] setting entirely.
+pub fn cpu_execution_providers() -> Vec<ExecutionProviderDispatch> {
+    vec![CPUExecutionProvider::default().build()]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Restore Auto after each test since the AtomicU8 is process-global.
+    struct RestoreAuto;
+    impl Drop for RestoreAuto {
+        fn drop(&mut self) {
+            set_gpu_provider(GpuProvider::Auto);
+        }
+    }
+
+    #[test]
+    fn from_u8_round_trip() {
+        let variants = [
+            GpuProvider::Auto,
+            GpuProvider::CpuOnly,
+            GpuProvider::DirectMl,
+            GpuProvider::Cuda,
+            GpuProvider::CoreMl,
+            GpuProvider::WebGpu,
+        ];
+        for v in variants {
+            assert_eq!(GpuProvider::from_u8(v as u8), v);
+        }
+    }
+
+    #[test]
+    fn from_u8_unknown_defaults_to_auto() {
+        assert_eq!(GpuProvider::from_u8(6), GpuProvider::Auto);
+        assert_eq!(GpuProvider::from_u8(255), GpuProvider::Auto);
+    }
+
+    #[test]
+    fn set_get_round_trip() {
+        let _guard = RestoreAuto;
+        let variants = [
+            GpuProvider::Auto,
+            GpuProvider::CpuOnly,
+            GpuProvider::DirectMl,
+            GpuProvider::Cuda,
+            GpuProvider::CoreMl,
+            GpuProvider::WebGpu,
+        ];
+        for v in variants {
+            set_gpu_provider(v);
+            assert_eq!(get_gpu_provider(), v);
+        }
+    }
+
+    #[test]
+    fn available_providers_baseline() {
+        let providers = available_providers();
+        assert!(providers.contains(&GpuProvider::Auto));
+        assert!(providers.contains(&GpuProvider::CpuOnly));
+        assert!(providers.len() >= 2);
+    }
+
+    #[test]
+    fn available_providers_no_duplicates() {
+        let providers = available_providers();
+        let mut seen = Vec::new();
+        for p in &providers {
+            assert!(!seen.contains(p), "duplicate provider: {:?}", p);
+            seen.push(*p);
+        }
+    }
+
+    #[test]
+    fn default_provider_is_auto() {
+        let _guard = RestoreAuto;
+        // Reset to a known state first
+        set_gpu_provider(GpuProvider::Auto);
+        assert_eq!(get_gpu_provider(), GpuProvider::Auto);
+    }
+
+    #[test]
+    fn display_round_trip() {
+        let cases = [
+            (GpuProvider::Auto, "auto"),
+            (GpuProvider::CpuOnly, "cpu"),
+            (GpuProvider::DirectMl, "directml"),
+            (GpuProvider::Cuda, "cuda"),
+            (GpuProvider::CoreMl, "coreml"),
+            (GpuProvider::WebGpu, "webgpu"),
+        ];
+        for (variant, expected) in cases {
+            assert_eq!(variant.to_string(), expected);
+            assert_eq!(expected.parse::<GpuProvider>().unwrap(), variant);
+        }
+    }
+
+    #[test]
+    fn from_str_unknown_errors() {
+        assert!("vulkan".parse::<GpuProvider>().is_err());
+        assert!("AUTO".parse::<GpuProvider>().is_err());
+        assert!("".parse::<GpuProvider>().is_err());
+    }
+
+    #[test]
+    fn serde_round_trip() {
+        let cases = [
+            (GpuProvider::Auto, "\"auto\""),
+            (GpuProvider::CpuOnly, "\"cpu\""),
+            (GpuProvider::DirectMl, "\"directml\""),
+            (GpuProvider::Cuda, "\"cuda\""),
+            (GpuProvider::CoreMl, "\"coreml\""),
+            (GpuProvider::WebGpu, "\"webgpu\""),
+        ];
+        for (variant, json) in cases {
+            assert_eq!(serde_json::to_string(&variant).unwrap(), json);
+            assert_eq!(serde_json::from_str::<GpuProvider>(json).unwrap(), variant);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds opt-in GPU acceleration for all ONNX-based engines (Parakeet, Moonshine, SenseVoice) via a shared `ort_providers` module.

- **Feature flags**: `directml` (Windows), `cuda` (Linux), `coreml` (macOS), `webgpu` (cross-platform) — each forwards to the corresponding `ort` EP feature
- **Runtime selection**: `GpuProvider` enum with `set_gpu_provider()`/`get_gpu_provider()` allows switching at runtime between Auto, CpuOnly, or a specific provider
- **Fallback**: ORT tries the selected provider first, falls back to CPU silently on failure
- **No-op without flags**: Without any GPU feature enabled, behaviour is identical to the current CPU-only code

Existing engines' `init_session` calls now go through `ort_providers::execution_providers()` instead of hardcoding `CPUExecutionProvider`.