### PR TITLE
feat: add Qwen3-ASR ONNX engine

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,6 +115,10 @@ name = "cohere"
 required-features = ["onnx"]
 
 [[example]]
+name = "qwen3"
+required-features = ["onnx"]
+
+[[example]]
 name = "whisperfile"
 required-features = ["whisperfile"]
 

--- a/examples/qwen3.rs
+++ b/examples/qwen3.rs
@@ -1,0 +1,27 @@
+//! Qwen3-ASR example — batch transcription.
+
+use std::path::PathBuf;
+
+use transcribe_rs::onnx::qwen3::{Qwen3Model, Qwen3Params};
+use transcribe_rs::onnx::Quantization;
+use transcribe_rs::SpeechModel;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    env_logger::Builder::from_env(env_logger::Env::new().default_filter_or("info")).init();
+
+    let model_dir = std::env::args()
+        .nth(1)
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("models/qwen3-asr-0.6b"));
+
+    let audio_path = std::env::args()
+        .nth(2)
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("tests/fixtures/test_audio.wav"));
+
+    let mut model = Qwen3Model::load(&model_dir, &Quantization::FP32)?;
+    let result = model.transcribe_file(&audio_path, &Default::default())?;
+    println!("{}", result.text);
+
+    Ok(())
+}

--- a/src/accel.rs
+++ b/src/accel.rs
@@ -6,7 +6,7 @@
 
 use std::fmt;
 use std::str::FromStr;
-use std::sync::atomic::{AtomicI32, AtomicU8, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicI32, AtomicU8, Ordering};
 
 use serde::{Deserialize, Serialize};
 
@@ -259,6 +259,27 @@ impl FromStr for WhisperAccelerator {
             other => Err(format!("unknown Whisper accelerator: {other}")),
         }
     }
+}
+
+// ---------------------------------------------------------------------------
+// ORT decoder GPU toggle
+// ---------------------------------------------------------------------------
+
+static DECODER_GPU: AtomicBool = AtomicBool::new(false);
+
+/// Control whether decoder sessions use GPU acceleration.
+///
+/// By default, decoder sessions are CPU-only (sequential execution makes GPU
+/// kernel launch overhead net-negative for per-token latency at batch size 1).
+/// Set this to `true` to use the global accelerator for decoder sessions
+/// (for GPU benchmarking or batch workloads).
+pub fn set_decoder_gpu(use_gpu: bool) {
+    DECODER_GPU.store(use_gpu, Ordering::Relaxed);
+}
+
+/// Returns whether decoder sessions should use the global accelerator.
+pub fn get_decoder_gpu() -> bool {
+    DECODER_GPU.load(Ordering::Relaxed)
 }
 
 // ---------------------------------------------------------------------------

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,9 +90,9 @@ pub mod accel;
 pub mod audio;
 pub mod error;
 pub use accel::{
-    get_ort_accelerator, get_whisper_accelerator, get_whisper_gpu_device, set_ort_accelerator,
-    set_whisper_accelerator, set_whisper_gpu_device, OrtAccelerator, WhisperAccelerator,
-    GPU_DEVICE_AUTO,
+    get_decoder_gpu, get_ort_accelerator, get_whisper_accelerator, get_whisper_gpu_device,
+    set_decoder_gpu, set_ort_accelerator, set_whisper_accelerator, set_whisper_gpu_device,
+    OrtAccelerator, WhisperAccelerator, GPU_DEVICE_AUTO,
 };
 pub use error::TranscribeError;
 

--- a/src/onnx/mod.rs
+++ b/src/onnx/mod.rs
@@ -25,4 +25,5 @@ pub mod cohere;
 pub mod gigaam;
 pub mod moonshine;
 pub mod parakeet;
+pub mod qwen3;
 pub mod sense_voice;

--- a/src/onnx/qwen3/config.rs
+++ b/src/onnx/qwen3/config.rs
@@ -1,0 +1,194 @@
+use serde::Deserialize;
+use std::fs;
+use std::path::Path;
+
+use crate::TranscribeError;
+
+/// Top-level model configuration loaded from `config.json`.
+// Fields are deserialized from config.json; not all are used at runtime.
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+pub struct Qwen3AsrConfig {
+    pub encoder: EncoderConfig,
+    pub decoder: DecoderConfig,
+    pub mel: Qwen3MelParams,
+    pub special_tokens: SpecialTokens,
+    /// Storage dtype of `embed_tokens.bin`.
+    #[serde(default)]
+    pub embed_tokens_dtype: EmbedDtype,
+}
+
+/// Storage dtype for `embed_tokens.bin`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum EmbedDtype {
+    /// 32-bit IEEE 754 float (4 bytes per element).
+    Float32,
+    /// 16-bit IEEE 754 half-precision float (2 bytes per element).
+    Float16,
+}
+
+impl Default for EmbedDtype {
+    fn default() -> Self {
+        Self::Float32
+    }
+}
+
+impl EmbedDtype {
+    /// Bytes per element for this dtype.
+    pub fn bytes_per_element(self) -> usize {
+        match self {
+            Self::Float32 => 4,
+            Self::Float16 => 2,
+        }
+    }
+}
+
+// Fields are deserialized from config.json; not all are used at runtime.
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+pub struct EncoderConfig {
+    pub num_mel_bins: usize,
+    pub output_dim: usize,
+}
+
+// Fields are deserialized from config.json; not all are used at runtime.
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+pub struct DecoderConfig {
+    pub num_layers: usize,
+    pub hidden_size: usize,
+    pub num_attention_heads: usize,
+    pub num_key_value_heads: usize,
+    pub head_dim: usize,
+    pub vocab_size: usize,
+}
+
+/// Mel spectrogram parameters from config.json, validated against the compiled-in constants
+/// in `mel.rs` at model load time.
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+pub struct Qwen3MelParams {
+    pub sample_rate: u32,
+    pub n_fft: usize,
+    pub hop_length: usize,
+    pub n_mels: usize,
+    pub fmin: f64,
+    pub fmax: f64,
+}
+
+// Fields are deserialized from config.json; not all are used at runtime.
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+pub struct SpecialTokens {
+    pub eos_token_ids: Vec<i64>,
+    pub pad_token_id: i64,
+    pub im_start_token_id: i64,
+    pub im_end_token_id: i64,
+    pub audio_start_token_id: i64,
+    pub audio_end_token_id: i64,
+    pub audio_pad_token_id: i64,
+    /// Token that separates the language prefix from the transcription text.
+    /// If absent from generated tokens, the model failed to produce a valid transcription.
+    #[serde(default = "default_asr_text_token_id")]
+    pub asr_text_token_id: i64,
+}
+
+fn default_asr_text_token_id() -> i64 {
+    151704
+}
+
+impl Qwen3AsrConfig {
+    pub fn load(model_dir: &Path) -> Result<Self, TranscribeError> {
+        let config_path = model_dir.join("config.json");
+        let data = fs::read_to_string(&config_path)?;
+        let config: Self = serde_json::from_str(&data)?;
+        Ok(config)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_deserialize_config() {
+        let json = r#"{
+            "model_type": "qwen3_asr",
+            "encoder": {
+                "num_layers": 18, "hidden_size": 896, "num_heads": 14,
+                "ffn_dim": 3584, "conv_channels": 480, "output_dim": 1024,
+                "downsample_factor": 8, "num_mel_bins": 128
+            },
+            "decoder": {
+                "num_layers": 28, "hidden_size": 1024, "num_attention_heads": 16,
+                "num_key_value_heads": 8, "head_dim": 128, "intermediate_size": 3072,
+                "vocab_size": 151936, "rope_theta": 1000000, "rms_norm_eps": 1e-6,
+                "tie_word_embeddings": true,
+                "rope_scaling": { "mrope_section": [24, 20, 20], "interleaved": true }
+            },
+            "mel": {
+                "sample_rate": 16000, "n_fft": 400, "hop_length": 160,
+                "n_mels": 128, "fmin": 0, "fmax": 8000
+            },
+            "special_tokens": {
+                "eos_token_ids": [151643, 151645],
+                "pad_token_id": 151643,
+                "im_start_token_id": 151644,
+                "im_end_token_id": 151645,
+                "audio_start_token_id": 151669,
+                "audio_end_token_id": 151670,
+                "audio_pad_token_id": 151676,
+                "asr_text_token_id": 151704
+            },
+            "embed_tokens_shape": [151936, 1024],
+            "embed_tokens_dtype": "float32"
+        }"#;
+
+        let config: Qwen3AsrConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(config.decoder.num_layers, 28);
+        assert_eq!(config.decoder.vocab_size, 151936);
+        assert_eq!(config.mel.n_mels, 128);
+        assert_eq!(config.special_tokens.eos_token_ids, vec![151643, 151645]);
+        assert_eq!(config.embed_tokens_dtype, EmbedDtype::Float32);
+    }
+
+    #[test]
+    fn test_embed_dtype_float16() {
+        let json = r#"{
+            "encoder": { "num_layers": 18, "hidden_size": 896, "num_heads": 14, "ffn_dim": 3584, "conv_channels": 480, "output_dim": 1024, "downsample_factor": 8, "num_mel_bins": 128 },
+            "decoder": { "num_layers": 28, "hidden_size": 1024, "num_attention_heads": 16, "num_key_value_heads": 8, "head_dim": 128, "intermediate_size": 3072, "vocab_size": 151936, "rope_theta": 1000000, "rms_norm_eps": 1e-6, "tie_word_embeddings": true, "rope_scaling": { "mrope_section": [24, 20, 20], "interleaved": true } },
+            "mel": { "sample_rate": 16000, "n_fft": 400, "hop_length": 160, "n_mels": 128, "fmin": 0, "fmax": 8000 },
+            "special_tokens": { "eos_token_ids": [151643, 151645], "pad_token_id": 151643, "im_start_token_id": 151644, "im_end_token_id": 151645, "audio_start_token_id": 151669, "audio_end_token_id": 151670, "audio_pad_token_id": 151676 },
+            "embed_tokens_dtype": "float16"
+        }"#;
+        let config: Qwen3AsrConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(config.embed_tokens_dtype, EmbedDtype::Float16);
+        assert_eq!(config.embed_tokens_dtype.bytes_per_element(), 2);
+    }
+
+    #[test]
+    fn test_embed_dtype_default_when_missing() {
+        let json = r#"{
+            "encoder": { "num_layers": 18, "hidden_size": 896, "num_heads": 14, "ffn_dim": 3584, "conv_channels": 480, "output_dim": 1024, "downsample_factor": 8, "num_mel_bins": 128 },
+            "decoder": { "num_layers": 28, "hidden_size": 1024, "num_attention_heads": 16, "num_key_value_heads": 8, "head_dim": 128, "intermediate_size": 3072, "vocab_size": 151936, "rope_theta": 1000000, "rms_norm_eps": 1e-6, "tie_word_embeddings": true, "rope_scaling": { "mrope_section": [24, 20, 20], "interleaved": true } },
+            "mel": { "sample_rate": 16000, "n_fft": 400, "hop_length": 160, "n_mels": 128, "fmin": 0, "fmax": 8000 },
+            "special_tokens": { "eos_token_ids": [151643, 151645], "pad_token_id": 151643, "im_start_token_id": 151644, "im_end_token_id": 151645, "audio_start_token_id": 151669, "audio_end_token_id": 151670, "audio_pad_token_id": 151676 }
+        }"#;
+        let config: Qwen3AsrConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(config.embed_tokens_dtype, EmbedDtype::Float32);
+    }
+
+    #[test]
+    fn test_embed_dtype_unknown_rejected() {
+        let json = r#"{
+            "encoder": { "num_layers": 18, "hidden_size": 896, "num_heads": 14, "ffn_dim": 3584, "conv_channels": 480, "output_dim": 1024, "downsample_factor": 8, "num_mel_bins": 128 },
+            "decoder": { "num_layers": 28, "hidden_size": 1024, "num_attention_heads": 16, "num_key_value_heads": 8, "head_dim": 128, "intermediate_size": 3072, "vocab_size": 151936, "rope_theta": 1000000, "rms_norm_eps": 1e-6, "tie_word_embeddings": true, "rope_scaling": { "mrope_section": [24, 20, 20], "interleaved": true } },
+            "mel": { "sample_rate": 16000, "n_fft": 400, "hop_length": 160, "n_mels": 128, "fmin": 0, "fmax": 8000 },
+            "special_tokens": { "eos_token_ids": [151643, 151645], "pad_token_id": 151643, "im_start_token_id": 151644, "im_end_token_id": 151645, "audio_start_token_id": 151669, "audio_end_token_id": 151670, "audio_pad_token_id": 151676 },
+            "embed_tokens_dtype": "bfloat16"
+        }"#;
+        let result = serde_json::from_str::<Qwen3AsrConfig>(json);
+        assert!(result.is_err(), "bfloat16 should be rejected");
+    }
+}

--- a/src/onnx/qwen3/engine.rs
+++ b/src/onnx/qwen3/engine.rs
@@ -1,0 +1,271 @@
+//! `SpeechModel` implementation for Qwen3-ASR (batch mode).
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use crate::onnx::Quantization;
+use crate::{
+    ModelCapabilities, SpeechModel, TranscribeError, TranscribeOptions, TranscriptionResult,
+};
+
+use super::model::Qwen3AsrModel;
+
+const CAPABILITIES: ModelCapabilities = ModelCapabilities {
+    name: "Qwen3-ASR",
+    engine_id: "qwen3",
+    sample_rate: 16000,
+    languages: &[],
+    supports_timestamps: false,
+    supports_translation: false,
+    supports_streaming: false,
+};
+
+pub struct Qwen3Model {
+    inner: Qwen3AsrModel,
+    language_cache: HashMap<String, Vec<i64>>,
+}
+
+impl Qwen3Model {
+    pub fn load(model_dir: &Path, quantization: &Quantization) -> Result<Self, TranscribeError> {
+        let inner = Qwen3AsrModel::load(model_dir, quantization)?;
+        log::info!("Loaded Qwen3-ASR model from {:?}", model_dir);
+        Ok(Self {
+            inner,
+            language_cache: HashMap::new(),
+        })
+    }
+
+    pub fn transcribe_with(
+        &mut self,
+        samples: &[f32],
+        params: &Qwen3Params,
+    ) -> Result<TranscriptionResult, TranscribeError> {
+        let lang_key = params.language.as_deref().filter(|s| !s.is_empty());
+        if let Some(lang) = lang_key {
+            self.ensure_language_cached(lang);
+        }
+        let lang_tokens = lang_key
+            .and_then(|lang| self.language_cache.get(lang))
+            .map(|v| v.as_slice());
+
+        let raw = self
+            .inner
+            .transcribe(samples, params.max_tokens, lang_tokens)?;
+        log::debug!("Qwen3-ASR raw decoder output: {:?}", raw);
+        let text = strip_language_prefix(&raw);
+        log::debug!("Qwen3-ASR after strip_language_prefix: {:?}", text);
+        Ok(TranscriptionResult {
+            text,
+            segments: None,
+        })
+    }
+
+    fn ensure_language_cached(&mut self, language: &str) {
+        if self.language_cache.contains_key(language) {
+            return;
+        }
+        let normalized = normalize_language(language);
+        let spaced = format!(" {normalized}");
+        let tokens = self.inner.encode_language(&spaced);
+        log::info!(
+            "Qwen3-ASR: encoded language {:?} → {:?} → {:?} (cached for reuse)",
+            language,
+            normalized,
+            tokens
+        );
+        self.language_cache.insert(language.to_string(), tokens);
+    }
+}
+
+/// Per-call parameters for Qwen3-ASR transcription.
+#[derive(Debug, Clone)]
+pub struct Qwen3Params {
+    pub max_tokens: usize,
+    pub language: Option<String>,
+}
+
+impl Default for Qwen3Params {
+    fn default() -> Self {
+        Self {
+            max_tokens: 512,
+            language: None,
+        }
+    }
+}
+
+impl SpeechModel for Qwen3Model {
+    fn capabilities(&self) -> ModelCapabilities {
+        CAPABILITIES
+    }
+
+    fn transcribe_raw(
+        &mut self,
+        samples: &[f32],
+        options: &TranscribeOptions,
+    ) -> Result<TranscriptionResult, TranscribeError> {
+        if options.translate {
+            log::warn!(
+                "Qwen3-ASR: translate is not supported; the model produces transcription only"
+            );
+        }
+        let params = Qwen3Params {
+            language: options.language.clone(),
+            ..Default::default()
+        };
+        self.transcribe_with(samples, &params)
+    }
+}
+
+fn normalize_language(code: &str) -> &str {
+    match code {
+        "en" => "English",
+        "zh" | "zh-Hans" | "zh-Hant" => "Chinese",
+        "ja" => "Japanese",
+        "ko" => "Korean",
+        "yue" => "Cantonese",
+        "fr" => "French",
+        "es" => "Spanish",
+        "de" => "German",
+        "it" => "Italian",
+        "pt" => "Portuguese",
+        "ru" => "Russian",
+        "ar" => "Arabic",
+        "hi" => "Hindi",
+        "th" => "Thai",
+        "vi" => "Vietnamese",
+        "id" => "Indonesian",
+        "ms" => "Malay",
+        "tr" => "Turkish",
+        "nl" => "Dutch",
+        "pl" => "Polish",
+        "sv" => "Swedish",
+        "no" => "Norwegian",
+        "da" => "Danish",
+        "fi" => "Finnish",
+        "cs" => "Czech",
+        "ro" => "Romanian",
+        "hu" => "Hungarian",
+        "el" => "Greek",
+        "he" => "Hebrew",
+        "uk" => "Ukrainian",
+        "bg" => "Bulgarian",
+        "hr" => "Croatian",
+        "sk" => "Slovak",
+        "sl" => "Slovenian",
+        "lt" => "Lithuanian",
+        "lv" => "Latvian",
+        "et" => "Estonian",
+        "sr" => "Serbian",
+        "tl" => "Tagalog",
+        "my" => "Burmese",
+        "bo" => "Tibetan",
+        "ug" => "Uyghur",
+        "mn" => "Mongolian",
+        "am" => "Amharic",
+        "sw" => "Swahili",
+        "kk" => "Kazakh",
+        "uz" => "Uzbek",
+        "az" => "Azerbaijani",
+        "ka" => "Georgian",
+        "hy" => "Armenian",
+        "ne" => "Nepali",
+        "bn" => "Bengali",
+        "ta" => "Tamil",
+        "te" => "Telugu",
+        "ur" => "Urdu",
+        "fa" => "Persian",
+        "lo" => "Lao",
+        "km" => "Khmer",
+        "ca" => "Catalan",
+        "gl" => "Galician",
+        "eu" => "Basque",
+        "af" => "Afrikaans",
+        other => other,
+    }
+}
+
+const KNOWN_LANGUAGES: &[&str] = &[
+    "English", "Chinese", "Japanese", "Korean", "Cantonese", "French", "Spanish", "German",
+    "Italian", "Portuguese", "Russian", "Arabic", "Hindi", "Thai", "Vietnamese", "Indonesian",
+    "Malay", "Turkish", "Dutch", "Polish", "Swedish", "Norwegian", "Danish", "Finnish",
+    "Czech", "Romanian", "Hungarian", "Greek", "Hebrew", "Ukrainian", "Bulgarian",
+    "Croatian", "Slovak", "Slovenian", "Lithuanian", "Latvian", "Estonian", "Serbian",
+    "Tagalog", "Burmese", "Tibetan", "Uyghur", "Mongolian", "Amharic", "Swahili",
+    "Kazakh", "Uzbek", "Azerbaijani", "Georgian", "Armenian", "Nepali", "Bengali",
+    "Tamil", "Telugu", "Urdu", "Persian", "Lao", "Khmer", "Catalan", "Galician",
+    "Basque", "Afrikaans",
+];
+
+fn strip_language_prefix(text: &str) -> String {
+    if let Some(rest) = text.strip_prefix("language ") {
+        if let Some(newline_pos) = rest.find('\n') {
+            return rest[newline_pos + 1..].to_string();
+        }
+        for lang in KNOWN_LANGUAGES {
+            if let Some(after) = rest.strip_prefix(lang) {
+                return after.to_string();
+            }
+        }
+        log::warn!(
+            "Qwen3-ASR: unrecognised language prefix with no newline separator; raw output: {:?}",
+            rest
+        );
+        return rest.to_string();
+    }
+    text.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_strip_language_prefix_with_newline() {
+        assert_eq!(
+            strip_language_prefix("language English\nHello world"),
+            "Hello world"
+        );
+    }
+
+    #[test]
+    fn test_strip_language_prefix_without_newline() {
+        assert_eq!(
+            strip_language_prefix("language EnglishHello world"),
+            "Hello world"
+        );
+    }
+
+    #[test]
+    fn test_strip_language_prefix_chinese_with_newline() {
+        assert_eq!(
+            strip_language_prefix("language Chinese\n你好世界"),
+            "你好世界"
+        );
+    }
+
+    #[test]
+    fn test_strip_language_prefix_no_prefix() {
+        assert_eq!(strip_language_prefix("Hello world"), "Hello world");
+    }
+
+    #[test]
+    fn test_strip_language_prefix_empty() {
+        assert_eq!(strip_language_prefix(""), "");
+    }
+
+    #[test]
+    fn test_normalize_language_maps_codes() {
+        assert_eq!(normalize_language("en"), "English");
+        assert_eq!(normalize_language("zh"), "Chinese");
+        assert_eq!(normalize_language("ja"), "Japanese");
+        assert_eq!(normalize_language("ko"), "Korean");
+        assert_eq!(normalize_language("yue"), "Cantonese");
+        assert_eq!(normalize_language("af"), "Afrikaans");
+    }
+
+    #[test]
+    fn test_normalize_language_passthrough() {
+        assert_eq!(normalize_language("English"), "English");
+        assert_eq!(normalize_language("unknown"), "unknown");
+    }
+}

--- a/src/onnx/qwen3/mel.rs
+++ b/src/onnx/qwen3/mel.rs
@@ -1,0 +1,265 @@
+//! Whisper-compatible log-mel spectrogram extraction.
+//!
+//! Parameters: 128 mel bins, Hann window, n_fft=400, hop=160, Slaney mel scale.
+//! This differs from SenseVoice's FBANK (80 bins, Hamming, HTK mel, pre-emphasis)
+//! and cannot be shared.
+
+#![allow(clippy::needless_range_loop)]
+
+use ndarray::Array3;
+use rustfft::{num_complex::Complex, FftPlanner};
+use std::f64::consts::PI;
+use std::sync::LazyLock;
+
+const SAMPLE_RATE: f64 = 16000.0;
+pub(crate) const N_FFT: usize = 400;
+pub(crate) const HOP_LENGTH: usize = 160;
+pub(crate) const N_MELS: usize = 128;
+const FMIN: f64 = 0.0;
+const FMAX: f64 = 8000.0;
+
+/// Cached Hann window (400 f64 values).
+static HANN_WINDOW: LazyLock<Vec<f64>> = LazyLock::new(|| hann_window(N_FFT));
+
+/// Cached Slaney mel filterbank (128x201 f64 matrix).
+static MEL_FILTERS: LazyLock<Vec<Vec<f64>>> =
+    LazyLock::new(|| slaney_mel_filterbank(SAMPLE_RATE, N_FFT, N_MELS, FMIN, FMAX));
+
+/// Compute Whisper-compatible log-mel spectrogram.
+///
+/// Input: 1-D f32 audio samples at 16kHz.
+/// Output: `Array3<f32>` shape `[1, 128, T]`.
+pub fn log_mel_spectrogram(audio: &[f32]) -> Array3<f32> {
+    if audio.len() <= N_FFT / 2 {
+        return Array3::zeros((1, N_MELS, 0));
+    }
+
+    let mel_filters = &*MEL_FILTERS;
+    let window = &*HANN_WINDOW;
+    let num_fft_bins = N_FFT / 2 + 1;
+
+    let num_frames = audio.len() / HOP_LENGTH + 1;
+    debug_assert!(num_frames >= 1);
+
+    let mut planner = FftPlanner::new();
+    let fft = planner.plan_fft_forward(N_FFT);
+
+    let mut magnitudes = vec![vec![0.0f64; num_frames]; num_fft_bins];
+
+    for frame_idx in 0..num_frames {
+        let center = frame_idx * HOP_LENGTH;
+        let mut fft_input: Vec<Complex<f64>> = Vec::with_capacity(N_FFT);
+
+        for i in 0..N_FFT {
+            let sample_idx = center as isize + i as isize - (N_FFT / 2) as isize;
+            let sample = if sample_idx < 0 {
+                let reflect_idx = (-sample_idx) as usize;
+                debug_assert!(
+                    reflect_idx < audio.len(),
+                    "reflect_idx {reflect_idx} out of bounds"
+                );
+                audio[reflect_idx] as f64
+            } else if (sample_idx as usize) >= audio.len() {
+                let overshoot = sample_idx as usize - audio.len();
+                if audio.len() > 1 && overshoot < audio.len() {
+                    debug_assert!(
+                        overshoot < audio.len().saturating_sub(1),
+                        "right reflect: overshoot {overshoot} >= audio.len()-1 ({})",
+                        audio.len() - 1
+                    );
+                    audio[audio.len().saturating_sub(2).saturating_sub(overshoot)] as f64
+                } else {
+                    log::warn!(
+                        "mel: right-reflect padding out of range \
+                         (audio_len={}, overshoot={}); zeroing frame {} sample {}",
+                        audio.len(),
+                        overshoot,
+                        frame_idx,
+                        i
+                    );
+                    0.0
+                }
+            } else {
+                audio[sample_idx as usize] as f64
+            };
+            fft_input.push(Complex::new(sample * window[i], 0.0));
+        }
+
+        fft.process(&mut fft_input);
+
+        for k in 0..num_fft_bins {
+            magnitudes[k][frame_idx] = fft_input[k].norm_sqr();
+        }
+    }
+
+    let time_steps = num_frames - 1;
+
+    let mut mel_spec = vec![vec![0.0f64; time_steps]; N_MELS];
+    for m in 0..N_MELS {
+        for k in 0..num_fft_bins {
+            if mel_filters[m][k] != 0.0 {
+                for t in 0..time_steps {
+                    mel_spec[m][t] += mel_filters[m][k] * magnitudes[k][t];
+                }
+            }
+        }
+    }
+
+    let mut log_spec = vec![vec![0.0f32; time_steps]; N_MELS];
+    let mut global_max: f32 = f32::NEG_INFINITY;
+
+    for m in 0..N_MELS {
+        for t in 0..time_steps {
+            let val = (mel_spec[m][t].max(1e-10).log10()) as f32;
+            log_spec[m][t] = val;
+            if val > global_max {
+                global_max = val;
+            }
+        }
+    }
+
+    let floor = global_max - 8.0;
+    for m in 0..N_MELS {
+        for t in 0..time_steps {
+            log_spec[m][t] = (log_spec[m][t].max(floor) + 4.0) / 4.0;
+        }
+    }
+
+    let mut result = Array3::<f32>::zeros((1, N_MELS, time_steps));
+    for m in 0..N_MELS {
+        for t in 0..time_steps {
+            result[[0, m, t]] = log_spec[m][t];
+        }
+    }
+    result
+}
+
+fn hann_window(length: usize) -> Vec<f64> {
+    (0..length)
+        .map(|i| 0.5 * (1.0 - (2.0 * PI * i as f64 / length as f64).cos()))
+        .collect()
+}
+
+fn slaney_mel_filterbank(
+    sr: f64,
+    n_fft: usize,
+    n_mels: usize,
+    fmin: f64,
+    fmax: f64,
+) -> Vec<Vec<f64>> {
+    let num_fft_bins = n_fft / 2 + 1;
+
+    let f_sp = 200.0 / 3.0;
+    let min_log_hz = 1000.0;
+    let min_log_mel = (min_log_hz - 0.0) / f_sp;
+    let log_step = 6.4_f64.ln() / 27.0;
+
+    let hz_to_mel = |hz: f64| -> f64 {
+        if hz < min_log_hz {
+            hz / f_sp
+        } else {
+            min_log_mel + (hz / min_log_hz).ln() / log_step
+        }
+    };
+
+    let mel_to_hz = |mel: f64| -> f64 {
+        if mel < min_log_mel {
+            mel * f_sp
+        } else {
+            min_log_hz * ((mel - min_log_mel) * log_step).exp()
+        }
+    };
+
+    let mel_min = hz_to_mel(fmin);
+    let mel_max = hz_to_mel(fmax);
+
+    let n_points = n_mels + 2;
+    let mel_points: Vec<f64> = (0..n_points)
+        .map(|i| mel_min + (mel_max - mel_min) * i as f64 / (n_points - 1) as f64)
+        .collect();
+    let hz_points: Vec<f64> = mel_points.iter().map(|&m| mel_to_hz(m)).collect();
+
+    let fft_freqs: Vec<f64> = (0..num_fft_bins)
+        .map(|k| k as f64 * sr / n_fft as f64)
+        .collect();
+
+    let mut filters = vec![vec![0.0f64; num_fft_bins]; n_mels];
+
+    for m in 0..n_mels {
+        let left = hz_points[m];
+        let center = hz_points[m + 1];
+        let right = hz_points[m + 2];
+
+        let enorm = 2.0 / (right - left);
+
+        for k in 0..num_fft_bins {
+            let freq = fft_freqs[k];
+            if freq > left && freq < center {
+                filters[m][k] = enorm * (freq - left) / (center - left);
+            } else if freq >= center && freq < right {
+                filters[m][k] = enorm * (right - freq) / (right - center);
+            }
+        }
+    }
+
+    filters
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_hann_window_endpoints() {
+        let w = hann_window(400);
+        assert_eq!(w.len(), 400);
+        assert!(w[0].abs() < 1e-10);
+        assert!((w[200] - 1.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_mel_filterbank_shape() {
+        let filters = slaney_mel_filterbank(16000.0, 400, 128, 0.0, 8000.0);
+        assert_eq!(filters.len(), 128);
+        assert_eq!(filters[0].len(), 201);
+    }
+
+    #[test]
+    fn test_mel_filterbank_nonzero() {
+        let filters = slaney_mel_filterbank(16000.0, 400, 128, 0.0, 8000.0);
+        for (i, filter) in filters.iter().enumerate() {
+            let sum: f64 = filter.iter().sum();
+            assert!(sum > 0.0, "Filter {} has zero sum", i);
+        }
+    }
+
+    #[test]
+    fn test_log_mel_spectrogram_very_short() {
+        let audio = vec![0.0f32; 100];
+        let mel = log_mel_spectrogram(&audio);
+        assert_eq!(mel.shape(), &[1, 128, 0]);
+    }
+
+    #[test]
+    fn test_log_mel_spectrogram_shape() {
+        let audio = vec![0.0f32; 16000];
+        let mel = log_mel_spectrogram(&audio);
+        assert_eq!(mel.shape()[0], 1);
+        assert_eq!(mel.shape()[1], 128);
+        assert_eq!(mel.shape()[2], 100);
+    }
+
+    #[test]
+    fn test_log_mel_spectrogram_sine_wave() {
+        let n = 8000;
+        let audio: Vec<f32> = (0..n)
+            .map(|i| (2.0 * std::f32::consts::PI * 440.0 * i as f32 / 16000.0).sin())
+            .collect();
+        let mel = log_mel_spectrogram(&audio);
+        assert_eq!(mel.shape()[0], 1);
+        assert_eq!(mel.shape()[1], 128);
+        let min = mel.iter().cloned().fold(f32::INFINITY, f32::min);
+        let max = mel.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
+        assert!(max > min, "Mel spectrogram should have dynamic range");
+    }
+}

--- a/src/onnx/qwen3/mod.rs
+++ b/src/onnx/qwen3/mod.rs
@@ -1,0 +1,36 @@
+//! Qwen3-ASR speech recognition engine (batch mode).
+//!
+//! Implements [`SpeechModel`](crate::SpeechModel) for multilingual batch transcription.
+//!
+//! # Requirements
+//!
+//! The model directory must contain:
+//! - `encoder.onnx` (+ `.data`) -- audio encoder
+//! - `decoder_init.onnx` (+ `.data`) -- decoder prefill (embedding table in graph)
+//! - `decoder_step.onnx` (+ `.data`) -- decoder autoregressive step (embedding table in graph)
+//! - `config.json` -- model configuration
+//! - `tokenizer.json` -- HuggingFace BPE tokenizer
+//!
+//! # Model output format
+//!
+//! The decoder produces a language identification prefix followed by the
+//! transcription. The standard format uses a newline token (GPT-2 BPE token
+//! ID 198, which decodes to `\n`) as the delimiter:
+//!
+//! ```text
+//! language English\n<transcription text>
+//! ```
+//!
+//! The engine layer ([`engine::strip_language_prefix`]) removes this prefix
+//! before returning the final text. It tries the newline split first (handles
+//! unknown languages automatically), then falls back to matching known
+//! language names for the rare no-newline case.
+
+mod config;
+mod engine;
+mod mel;
+mod model;
+mod prompt;
+mod tokenizer;
+
+pub use engine::{Qwen3Model, Qwen3Params};

--- a/src/onnx/qwen3/model.rs
+++ b/src/onnx/qwen3/model.rs
@@ -1,0 +1,528 @@
+//! Core ONNX inference for Qwen3-ASR: encoder, decoder prefill, and autoregressive decode.
+
+use ndarray::{Array1, Array2, Array3, ArrayD, Ix3, IxDyn};
+use ort::session::Session;
+use ort::value::{DynValue, TensorRef};
+use std::path::Path;
+
+use crate::onnx::{session, Quantization};
+use crate::TranscribeError;
+
+use super::config::Qwen3AsrConfig;
+use super::mel::{self, log_mel_spectrogram};
+use super::prompt::{
+    build_prompt_ids_with_language, get_audio_pad_range, get_feat_extract_output_lengths,
+};
+use super::tokenizer::Qwen3Tokenizer;
+
+pub struct Qwen3AsrModel {
+    encoder: Session,
+    decoder_init: Session,
+    decoder_step: Session,
+    /// Embedding matrix cached for fast per-step lookup. Loaded from
+    /// `embed_tokens.bin` (FP32 cache).
+    embed_tokens: Array2<f32>,
+    config: Qwen3AsrConfig,
+    tokenizer: Qwen3Tokenizer,
+}
+
+impl Qwen3AsrModel {
+    pub fn load(model_dir: &Path, quantization: &Quantization) -> Result<Self, TranscribeError> {
+        let config = Qwen3AsrConfig::load(model_dir)?;
+        let tokenizer =
+            Qwen3Tokenizer::new(model_dir).map_err(|e| TranscribeError::Config(e.to_string()))?;
+
+        {
+            let st = &config.special_tokens;
+            let valid = st.pad_token_id >= 0
+                && st.im_start_token_id >= 0
+                && st.im_end_token_id >= 0
+                && st.audio_start_token_id >= 0
+                && st.audio_end_token_id >= 0
+                && st.audio_pad_token_id >= 0
+                && st.asr_text_token_id >= 0
+                && !st.eos_token_ids.is_empty()
+                && st.eos_token_ids.iter().all(|&id| id >= 0);
+            if !valid {
+                return Err(TranscribeError::Config(
+                    "config.json: special_tokens contains negative or missing IDs".into(),
+                ));
+            }
+        }
+
+        if config.mel.n_mels != mel::N_MELS {
+            return Err(TranscribeError::Config(format!(
+                "Qwen3-ASR: expected n_mels={}, got {}",
+                mel::N_MELS,
+                config.mel.n_mels
+            )));
+        }
+        if config.mel.n_fft != mel::N_FFT {
+            return Err(TranscribeError::Config(format!(
+                "Qwen3-ASR: expected n_fft={}, got {}",
+                mel::N_FFT,
+                config.mel.n_fft
+            )));
+        }
+        if config.mel.hop_length != mel::HOP_LENGTH {
+            return Err(TranscribeError::Config(format!(
+                "Qwen3-ASR: expected hop_length={}, got {}",
+                mel::HOP_LENGTH,
+                config.mel.hop_length
+            )));
+        }
+
+        let encoder_path = session::resolve_model_path(model_dir, "encoder", quantization);
+        if !encoder_path.exists() {
+            return Err(TranscribeError::ModelNotFound(encoder_path));
+        }
+
+        let decoder_threads: usize = 0;
+
+        log::info!("Loading Qwen3-ASR encoder from {:?}", encoder_path);
+        let encoder = session::create_session(&encoder_path)?;
+
+        let decoder_init_path =
+            session::resolve_model_path(model_dir, "decoder_init", quantization);
+        let decoder_step_path =
+            session::resolve_model_path(model_dir, "decoder_step", quantization);
+        if !decoder_init_path.exists() {
+            return Err(TranscribeError::ModelNotFound(decoder_init_path));
+        }
+        if !decoder_step_path.exists() {
+            return Err(TranscribeError::ModelNotFound(decoder_step_path));
+        }
+        log::info!(
+            "Loading Qwen3-ASR decoder from {:?} + {:?}",
+            decoder_init_path,
+            decoder_step_path
+        );
+        let decoder_init = session::create_decoder_session(&decoder_init_path, decoder_threads)?;
+        let decoder_step = session::create_decoder_session(&decoder_step_path, decoder_threads)?;
+
+        let embed_path = model_dir.join("embed_tokens.bin");
+        if !embed_path.exists() {
+            return Err(TranscribeError::ModelNotFound(embed_path));
+        }
+        log::info!("Loading embedding cache from {:?}", embed_path);
+        let embed_tokens = load_embed_cache(&embed_path, &config)?;
+        log::info!("Embedding cache: {:?}", embed_tokens.shape());
+
+        Ok(Self {
+            encoder,
+            decoder_init,
+            decoder_step,
+            embed_tokens,
+            config,
+            tokenizer,
+        })
+    }
+
+    fn encode(&mut self, mel: &Array3<f32>) -> Result<Array3<f32>, TranscribeError> {
+        let mel_dyn = mel.view().into_dyn();
+        let inputs = ort::inputs![
+            "mel" => TensorRef::from_array_view(mel_dyn.view())?,
+        ];
+        let outputs = self.encoder.run(inputs)?;
+
+        let features = outputs
+            .get("audio_features")
+            .ok_or_else(|| TranscribeError::Inference("Missing 'audio_features' output".into()))?
+            .try_extract_array::<f32>()?;
+
+        Ok(features.to_owned().into_dimensionality::<Ix3>()?)
+    }
+
+    fn greedy_decode(
+        &mut self,
+        audio_features: &Array3<f32>,
+        max_tokens: usize,
+        language_token_ids: Option<&[i64]>,
+    ) -> Result<String, TranscribeError> {
+        let max_tokens = max_tokens.min(4096);
+        let audio_token_count = audio_features.shape()[1];
+        let prompt_ids = build_prompt_ids_with_language(
+            &self.config.special_tokens,
+            audio_token_count,
+            language_token_ids,
+        );
+        let seq_len = prompt_ids.len();
+
+        let (audio_start, _) =
+            get_audio_pad_range(&prompt_ids, self.config.special_tokens.audio_pad_token_id)
+                .map_err(TranscribeError::Inference)?;
+
+        let input_ids = Array2::<i64>::from_shape_vec((1, seq_len), prompt_ids.clone())?;
+        let position_ids = Array2::<i64>::from_shape_fn((1, seq_len), |(_, j)| j as i64);
+        let audio_offset = Array1::<i64>::from_elem(1, audio_start as i64);
+        let ids_dyn = input_ids.into_dyn();
+        let pos_dyn = position_ids.into_dyn();
+        let audio_dyn = audio_features.view().into_dyn();
+        let offset_dyn = audio_offset.into_dyn();
+
+        let (mut current_token, mut keys, mut values) = {
+            let inputs = ort::inputs![
+                "input_ids"        => TensorRef::from_array_view(ids_dyn.view())?,
+                "position_ids"     => TensorRef::from_array_view(pos_dyn.view())?,
+                "audio_features"   => TensorRef::from_array_view(audio_dyn.view())?,
+                "audio_offset"     => TensorRef::from_array_view(offset_dyn.view())?,
+            ];
+            let mut init_outputs = self.decoder_init.run(inputs)?;
+
+            let logits = init_outputs
+                .get("logits")
+                .ok_or_else(|| {
+                    TranscribeError::Inference("Missing 'logits' from decoder_init".into())
+                })?
+                .try_extract_array::<f32>()?;
+            let last_pos = logits.shape()[1].checked_sub(1).ok_or_else(|| {
+                TranscribeError::Inference("decoder_init returned empty logits sequence".into())
+            })?;
+            let token = argmax_slice(&logits, last_pos)?;
+            drop(logits);
+            let keys: DynValue = init_outputs.remove("present_keys").ok_or_else(|| {
+                TranscribeError::Inference("Missing 'present_keys' from decoder_init".into())
+            })?;
+            let values: DynValue = init_outputs.remove("present_values").ok_or_else(|| {
+                TranscribeError::Inference("Missing 'present_values' from decoder_init".into())
+            })?;
+            (token, keys, values)
+        };
+
+        let mut output_tokens = vec![current_token];
+
+        if self
+            .config
+            .special_tokens
+            .eos_token_ids
+            .contains(&current_token)
+        {
+            return Ok(self.tokenizer.decode(&output_tokens));
+        }
+
+        let hidden_size = self.config.decoder.hidden_size;
+        let mut pos = seq_len as i64;
+
+        for _ in 1..max_tokens {
+            let token_embed = {
+                if current_token < 0 {
+                    return Err(TranscribeError::Inference(format!(
+                        "decoder produced negative token ID: {}",
+                        current_token
+                    )));
+                }
+                let id = current_token as usize;
+                if id >= self.embed_tokens.nrows() {
+                    return Err(TranscribeError::Inference(format!(
+                        "token ID {} exceeds embedding rows {}",
+                        id,
+                        self.embed_tokens.nrows()
+                    )));
+                }
+                let row = self.embed_tokens.row(id);
+                let mut arr = Array3::<f32>::zeros((1, 1, hidden_size));
+                arr.slice_mut(ndarray::s![0, 0, ..]).assign(&row);
+                arr.into_dyn()
+            };
+
+            let step_pos = ArrayD::<i64>::from_shape_vec(IxDyn(&[1, 1]), vec![pos])?;
+
+            let step_inputs = ort::inputs![
+                "input_embeds"  => TensorRef::from_array_view(token_embed.view())?,
+                "position_ids"  => TensorRef::from_array_view(step_pos.view())?,
+                "past_keys"     => keys,
+                "past_values"   => values,
+            ];
+            let mut step_outputs = self.decoder_step.run(step_inputs)?;
+
+            let step_logits = step_outputs
+                .get("logits")
+                .ok_or_else(|| {
+                    TranscribeError::Inference("Missing 'logits' from decoder_step".into())
+                })?
+                .try_extract_array::<f32>()?;
+
+            current_token = argmax_slice(&step_logits, 0)?;
+            output_tokens.push(current_token);
+            pos += 1;
+            drop(step_logits);
+            keys = step_outputs.remove("present_keys").ok_or_else(|| {
+                TranscribeError::Inference("Missing 'present_keys' from step".into())
+            })?;
+            values = step_outputs.remove("present_values").ok_or_else(|| {
+                TranscribeError::Inference("Missing 'present_values' from step".into())
+            })?;
+
+            if self
+                .config
+                .special_tokens
+                .eos_token_ids
+                .contains(&current_token)
+            {
+                break;
+            }
+        }
+
+        let eos_reached = self
+            .config
+            .special_tokens
+            .eos_token_ids
+            .contains(&current_token);
+        if !eos_reached {
+            log::warn!(
+                "Qwen3-ASR: max_tokens ({}) reached without EOS token",
+                max_tokens
+            );
+        }
+
+        let asr_text_id = self.config.special_tokens.asr_text_token_id;
+        if language_token_ids.is_none() && eos_reached && !output_tokens.contains(&asr_text_id) {
+            let preview: Vec<_> = output_tokens.iter().take(20).collect();
+            log::warn!(
+                "Qwen3-ASR: no <asr_text> token in output ({} tokens, first 20: {:?}); \
+                 returning empty transcription",
+                output_tokens.len(),
+                preview,
+            );
+            return Ok(String::new());
+        }
+
+        Ok(self.tokenizer.decode(&output_tokens))
+    }
+
+    pub fn transcribe(
+        &mut self,
+        samples: &[f32],
+        max_tokens: usize,
+        language_token_ids: Option<&[i64]>,
+    ) -> Result<String, TranscribeError> {
+        const MAX_SAMPLES: usize = 60 * 16_000;
+        if samples.len() > MAX_SAMPLES {
+            return Err(TranscribeError::Inference(format!(
+                "audio too long: {} samples ({:.1} s); maximum is 60 s",
+                samples.len(),
+                samples.len() as f32 / 16_000.0,
+            )));
+        }
+
+        let mel = log_mel_spectrogram(samples);
+        let mel_frames = mel.shape()[2];
+        let audio_tokens = get_feat_extract_output_lengths(mel_frames);
+        log::debug!(
+            "Mel frames: {}, encoder output tokens: {}",
+            mel_frames,
+            audio_tokens
+        );
+
+        if audio_tokens == 0 {
+            return Ok(String::new());
+        }
+
+        let audio_features = self.encode(&mel)?;
+        log::debug!("Audio features shape: {:?}", audio_features.shape());
+
+        let encoder_frames = audio_features.shape()[1];
+        if encoder_frames != audio_tokens {
+            return Err(TranscribeError::Inference(format!(
+                "Qwen3-ASR encoder produced {} frames, expected {} from mel formula \
+                 (mel_frames={}, audio_tokens={})",
+                encoder_frames, audio_tokens, mel_frames, audio_tokens
+            )));
+        }
+
+        self.greedy_decode(&audio_features, max_tokens, language_token_ids)
+    }
+
+    /// Encode a language name to token IDs using the tokenizer.
+    pub fn encode_language(&self, language: &str) -> Vec<i64> {
+        self.tokenizer.encode(language)
+    }
+}
+
+/// Load the embedding cache from a raw binary file.
+fn load_embed_cache(path: &Path, config: &Qwen3AsrConfig) -> Result<Array2<f32>, TranscribeError> {
+    use super::config::EmbedDtype;
+
+    let vocab_size = config.decoder.vocab_size;
+    let hidden_size = config.decoder.hidden_size;
+    let n_elements = vocab_size * hidden_size;
+    let bpe = config.embed_tokens_dtype.bytes_per_element();
+    let expected_bytes = n_elements * bpe;
+
+    let file_size = path.metadata()?.len() as usize;
+    if file_size != expected_bytes {
+        return Err(TranscribeError::Config(format!(
+            "embed_tokens.bin size {} != expected {} ({}x{}x{}, dtype={:?})",
+            file_size, expected_bytes, vocab_size, hidden_size, bpe, config.embed_tokens_dtype
+        )));
+    }
+
+    let data = std::fs::read(path)?;
+
+    let float_data: Vec<f32> = match config.embed_tokens_dtype {
+        EmbedDtype::Float16 => {
+            log::info!(
+                "Loading FP16 embedding cache ({} MB)",
+                file_size / (1024 * 1024)
+            );
+            data.chunks_exact(2)
+                .map(|chunk| f16_to_f32(u16::from_le_bytes([chunk[0], chunk[1]])))
+                .collect()
+        }
+        EmbedDtype::Float32 => {
+            log::info!(
+                "Loading FP32 embedding cache ({} MB)",
+                file_size / (1024 * 1024)
+            );
+            data.chunks_exact(4)
+                .map(|chunk| f32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]))
+                .collect()
+        }
+    };
+
+    Ok(Array2::from_shape_vec(
+        (vocab_size, hidden_size),
+        float_data,
+    )?)
+}
+
+#[inline]
+fn f16_to_f32(h: u16) -> f32 {
+    let sign = ((h >> 15) & 1) as u32;
+    let exp = ((h >> 10) & 0x1F) as u32;
+    let frac = (h & 0x3FF) as u32;
+
+    if exp == 0 {
+        if frac == 0 {
+            f32::from_bits(sign << 31)
+        } else {
+            let mut e = exp;
+            let mut f = frac;
+            while f & 0x400 == 0 {
+                f <<= 1;
+                e += 1;
+            }
+            f &= 0x3FF;
+            let exp32 = 127 - 15 - e + 1;
+            f32::from_bits((sign << 31) | (exp32 << 23) | (f << 13))
+        }
+    } else if exp == 31 {
+        f32::from_bits((sign << 31) | (0xFF << 23) | (frac << 13))
+    } else {
+        let exp32 = exp + 127 - 15;
+        f32::from_bits((sign << 31) | (exp32 << 23) | (frac << 13))
+    }
+}
+
+/// Argmax over a 3D logits array at `[0, pos, :]`.
+fn argmax_slice(logits: &ndarray::ArrayViewD<'_, f32>, pos: usize) -> Result<i64, TranscribeError> {
+    let shape = logits.shape();
+    if logits.ndim() != 3 || shape[0] != 1 {
+        return Err(TranscribeError::Inference(format!(
+            "argmax_slice: expected shape [1, T, vocab], got {:?}",
+            shape
+        )));
+    }
+    if pos >= shape[1] {
+        return Err(TranscribeError::Inference(format!(
+            "argmax_slice: pos {} out of range for sequence length {}",
+            pos, shape[1]
+        )));
+    }
+
+    let row = logits.slice(ndarray::s![0, pos, ..]);
+    if let Some(slice) = row.as_slice() {
+        let best_idx = slice
+            .iter()
+            .enumerate()
+            .fold((0usize, f32::NEG_INFINITY), |(bi, bv), (i, &v)| {
+                if v > bv {
+                    (i, v)
+                } else {
+                    (bi, bv)
+                }
+            })
+            .0;
+        return Ok(best_idx as i64);
+    }
+
+    let vocab_size = shape[2];
+    let mut best_idx = 0i64;
+    let mut best_val = f32::NEG_INFINITY;
+    for v in 0..vocab_size {
+        let val = logits[[0, pos, v]];
+        if val > best_val {
+            best_val = val;
+            best_idx = v as i64;
+        }
+    }
+    Ok(best_idx)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::f16_to_f32;
+
+    #[test]
+    fn f16_positive_zero() {
+        assert_eq!(f16_to_f32(0x0000), 0.0f32);
+        assert!(f16_to_f32(0x0000).is_sign_positive());
+    }
+
+    #[test]
+    fn f16_negative_zero() {
+        assert_eq!(f16_to_f32(0x8000), -0.0f32);
+        assert!(f16_to_f32(0x8000).is_sign_negative());
+    }
+
+    #[test]
+    fn f16_one() {
+        assert_eq!(f16_to_f32(0x3C00), 1.0f32);
+    }
+
+    #[test]
+    fn f16_negative_one() {
+        assert_eq!(f16_to_f32(0xBC00), -1.0f32);
+    }
+
+    #[test]
+    fn f16_positive_infinity() {
+        assert_eq!(f16_to_f32(0x7C00), f32::INFINITY);
+    }
+
+    #[test]
+    fn f16_negative_infinity() {
+        assert_eq!(f16_to_f32(0xFC00), f32::NEG_INFINITY);
+    }
+
+    #[test]
+    fn f16_nan() {
+        assert!(f16_to_f32(0x7E00).is_nan());
+    }
+
+    #[test]
+    fn f16_smallest_subnormal() {
+        let val = f16_to_f32(0x0001);
+        assert!(val > 0.0);
+        assert!((val - 5.960_464_5e-8).abs() < 1e-12);
+    }
+
+    #[test]
+    fn f16_largest_subnormal() {
+        let val = f16_to_f32(0x03FF);
+        assert!(val > 0.0);
+        assert!((val - 6.097_555e-5).abs() < 1e-9);
+    }
+
+    #[test]
+    fn f16_max_finite() {
+        assert_eq!(f16_to_f32(0x7BFF), 65504.0f32);
+    }
+
+    #[test]
+    fn f16_common_values() {
+        assert_eq!(f16_to_f32(0x4000), 2.0f32);
+        assert_eq!(f16_to_f32(0x3800), 0.5f32);
+        assert!((f16_to_f32(0x3555) - 0.3333).abs() < 0.001);
+    }
+}

--- a/src/onnx/qwen3/prompt.rs
+++ b/src/onnx/qwen3/prompt.rs
@@ -1,0 +1,181 @@
+//! Prompt template construction for Qwen3-ASR.
+//!
+//! Builds the token ID sequence for the chat-style prompt that Qwen3-ASR expects.
+//! Standard prompt (no language hint):
+//!   `<|im_start|>system\n<|im_end|>\n<|im_start|>user\n<|audio_start|><|audio_pad|>*N<|audio_end|><|im_end|>\n<|im_start|>assistant\n`
+//!
+//! With language hint (official Qwen3-ASR template):
+//!   `...<|im_start|>assistant\nlanguage {Name}<asr_text>`
+//! This forces the model to skip language detection and go straight to transcription.
+
+use super::config::SpecialTokens;
+
+const SYSTEM_TOKEN_ID: i64 = 9125;
+const USER_TOKEN_ID: i64 = 882;
+const ASSISTANT_TOKEN_ID: i64 = 77091;
+const NEWLINE_TOKEN_ID: i64 = 198;
+const LANGUAGE_TOKEN_ID: i64 = 11528;
+
+/// Compute the number of encoder output tokens from a mel frame count.
+pub fn get_feat_extract_output_lengths(input_lengths: usize) -> usize {
+    let leave = input_lengths % 100;
+    let mut t = leave.div_ceil(2);
+    t = t.div_ceil(2);
+    t = t.div_ceil(2);
+    t + (input_lengths / 100) * 13
+}
+
+/// Build the complete prompt token ID sequence for ASR transcription.
+#[cfg(test)]
+pub(crate) fn build_prompt_ids(
+    special_tokens: &SpecialTokens,
+    audio_token_count: usize,
+) -> Vec<i64> {
+    build_prompt_ids_with_language(special_tokens, audio_token_count, None)
+}
+
+/// Build a prompt with optional language hint using the official Qwen3-ASR template.
+///
+/// When `language_token_ids` is provided, the assistant prefix is extended with
+/// `language {Name}<asr_text>`, forcing the model to skip language detection and
+/// begin transcription immediately.
+///
+/// `language_token_ids` should be the tokenized form of ` {Name}` (with leading
+/// space) — e.g. `encode(" English")` → `[6364]`. The "language" prefix token
+/// is added automatically.
+///
+/// When `language_token_ids` is `None`, builds the standard prompt with no
+/// language hint (model auto-detects language).
+pub fn build_prompt_ids_with_language(
+    special_tokens: &SpecialTokens,
+    audio_token_count: usize,
+    language_token_ids: Option<&[i64]>,
+) -> Vec<i64> {
+    let mut ids = Vec::with_capacity(audio_token_count + 20);
+
+    // System turn (empty content)
+    ids.push(special_tokens.im_start_token_id);
+    ids.push(SYSTEM_TOKEN_ID);
+    ids.push(NEWLINE_TOKEN_ID);
+    ids.push(special_tokens.im_end_token_id);
+    ids.push(NEWLINE_TOKEN_ID);
+
+    // User turn with audio
+    ids.push(special_tokens.im_start_token_id);
+    ids.push(USER_TOKEN_ID);
+    ids.push(NEWLINE_TOKEN_ID);
+    ids.push(special_tokens.audio_start_token_id);
+
+    // Audio pad tokens — replaced by encoder output embeddings at runtime
+    ids.extend(std::iter::repeat_n(
+        special_tokens.audio_pad_token_id,
+        audio_token_count,
+    ));
+
+    ids.push(special_tokens.audio_end_token_id);
+    ids.push(special_tokens.im_end_token_id);
+    ids.push(NEWLINE_TOKEN_ID);
+
+    // Assistant turn prefix
+    ids.push(special_tokens.im_start_token_id);
+    ids.push(ASSISTANT_TOKEN_ID);
+    ids.push(NEWLINE_TOKEN_ID);
+
+    // Language hint: force "language {Name}<asr_text>" as assistant prefix
+    if let Some(lang_ids) = language_token_ids {
+        ids.push(LANGUAGE_TOKEN_ID);
+        ids.extend_from_slice(lang_ids);
+        ids.push(special_tokens.asr_text_token_id);
+    }
+
+    ids
+}
+
+/// Find the `[start, end)` range of `audio_pad` token positions in the prompt.
+pub fn get_audio_pad_range(
+    prompt_ids: &[i64],
+    audio_pad_token_id: i64,
+) -> Result<(usize, usize), String> {
+    let start = prompt_ids
+        .iter()
+        .position(|&id| id == audio_pad_token_id)
+        .ok_or_else(|| "No audio_pad tokens in prompt".to_string())?;
+    let end = prompt_ids
+        .iter()
+        .rposition(|&id| id == audio_pad_token_id)
+        .ok_or_else(|| "No audio_pad tokens in prompt".to_string())?
+        + 1;
+    Ok((start, end))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_special_tokens() -> SpecialTokens {
+        SpecialTokens {
+            eos_token_ids: vec![151643, 151645],
+            pad_token_id: 151643,
+            im_start_token_id: 151644,
+            im_end_token_id: 151645,
+            audio_start_token_id: 151669,
+            audio_end_token_id: 151670,
+            audio_pad_token_id: 151676,
+            asr_text_token_id: 151704,
+        }
+    }
+
+    #[test]
+    fn test_encoder_output_lengths() {
+        assert_eq!(get_feat_extract_output_lengths(0), 0);
+        assert_eq!(get_feat_extract_output_lengths(1), 1);
+        assert_eq!(get_feat_extract_output_lengths(99), 13);
+        assert_eq!(get_feat_extract_output_lengths(100), 13);
+        assert_eq!(get_feat_extract_output_lengths(200), 26);
+        assert_eq!(get_feat_extract_output_lengths(997), 130);
+    }
+
+    #[test]
+    fn test_build_prompt_ids_structure() {
+        let st = test_special_tokens();
+        let ids = build_prompt_ids(&st, 10);
+
+        assert_eq!(ids[0], st.im_start_token_id);
+        assert_eq!(ids[1], SYSTEM_TOKEN_ID);
+        assert_eq!(ids[2], NEWLINE_TOKEN_ID);
+        assert_eq!(ids[3], st.im_end_token_id);
+        assert_eq!(ids[4], NEWLINE_TOKEN_ID);
+        // ... abbreviated assertions
+        assert_eq!(ids.len(), 25);
+    }
+
+    #[test]
+    fn test_audio_pad_range() {
+        let st = test_special_tokens();
+        let ids = build_prompt_ids(&st, 10);
+        let (start, end) = get_audio_pad_range(&ids, st.audio_pad_token_id).unwrap();
+        assert_eq!(start, 9);
+        assert_eq!(end, 19);
+        assert_eq!(end - start, 10);
+    }
+
+    #[test]
+    fn test_build_prompt_ids_with_language() {
+        let st = test_special_tokens();
+        let lang_ids: &[i64] = &[6364]; // " English" (with leading space)
+        let ids = build_prompt_ids_with_language(&st, 5, Some(lang_ids));
+
+        assert_eq!(ids[20], LANGUAGE_TOKEN_ID);
+        assert_eq!(ids[21], 6364);
+        assert_eq!(ids[22], st.asr_text_token_id);
+        assert_eq!(ids.len(), 23);
+    }
+
+    #[test]
+    fn test_language_none_matches_standard_prompt() {
+        let st = test_special_tokens();
+        let standard = build_prompt_ids(&st, 10);
+        let with_none = build_prompt_ids_with_language(&st, 10, None);
+        assert_eq!(standard, with_none);
+    }
+}

--- a/src/onnx/qwen3/tokenizer.rs
+++ b/src/onnx/qwen3/tokenizer.rs
@@ -1,0 +1,222 @@
+//! BPE tokenizer for Qwen3-ASR (encode + decode).
+//!
+//! Parses `tokenizer.json` (HuggingFace format) and provides both encoding
+//! (text → token IDs) and decoding (token IDs → text) using the GPT-2
+//! byte-level BPE mapping. No dependency on the `tokenizers` crate (follows
+//! Moonshine's pattern for Windows build compatibility).
+//!
+//! Encoding uses greedy longest-match on the byte-level vocabulary. This does
+//! not apply BPE merge rules, so results may differ from the reference tokenizer
+//! on rare subword boundaries. For the short, common English text used in
+//! language-conditioned prompts (e.g. "English", "Chinese"), this produces
+//! identical output to the reference.
+
+use std::collections::{HashMap, HashSet};
+use std::fs;
+use std::path::Path;
+
+use crate::TranscribeError;
+
+/// BPE tokenizer that maps between token IDs and text.
+pub struct Qwen3Tokenizer {
+    /// Maps token ID to raw byte sequence (after GPT-2 unicode-to-byte decode).
+    id_to_bytes: HashMap<u32, Vec<u8>>,
+    /// Maps raw byte sequence to token ID (reverse of `id_to_bytes`).
+    bytes_to_id: HashMap<Vec<u8>, u32>,
+    /// Maximum token length in bytes (for bounding the greedy search).
+    max_token_len: usize,
+    /// Set of special token IDs to skip during decode.
+    special_token_ids: HashSet<u32>,
+}
+
+impl Qwen3Tokenizer {
+    pub fn new(model_dir: &Path) -> Result<Self, TranscribeError> {
+        let tokenizer_path = model_dir.join("tokenizer.json");
+        let file = fs::File::open(&tokenizer_path)?;
+        let reader = std::io::BufReader::new(file);
+        let json: serde_json::Value = serde_json::from_reader(reader)?;
+
+        let byte_decoder = build_gpt2_byte_decoder();
+
+        let mut id_to_bytes = HashMap::new();
+        if let Some(model) = json.get("model") {
+            if let Some(vocab) = model.get("vocab").and_then(|v| v.as_object()) {
+                for (token_str, id_val) in vocab {
+                    if let Some(id) = id_val.as_u64() {
+                        let bytes = decode_token_string(token_str, &byte_decoder);
+                        id_to_bytes.insert(id as u32, bytes);
+                    }
+                }
+            }
+        }
+
+        if id_to_bytes.is_empty() {
+            return Err(TranscribeError::Config(
+                "No vocabulary found in tokenizer.json".into(),
+            ));
+        }
+
+        log::info!(
+            "Loaded {} tokens from Qwen3-ASR vocabulary",
+            id_to_bytes.len()
+        );
+
+        let mut special_token_ids = HashSet::new();
+        if let Some(added_tokens) = json.get("added_tokens").and_then(|v| v.as_array()) {
+            for token in added_tokens {
+                let is_special = token
+                    .get("special")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false);
+                if is_special {
+                    if let Some(id) = token.get("id").and_then(|v| v.as_u64()) {
+                        special_token_ids.insert(id as u32);
+                    }
+                }
+            }
+        }
+
+        let mut bytes_to_id: HashMap<Vec<u8>, u32> = HashMap::new();
+        let mut max_token_len = 0usize;
+        for (&id, bytes) in &id_to_bytes {
+            max_token_len = max_token_len.max(bytes.len());
+            bytes_to_id
+                .entry(bytes.clone())
+                .and_modify(|existing| {
+                    if id < *existing {
+                        *existing = id;
+                    }
+                })
+                .or_insert(id);
+        }
+
+        Ok(Self {
+            id_to_bytes,
+            bytes_to_id,
+            max_token_len,
+            special_token_ids,
+        })
+    }
+
+    /// Encode a text string to token IDs using greedy longest-match.
+    pub(crate) fn encode(&self, text: &str) -> Vec<i64> {
+        let bytes = text.as_bytes();
+        let mut ids = Vec::new();
+        let mut pos = 0;
+
+        while pos < bytes.len() {
+            let max_len = self.max_token_len.min(bytes.len() - pos);
+            let mut matched = false;
+            for len in (1..=max_len).rev() {
+                let candidate = &bytes[pos..pos + len];
+                if let Some(&id) = self.bytes_to_id.get(candidate) {
+                    ids.push(id as i64);
+                    pos += len;
+                    matched = true;
+                    break;
+                }
+            }
+            if !matched {
+                log::warn!(
+                    "Qwen3 tokenizer encode: no match for byte 0x{:02x} at position {}",
+                    bytes[pos],
+                    pos
+                );
+                pos += 1;
+            }
+        }
+
+        ids
+    }
+
+    /// Decode a sequence of token IDs to a string, skipping special tokens.
+    pub fn decode(&self, token_ids: &[i64]) -> String {
+        let mut bytes = Vec::new();
+        for &id in token_ids {
+            if id < 0 {
+                log::warn!("Qwen3 tokenizer: skipping negative token ID {}", id);
+                continue;
+            }
+            let id_u32 = id as u32;
+            if self.special_token_ids.contains(&id_u32) {
+                continue;
+            }
+            if let Some(token_bytes) = self.id_to_bytes.get(&id_u32) {
+                bytes.extend_from_slice(token_bytes);
+            }
+        }
+        String::from_utf8_lossy(&bytes).into_owned()
+    }
+}
+
+/// Build the GPT-2 unicode-to-byte decoder table.
+fn build_gpt2_byte_decoder() -> HashMap<char, u8> {
+    let mut byte_encoder: HashMap<u8, char> = HashMap::new();
+
+    // Printable ASCII ranges that map to themselves
+    for b in b'!'..=b'~' {
+        byte_encoder.insert(b, b as char);
+    }
+    // Latin-1 supplement range
+    for b in 0xa1u8..=0xacu8 {
+        byte_encoder.insert(b, b as char);
+    }
+    for b in 0xaeu8..=0xffu8 {
+        byte_encoder.insert(b, b as char);
+    }
+
+    let mut n = 256u32;
+    for b in 0u8..=255u8 {
+        if let std::collections::hash_map::Entry::Vacant(e) = byte_encoder.entry(b) {
+            e.insert(char::from_u32(n).expect("BPE byte range always valid Unicode"));
+            n += 1;
+        }
+    }
+
+    byte_encoder.into_iter().map(|(b, c)| (c, b)).collect()
+}
+
+/// Decode a GPT-2 BPE token string to raw bytes.
+fn decode_token_string(token_str: &str, byte_decoder: &HashMap<char, u8>) -> Vec<u8> {
+    token_str
+        .chars()
+        .filter_map(|c| byte_decoder.get(&c).copied())
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_gpt2_byte_decoder_coverage() {
+        let decoder = build_gpt2_byte_decoder();
+        assert_eq!(decoder.len(), 256);
+    }
+
+    #[test]
+    fn test_gpt2_ascii_passthrough() {
+        let decoder = build_gpt2_byte_decoder();
+        assert_eq!(decoder[&'A'], b'A');
+        assert_eq!(decoder[&'z'], b'z');
+        assert_eq!(decoder[&'0'], b'0');
+        let space_exists = decoder.values().any(|&b| b == 0x20);
+        assert!(
+            space_exists,
+            "Space byte should be represented in the decoder"
+        );
+    }
+
+    #[test]
+    fn test_gpt2_space_mapping() {
+        let decoder = build_gpt2_byte_decoder();
+        assert_eq!(decoder[&'\u{0120}'], 0x20);
+    }
+
+    #[test]
+    fn test_decode_token_string_simple() {
+        let decoder = build_gpt2_byte_decoder();
+        let bytes = decode_token_string("Hello", &decoder);
+        assert_eq!(bytes, b"Hello");
+    }
+}

--- a/src/onnx/session.rs
+++ b/src/onnx/session.rs
@@ -242,6 +242,64 @@ pub fn resolve_model_path(
     dir.join(format!("{}.onnx", name))
 }
 
+/// Session for autoregressive decoders: sequential execution, configurable
+/// intra-op threads.
+///
+/// By default forces CPU-only with arena allocator — sequential execution makes
+/// GPU kernel launch overhead net-negative for per-token latency at batch size 1.
+///
+/// Call [`crate::set_decoder_gpu(true)`] to use the global accelerator preference
+/// for decoder sessions (for GPU benchmarking).
+///
+/// Thread count resolution:
+/// 1. `num_threads` if > 0
+/// 2. Global `set_ort_intra_threads` if > 0
+/// 3. ORT default (all cores)
+pub fn create_decoder_session(path: &Path, num_threads: usize) -> Result<Session, ort::Error> {
+    let use_gpu = crate::accel::get_decoder_gpu();
+
+    let mut builder = Session::builder()?
+        .with_optimization_level(GraphOptimizationLevel::Level3)?
+        .with_parallel_execution(false)?;
+    if num_threads > 0 {
+        builder = builder.with_intra_threads(num_threads)?;
+    }
+
+    let session = if use_gpu {
+        log::info!("Decoder session using global accelerator (TRANSCRIBE_DECODER_GPU=1)");
+        builder
+            .with_execution_providers(execution_providers())?
+            .commit_from_file(path)?
+    } else {
+        if get_ort_accelerator() != OrtAccelerator::CpuOnly {
+            log::info!(
+                "Decoder session uses CPU-only (sequential execution); \
+                 set TRANSCRIBE_DECODER_GPU=1 to override"
+            );
+        }
+        builder
+            .with_execution_providers([CPU::default().with_arena_allocator(true).build()])?
+            .commit_from_file(path)?
+    };
+
+    for input in session.inputs() {
+        log::info!(
+            "Model input: name={}, type={:?}",
+            input.name(),
+            input.dtype()
+        );
+    }
+    for output in session.outputs() {
+        log::info!(
+            "Model output: name={}, type={:?}",
+            output.name(),
+            output.dtype()
+        );
+    }
+
+    Ok(session)
+}
+
 /// Read a custom metadata string from an ONNX session.
 pub fn read_metadata_str(session: &Session, key: &str) -> Result<Option<String>, ort::Error> {
     let meta = session.metadata()?;

--- a/tests/qwen3.rs
+++ b/tests/qwen3.rs
@@ -1,0 +1,23 @@
+//! Qwen3-ASR unit tests — these run without model files present.
+//!
+//! Inference tests are gated behind `#[cfg(feature = "full-tests")]`
+//! because they require a multi-GB model download.
+
+use transcribe_rs::onnx::qwen3::Qwen3Params;
+
+#[test]
+fn test_qwen3_params_default() {
+    let params = Qwen3Params::default();
+    assert_eq!(params.max_tokens, 512);
+    assert!(params.language.is_none());
+}
+
+#[test]
+fn test_qwen3_params_with_language() {
+    let params = Qwen3Params {
+        language: Some("zh".into()),
+        ..Default::default()
+    };
+    assert_eq!(params.language.as_deref(), Some("zh"));
+    assert_eq!(params.max_tokens, 512);
+}


### PR DESCRIPTION
Add Qwen3-ASR speech recognition engine supporting batch transcription via ONNX Runtime. Architecture: audio encoder + Qwen3 decoder with KV cache and MRoPE (Multimodal Rotary Position Embeddings).

Key changes:
- New onnx::qwen3 module with tokenizer, prompt, mel, and model
- create_decoder_session for autoregressive decoders with CPU fallback
- decoder_gpu toggle for GPU benchmarking
- Integrates with ONNX models from andrewleech/qwen3-asr-onnx

Partially based on andrewleech/transcribe-rs feat/qwen3-batch branch.