### PR TITLE
Allow swapping ort backend (download vs load-dynamic)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -210,7 +210,7 @@ checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
 dependencies = [
  "glob",
  "libc",
- "libloading",
+ "libloading 0.8.8",
 ]
 
 [[package]]
@@ -904,6 +904,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libloading"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "754ca22de805bb5744484a5b151a9e1a8e837d5dc232c2d7d8c2e3492edc8b60"
+dependencies = [
+ "cfg-if",
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1125,6 +1135,7 @@ version = "2.0.0-rc.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7de3af33d24a745ffb8fab904b13478438d1cd52868e6f17735ef6e1f8bf133"
 dependencies = [
+ "libloading 0.9.0",
  "ndarray",
  "ort-sys",
  "smallvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ default = []
 audio-features = ["dep:ndarray", "dep:rustfft"]
 
 # ONNX-based models (SenseVoice, GigaAM, Parakeet, Moonshine, Canary)
-onnx = ["audio-features", "dep:ort", "dep:base64", "dep:regex", "dep:once_cell"]
+onnx = ["audio-features", "dep:ort", "ort-download-binaries", "dep:base64", "dep:regex", "dep:once_cell"]
 
 # Whisper via whisper.cpp (CPU-only by default; add whisper-metal, whisper-vulkan, or whisper-cuda for GPU)
 whisper-cpp = ["dep:whisper-rs", "whisper-rs/raw-api"]
@@ -31,7 +31,7 @@ whisperfile = ["dep:ureq"]
 openai = ["dep:async-openai", "dep:tokio", "dep:async-trait"]
 
 # Silero neural VAD (requires silero_vad_v4.onnx model file)
-vad-silero = ["dep:ort", "dep:ndarray"]
+vad-silero = ["dep:ort", "ort-download-binaries", "dep:ndarray"]
 
 # --- ORT Accelerators ---
 # Note: ort-cuda pulls in the CUDA execution provider, which adds ~800 MB+
@@ -45,6 +45,10 @@ ort-webgpu   = ["onnx", "ort/webgpu"]
 ort-xnnpack  = ["onnx", "ort/xnnpack"]
 ort-tracing  = ["onnx", "ort/tracing"]
 ort-accel    = ["ort-cuda", "ort-tensorrt", "ort-directml", "ort-rocm", "ort-coreml", "ort-webgpu", "ort-xnnpack"]
+
+# Backend acquisition
+ort-download-binaries = ["ort/download-binaries", "ort/tls-native", "ort/copy-dylibs"]
+ort-load-dynamic = ["ort/load-dynamic"]
 
 # Convenience
 all = ["onnx", "whisper-cpp", "whisperfile", "openai"]
@@ -60,7 +64,7 @@ env_logger = "0.10.0"
 derive_builder = { version = "0.20.2" }
 
 # ONNX runtime
-ort = { version = "=2.0.0-rc.12", optional = true }
+ort = { version = "=2.0.0-rc.12", optional = true, default-features = false, features = ["std", "ndarray", "tracing", "api-24"] }
 ndarray = { version = "0.17", optional = true }
 regex = { version = "1.11.2", optional = true }
 once_cell = { version = "1.21.3", optional = true }

--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ set_whisper_accelerator(WhisperAccelerator::CpuOnly); // force CPU
 
 Query which ORT accelerators are compiled in with `OrtAccelerator::available()`.
 
+**Note:** by default `onnx` and `vad-silero` download a prebuilt ONNX Runtime from pyke. To supply your own libonnxruntime.so (e.g. for CPUs without AVX), see `ONNX Runtime backend` under Models below.
+
 ## Usage by Engine
 
 ### Canary
@@ -403,6 +405,10 @@ models/giga-am-v3/
 | TinyVi | Vietnamese |
 | Base | English |
 | BaseEs | Spanish |
+
+### ONNX Runtime backend
+
+`onnx` and `vad-silero` use pyke's prebuilt ONNX Runtime by default. To supply your own `libonnxruntime.so` (e.g. for CPUs without AVX or externally-managed ONNX Runtime), enable `ort-load-dynamic` instead and set `ORT_DYLIB_PATH=/path/to/libonnxruntime.so` at runtime.
 
 ## Examples and Tests
 


### PR DESCRIPTION
Closes issue https://github.com/cjpais/transcribe-rs/issues/81

This change lets downstream consumers choose how `ort` is obtained, without forking transcribe-rs.

What:
- `ort` dep is now declared with `default-features = false`.
- Two new opt-in feature flags:
  - `ort-download-binaries` (default for `onnx` and `vad-silero`, preserves prior behavior of pulling pyke's prebuilt binaries)
  - `ort-load-dynamic` (consumer supplies libonnxruntime.so at runtime)

Why:
- Some targets (e.g. older CPUs without AVX/AVX2, embedded x86 boards, systems with a system-managed onnxruntime) need a custom libonnxruntime.so. Currently, since `transcribe-rs` activates `ort` without `default-features = false`, Cargo feature unification forces `ort/download-binaries` on for every consumer regardless of what they declare. There is no clean way to switch to `load-dynamic` without patching `transcribe-rs` itself.
- `parakeet-rs` already follows this pattern; this aligns `transcribe-rs` with that precedent.

Backward compatibility:
- `features = ["onnx"]` and `features = ["vad-silero"]` work exactly as before — both now explicitly pull `ort-download-binaries`, which is logically what `dep:ort` activation used to do implicitly via ort's default features.
- All `ort-cuda` / `ort-tensorrt` / `ort-directml` / etc. accelerator features are unaffected.
- `features = ["onnx", "ort-load-dynamic"]` is a valid new combo — `load-dynamic` activates `ort-sys/disable-linking`, which short-circuits the build script before `download-binaries` is consulted. No conflict.

Verified locally: 
`cargo check --features onnx`,
`cargo check --features vad-silero`
`cargo check --features "onnx ort-load-dynamic"` 
all compile cleanly.