### PR TITLE
feat: enhance qwen3 example with quantization, language hint, and chunking

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,176 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+  VULKAN_VERSION: 1.4.341.1
+
+jobs:
+  test:
+    name: Test on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          # Invalidate cache when Vulkan version
+          prefix-key: "v1-vulkan-${{ env.VULKAN_VERSION }}-${{ runner.os }}"
+
+      - name: Setup Vulkan SDK (Linux)
+        if: runner.os == 'Linux'
+        uses: jakoch/install-vulkan-sdk-action@v1
+        with:
+          vulkan_version: ${{ env.VULKAN_VERSION }}
+          install_runtime: true
+
+      - name: Setup Vulkan SDK (Windows)
+        if: runner.os == 'Windows'
+        uses: jakoch/install-vulkan-sdk-action@v1
+        with:
+          vulkan_version: ${{ env.VULKAN_VERSION }}
+          install_runtime: true
+          install_swiftshader: true
+
+      - name: Configure Environment
+        shell: bash
+        run: |
+          if [ "$RUNNER_OS" == "macOS" ]; then
+            echo "WHISPER_USE_GPU=1" >> $GITHUB_ENV
+          elif [ "$RUNNER_OS" == "Linux" ]; then
+            sudo apt-get update
+            sudo apt-get install -y mesa-vulkan-drivers libgomp1 libvulkan-dev
+            LVP_ICD=$(find /usr/share/vulkan/icd.d/ -name "lvp_icd*.json" | head -n 1)
+            echo "VK_ICD_FILENAMES=$LVP_ICD" >> $GITHUB_ENV
+            echo "WHISPER_USE_GPU=0" >> $GITHUB_ENV
+          elif [ "$RUNNER_OS" == "Windows" ]; then
+            echo "VK_ICD_FILENAMES=C:\swiftshader\vk_swiftshader_icd.json" >> $GITHUB_ENV
+            echo "WHISPER_USE_GPU=0" >> $GITHUB_ENV
+          fi
+
+      - name: Run Tests (Default Features)
+        run: cargo test
+
+      - name: Cache Moonshine Model
+        id: cache-moonshine
+        uses: actions/cache@v5
+        with:
+          path: models/moonshine-base/
+          key: ${{ runner.os }}-moonshine-base-v1
+
+      - name: Download Moonshine
+        if: steps.cache-moonshine.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          mkdir -p models/moonshine-base
+          cd models/moonshine-base
+          curl -sLO https://huggingface.co/onnx-community/moonshine-base-ONNX/resolve/main/onnx/encoder_model.onnx
+          curl -sLO https://huggingface.co/onnx-community/moonshine-base-ONNX/resolve/main/onnx/decoder_model_merged.onnx
+          curl -sLO https://huggingface.co/onnx-community/moonshine-base-ONNX/resolve/main/tokenizer.json
+
+      - name: Run Tests (Moonshine)
+        run: cargo test --features onnx
+
+      - name: Cache Parakeet Model
+        id: cache-parakeet
+        uses: actions/cache@v5
+        with:
+          path: models/parakeet-tdt-0.6b-v3-int8/
+          key: ${{ runner.os }}-parakeet-v1
+
+      - name: Download Parakeet
+        if: steps.cache-parakeet.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          mkdir -p models
+          curl -sL https://blob.handy.computer/parakeet-v3-int8.tar.gz | tar -xz -C models/
+
+      - name: Run Tests (Parakeet)
+        run: cargo test --features onnx
+
+      - name: Cache SenseVoice Model
+        id: cache-sensevoice
+        uses: actions/cache@v5
+        with:
+          path: models/sense-voice-int8/
+          key: ${{ runner.os }}-sensevoice-v1
+
+      - name: Download SenseVoice
+        if: steps.cache-sensevoice.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          mkdir -p models
+          curl -sL https://blob.handy.computer/sense-voice-int8.tar.gz | tar -xz -C models/
+
+      - name: Run Tests (SenseVoice)
+        run: cargo test --features onnx
+
+      - name: Cache Whisper Model
+        id: cache-whisper
+        uses: actions/cache@v5
+        with:
+          path: models/whisper-tiny.bin
+          key: ${{ runner.os }}-whisper-tiny-v1
+
+      - name: Download Whisper
+        if: steps.cache-whisper.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          mkdir -p models
+          curl -sLo models/whisper-tiny.bin https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-tiny.bin
+
+      - name: Run Tests (Whisper)
+        run: cargo test --features whisper-cpp
+
+      - name: Cache Whisperfile Resources
+        id: cache-whisperfile
+        uses: actions/cache@v5
+        with:
+          path: |
+            models/ggml-small.bin
+            models/whisperfile-*
+          key: ${{ runner.os }}-whisperfile-v1
+
+      - name: Download Whisperfile
+        if: steps.cache-whisperfile.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          mkdir -p models
+          curl -sLo models/ggml-small.bin https://blob.handy.computer/ggml-small.bin
+
+          if [ "$RUNNER_OS" == "Windows" ]; then
+            curl -sLo models/whisperfile-0.9.3.exe https://github.com/mozilla-ai/llamafile/releases/download/0.9.3/whisperfile-0.9.3
+          else
+            curl -sLo models/whisperfile-0.9.3 https://github.com/mozilla-ai/llamafile/releases/download/0.9.3/whisperfile-0.9.3
+          fi
+
+      - name: Run Tests (Whisperfile)
+        shell: bash
+        run: |
+          if [ "$RUNNER_OS" == "Windows" ]; then
+            export WHISPERFILE_BIN="models/whisperfile-0.9.3.exe"
+          else
+            chmod +x models/whisperfile-0.9.3 || true
+            export WHISPERFILE_BIN="models/whisperfile-0.9.3"
+          fi
+          export WHISPERFILE_MODEL="models/ggml-small.bin"
+
+          if [ -f "$WHISPERFILE_BIN" ]; then
+            cargo test --features whisperfile
+          else
+            echo "Skipping whisperfile tests due to missing binary at $WHISPERFILE_BIN"
+          fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -119,6 +119,23 @@ jobs:
       - name: Run Tests (SenseVoice)
         run: cargo test --features onnx
 
+      - name: Cache Silero VAD Model
+        id: cache-silero-vad
+        uses: actions/cache@v5
+        with:
+          path: models/silero_vad_v4.onnx
+          key: ${{ runner.os }}-silero-vad-v4
+
+      - name: Download Silero VAD
+        if: steps.cache-silero-vad.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          mkdir -p models
+          curl -sLo models/silero_vad_v4.onnx https://blob.handy.computer/silero_vad_v4.onnx
+
+      - name: Run Tests (VAD + Transcriber)
+        run: cargo test --features "onnx,vad-silero"
+
       - name: Cache Whisper Model
         id: cache-whisper
         uses: actions/cache@v5

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /target
 models/
 *.DS_Store
+
+notes/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2020,7 +2020,7 @@ dependencies = [
 
 [[package]]
 name = "transcribe-rs"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "async-openai",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2019,7 +2019,7 @@ dependencies = [
 
 [[package]]
 name = "transcribe-rs"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "async-openai",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2020,7 +2020,7 @@ dependencies = [
 
 [[package]]
 name = "transcribe-rs"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "async-openai",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2020,7 +2020,7 @@ dependencies = [
 
 [[package]]
 name = "transcribe-rs"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "async-openai",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1138,6 +1138,7 @@ version = "2.0.0-rc.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7b497d21a8b6fbb4b5a544f8fadb77e801a09ae0add9e411d31c6f89e3c1e90"
 dependencies = [
+ "glob",
  "hmac-sha256",
  "lzma-rust2",
  "ureq",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2020,7 +2020,7 @@ dependencies = [
 
 [[package]]
 name = "transcribe-rs"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "async-openai",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2019,7 +2019,7 @@ dependencies = [
 
 [[package]]
 name = "transcribe-rs"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "async-openai",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2020,7 +2020,7 @@ dependencies = [
 
 [[package]]
 name = "transcribe-rs"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "async-openai",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2020,7 +2020,7 @@ dependencies = [
 
 [[package]]
 name = "transcribe-rs"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "async-openai",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2020,7 +2020,7 @@ dependencies = [
 
 [[package]]
 name = "transcribe-rs"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "async-openai",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "transcribe-rs"
-version = "0.3.5"
+version = "0.3.6"
 build = "build.rs"
 edition = "2021"
 description = "A simple library to help you transcribe audio"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "transcribe-rs"
-version = "0.3.7"
+version = "0.3.8"
 build = "build.rs"
 edition = "2021"
 description = "A simple library to help you transcribe audio"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "transcribe-rs"
 version = "0.3.2"
+build = "build.rs"
 edition = "2021"
 description = "A simple library to help you transcribe audio"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ audio-features = ["dep:ndarray", "dep:rustfft"]
 onnx = ["audio-features", "dep:ort", "dep:base64", "dep:regex", "dep:once_cell"]
 
 # Whisper via whisper.cpp (CPU-only by default; add whisper-metal, whisper-vulkan, or whisper-cuda for GPU)
-whisper-cpp = ["dep:whisper-rs"]
+whisper-cpp = ["dep:whisper-rs", "whisper-rs/raw-api"]
 
 # --- Whisper Accelerators ---
 whisper-metal  = ["whisper-cpp", "whisper-rs/metal"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "transcribe-rs"
-version = "0.3.9"
+version = "0.3.10"
 build = "build.rs"
 edition = "2021"
 description = "A simple library to help you transcribe audio"
@@ -37,12 +37,13 @@ vad-silero = ["dep:ort", "dep:ndarray"]
 # Note: ort-cuda pulls in the CUDA execution provider, which adds ~800 MB+
 # to the ORT binary and requires a CUDA toolkit / cuDNN installation at runtime.
 ort-cuda     = ["onnx", "ort/cuda"]
+ort-tensorrt = ["ort-cuda", "ort/tensorrt"]
 ort-directml = ["onnx", "ort/directml"]
 ort-rocm     = ["onnx", "ort/rocm"]
 ort-coreml   = ["onnx", "ort/coreml"]
 ort-webgpu   = ["onnx", "ort/webgpu"]
 ort-tracing  = ["onnx", "ort/tracing"]
-ort-accel    = ["ort-cuda", "ort-directml", "ort-rocm", "ort-coreml", "ort-webgpu"]
+ort-accel    = ["ort-cuda", "ort-tensorrt", "ort-directml", "ort-rocm", "ort-coreml", "ort-webgpu"]
 
 # Convenience
 all = ["onnx", "whisper-cpp", "whisperfile", "openai"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "transcribe-rs"
-version = "0.3.8"
+version = "0.3.9"
 build = "build.rs"
 edition = "2021"
 description = "A simple library to help you transcribe audio"
@@ -41,6 +41,7 @@ ort-directml = ["onnx", "ort/directml"]
 ort-rocm     = ["onnx", "ort/rocm"]
 ort-coreml   = ["onnx", "ort/coreml"]
 ort-webgpu   = ["onnx", "ort/webgpu"]
+ort-tracing  = ["onnx", "ort/tracing"]
 ort-accel    = ["ort-cuda", "ort-directml", "ort-rocm", "ort-coreml", "ort-webgpu"]
 
 # Convenience

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,10 +34,14 @@ openai = ["dep:async-openai", "dep:tokio", "dep:async-trait"]
 vad-silero = ["dep:ort", "dep:ndarray"]
 
 # --- ORT Accelerators ---
+# Note: ort-cuda pulls in the CUDA execution provider, which adds ~800 MB+
+# to the ORT binary and requires a CUDA toolkit / cuDNN installation at runtime.
 ort-cuda     = ["onnx", "ort/cuda"]
 ort-directml = ["onnx", "ort/directml"]
 ort-rocm     = ["onnx", "ort/rocm"]
-ort-accel    = ["ort-cuda", "ort-directml", "ort-rocm"]
+ort-coreml   = ["onnx", "ort/coreml"]
+ort-webgpu   = ["onnx", "ort/webgpu"]
+ort-accel    = ["ort-cuda", "ort-directml", "ort-rocm", "ort-coreml", "ort-webgpu"]
 
 # Convenience
 all = ["onnx", "whisper-cpp", "whisperfile", "openai"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,6 +108,10 @@ name = "canary"
 required-features = ["onnx"]
 
 [[example]]
+name = "cohere"
+required-features = ["onnx"]
+
+[[example]]
 name = "whisperfile"
 required-features = ["whisperfile"]
 
@@ -141,6 +145,10 @@ required-features = ["onnx"]
 
 [[test]]
 name = "canary"
+required-features = ["onnx"]
+
+[[test]]
+name = "cohere"
 required-features = ["onnx"]
 
 [[test]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,8 +42,9 @@ ort-directml = ["onnx", "ort/directml"]
 ort-rocm     = ["onnx", "ort/rocm"]
 ort-coreml   = ["onnx", "ort/coreml"]
 ort-webgpu   = ["onnx", "ort/webgpu"]
+ort-xnnpack  = ["onnx", "ort/xnnpack"]
 ort-tracing  = ["onnx", "ort/tracing"]
-ort-accel    = ["ort-cuda", "ort-tensorrt", "ort-directml", "ort-rocm", "ort-coreml", "ort-webgpu"]
+ort-accel    = ["ort-cuda", "ort-tensorrt", "ort-directml", "ort-rocm", "ort-coreml", "ort-webgpu", "ort-xnnpack"]
 
 # Convenience
 all = ["onnx", "whisper-cpp", "whisperfile", "openai"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "transcribe-rs"
-version = "0.3.3"
+version = "0.3.4"
 build = "build.rs"
 edition = "2021"
 description = "A simple library to help you transcribe audio"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "transcribe-rs"
-version = "0.3.10"
+version = "0.3.11"
 build = "build.rs"
 edition = "2021"
 description = "A simple library to help you transcribe audio"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,9 @@ whisperfile = ["dep:ureq"]
 # Remote engines
 openai = ["dep:async-openai", "dep:tokio", "dep:async-trait"]
 
+# Silero neural VAD (requires silero_vad_v4.onnx model file)
+vad-silero = ["dep:ort", "dep:ndarray"]
+
 # --- ORT Accelerators ---
 ort-cuda     = ["onnx", "ort/cuda"]
 ort-directml = ["onnx", "ort/directml"]
@@ -143,3 +146,11 @@ required-features = ["whisperfile"]
 [[test]]
 name = "openai"
 required-features = ["openai"]
+
+[[test]]
+name = "transcriber"
+required-features = ["onnx", "vad-silero"]
+
+[[test]]
+name = "vad_silero"
+required-features = ["vad-silero"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "transcribe-rs"
-version = "0.3.2"
+version = "0.3.3"
 build = "build.rs"
 edition = "2021"
 description = "A simple library to help you transcribe audio"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "transcribe-rs"
-version = "0.3.6"
+version = "0.3.7"
 build = "build.rs"
 edition = "2021"
 description = "A simple library to help you transcribe audio"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "transcribe-rs"
-version = "0.3.4"
+version = "0.3.5"
 build = "build.rs"
 edition = "2021"
 description = "A simple library to help you transcribe audio"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,9 @@ whisper-cuda   = ["whisper-cpp", "whisper-rs/cuda"]
 # Whisperfile server
 whisperfile = ["dep:ureq"]
 
+# Qwen3-ASR (ONNX, Whisper-compatible mel)
+qwen3 = ["onnx"]
+
 # Remote engines
 openai = ["dep:async-openai", "dep:tokio", "dep:async-trait"]
 
@@ -47,7 +50,7 @@ ort-tracing  = ["onnx", "ort/tracing"]
 ort-accel    = ["ort-cuda", "ort-tensorrt", "ort-directml", "ort-rocm", "ort-coreml", "ort-webgpu", "ort-xnnpack"]
 
 # Convenience
-all = ["onnx", "whisper-cpp", "whisperfile", "openai"]
+all = ["onnx", "whisper-cpp", "whisperfile", "openai", "qwen3"]
 
 [dependencies]
 # Always required
@@ -122,6 +125,14 @@ required-features = ["whisperfile"]
 name = "openai"
 required-features = ["openai"]
 
+[[example]]
+name = "qwen3"
+required-features = ["qwen3"]
+
+[[example]]
+name = "bench_compare"
+required-features = ["qwen3"]
+
 [dev-dependencies]
 once_cell = "1.21.3"
 
@@ -157,6 +168,10 @@ required-features = ["onnx"]
 [[test]]
 name = "whisperfile"
 required-features = ["whisperfile"]
+
+[[test]]
+name = "qwen3"
+required-features = ["qwen3"]
 
 [[test]]
 name = "openai"

--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ All audio input must be **16 kHz, mono, 16-bit PCM WAV**.
 | Canary 1B Flash | [HuggingFace](https://huggingface.co/istupakov/canary-1b-flash-onnx) |
 | Canary 1B v2 | [HuggingFace](https://huggingface.co/istupakov/canary-1b-v2-onnx) |
 | SenseVoice (int8) | [blob.handy.computer](https://blob.handy.computer/sense-voice-int8.tar.gz) / [sherpa-onnx](https://github.com/k2-fsa/sherpa-onnx/releases/tag/asr-models) |
-| Moonshine | [HuggingFace](https://huggingface.co/UsefulSensors/moonshine/tree/main/onnx/merged) |
+| Moonshine | [blob.handy.computer (base)](https://blob.handy.computer/moonshine-base.tar.gz), [blob.handy.computer (tiny streaming en)](https://blob.handy.computer/moonshine-tiny-streaming-en.tar.gz), [blob.handy.computer (small streaming en)](https://blob.handy.computer/moonshine-small-streaming-en.tar.gz), [blob.handy.computer (medium streaming en)](https://blob.handy.computer/moonshine-medium-streaming-en.tar.gz) |
 | GigaAM | [HuggingFace](https://huggingface.co/istupakov/gigaam-v3-onnx/tree/main) |
 | Whisper (GGML) | [HuggingFace](https://huggingface.co/ggerganov/whisper.cpp/tree/main) |
 | Whisperfile binary | [GitHub](https://github.com/mozilla-ai/llamafile/releases/download/0.9.3/whisperfile-0.9.3) |

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ GPU accelerator features for ORT engines:
 | `ort-cuda` | NVIDIA CUDA |
 | `ort-rocm` | AMD ROCm |
 | `ort-directml` | Microsoft DirectML (Windows) |
+| `ort-coreml` | Apple CoreML (macOS/iOS) |
+| `ort-webgpu` | WebGPU via Dawn |
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # transcribe-rs
 
-Multi-engine speech-to-text library for Rust. Supports Parakeet, Canary, Moonshine, SenseVoice, GigaAM, Whisper, Whisperfile, and OpenAI.
+Multi-engine speech-to-text library for Rust. Supports Parakeet, Canary, Cohere, Moonshine, SenseVoice, GigaAM, Whisper, Whisperfile, and OpenAI.
 
 ## Breaking Changes in 0.3.0
 
@@ -24,7 +24,7 @@ No features are enabled by default. Pick the engines you need:
 
 | Feature | Engines |
 |---------|---------|
-| `onnx` | Parakeet, Canary, Moonshine, SenseVoice, GigaAM (via ONNX Runtime) |
+| `onnx` | Parakeet, Canary, Cohere, Moonshine, SenseVoice, GigaAM (via ONNX Runtime) |
 | `whisper-cpp` | Whisper (local, GGML via whisper.cpp with Metal/Vulkan/CUDA) |
 | `whisperfile` | Whisperfile (local server wrapper) |
 | `openai` | OpenAI API (remote, async) |
@@ -142,6 +142,30 @@ Model variant (Flash vs V2) is auto-detected from vocabulary size. Flash models 
 - **PnC** (punctuation and capitalization) — enabled by default. When on, the model adds proper punctuation and capitalization. Set `use_pnc: false` for raw output.
 - **ITN** (inverse text normalization) — enabled by default. Converts spoken numbers to written form (e.g. "one hundred twenty three" becomes "123"). Set `use_itn: false` to disable. Only supported on V2 models; silently ignored on Flash.
 - **Translation** — set `target_language` to translate between supported languages.
+
+### Cohere
+
+```rust
+use transcribe_rs::onnx::cohere::{CohereModel, CohereParams};
+use transcribe_rs::onnx::Quantization;
+use std::path::PathBuf;
+
+let mut model = CohereModel::load(
+    &PathBuf::from("models/cohere-int4"),
+    &Quantization::Int4,
+)?;
+
+let samples = transcribe_rs::audio::read_wav_samples(&PathBuf::from("audio.wav"))?;
+let result = model.transcribe_with(
+    &samples,
+    &CohereParams {
+        language: Some("en".to_string()),
+        ..Default::default()
+    },
+)?;
+```
+
+Available in int4 and int8 quantizations.
 
 ### SenseVoice
 
@@ -295,6 +319,8 @@ All audio input must be **16 kHz, mono, 16-bit PCM WAV**.
 | Canary 180M Flash | [HuggingFace](https://huggingface.co/istupakov/canary-180m-flash-onnx) |
 | Canary 1B Flash | [HuggingFace](https://huggingface.co/istupakov/canary-1b-flash-onnx) |
 | Canary 1B v2 | [HuggingFace](https://huggingface.co/istupakov/canary-1b-v2-onnx) |
+| Cohere (int4) | [HuggingFace](https://huggingface.co/cstr/cohere-transcribe-onnx-int4) |
+| Cohere (int8) | [HuggingFace](https://huggingface.co/tristanripke/cohere-transcribe-onnx-int8) |
 | SenseVoice (int8) | [blob.handy.computer](https://blob.handy.computer/sense-voice-int8.tar.gz) / [sherpa-onnx](https://github.com/k2-fsa/sherpa-onnx/releases/tag/asr-models) |
 | Moonshine | [blob.handy.computer (base)](https://blob.handy.computer/moonshine-base.tar.gz), [blob.handy.computer (tiny streaming en)](https://blob.handy.computer/moonshine-tiny-streaming-en.tar.gz), [blob.handy.computer (small streaming en)](https://blob.handy.computer/moonshine-small-streaming-en.tar.gz), [blob.handy.computer (medium streaming en)](https://blob.handy.computer/moonshine-medium-streaming-en.tar.gz) |
 | GigaAM | [HuggingFace](https://huggingface.co/istupakov/gigaam-v3-onnx/tree/main) |
@@ -319,6 +345,16 @@ models/canary-1b-v2/
 ├── decoder-model.int8.onnx
 ├── nemo128.onnx
 └── vocab.txt
+```
+
+**Cohere** (directory):
+```
+models/cohere-int4/
+├── cohere-encoder.int4.onnx
+├── cohere-encoder.int4.onnx.data
+├── cohere-decoder.int4.onnx
+├── cohere-decoder.int4.onnx.data
+└── tokens.txt
 ```
 
 **SenseVoice** (directory):
@@ -375,6 +411,7 @@ Each engine has an example in `examples/`. Run with the appropriate feature flag
 ```bash
 cargo run --example parakeet --features onnx
 cargo run --example canary --features onnx
+cargo run --example cohere --features onnx
 cargo run --example sense_voice --features onnx
 cargo run --example moonshine --features onnx
 cargo run --example moonshine_streaming --features onnx

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # transcribe-rs
 
-Multi-engine speech-to-text library for Rust. Supports Parakeet, Canary, Cohere, Moonshine, SenseVoice, GigaAM, Whisper, Whisperfile, and OpenAI.
+Multi-engine speech-to-text library for Rust. Supports Parakeet, Canary, Cohere, Moonshine, SenseVoice, GigaAM, Whisper, Whisperfile, Qwen3-ASR, and OpenAI.
 
 ## Breaking Changes in 0.3.0
 
@@ -25,6 +25,7 @@ No features are enabled by default. Pick the engines you need:
 | Feature | Engines |
 |---------|---------|
 | `onnx` | Parakeet, Canary, Cohere, Moonshine, SenseVoice, GigaAM (via ONNX Runtime) |
+| `qwen3` | Qwen3-ASR (ONNX, multilingual) |
 | `whisper-cpp` | Whisper (local, GGML via whisper.cpp with Metal/Vulkan/CUDA) |
 | `whisperfile` | Whisperfile (local server wrapper) |
 | `openai` | OpenAI API (remote, async) |
@@ -236,6 +237,22 @@ let mut model = GigaAMModel::load(
 let result = model.transcribe_file(&PathBuf::from("audio.wav"), &transcribe_rs::TranscribeOptions::default())?;
 ```
 
+### Qwen3-ASR
+
+```rust
+use transcribe_rs::onnx::qwen3::Qwen3Model;
+use transcribe_rs::onnx::Quantization;
+use transcribe_rs::SpeechModel;
+use std::path::PathBuf;
+
+let mut model = Qwen3Model::load(
+    &PathBuf::from("models/qwen3-asr-0.6b"),
+    &Quantization::default(),
+)?;
+let result = model.transcribe_file(&PathBuf::from("audio.wav"), &transcribe_rs::TranscribeOptions::default())?;
+println!("{}", result.text);
+```
+
 ### Whisper (whisper.cpp)
 
 ```rust
@@ -324,6 +341,8 @@ All audio input must be **16 kHz, mono, 16-bit PCM WAV**.
 | SenseVoice (int8) | [blob.handy.computer](https://blob.handy.computer/sense-voice-int8.tar.gz) / [sherpa-onnx](https://github.com/k2-fsa/sherpa-onnx/releases/tag/asr-models) |
 | Moonshine | [blob.handy.computer (base)](https://blob.handy.computer/moonshine-base.tar.gz), [blob.handy.computer (tiny streaming en)](https://blob.handy.computer/moonshine-tiny-streaming-en.tar.gz), [blob.handy.computer (small streaming en)](https://blob.handy.computer/moonshine-small-streaming-en.tar.gz), [blob.handy.computer (medium streaming en)](https://blob.handy.computer/moonshine-medium-streaming-en.tar.gz) |
 | GigaAM | [HuggingFace](https://huggingface.co/istupakov/gigaam-v3-onnx/tree/main) |
+| Qwen3-ASR 0.6B | [HuggingFace](https://huggingface.co/andrewleech/qwen3-asr-0.6b-onnx) |
+| Qwen3-ASR 1.7B | [HuggingFace](https://huggingface.co/andrewleech/qwen3-asr-1.7b-onnx) |
 | Whisper (GGML) | [HuggingFace](https://huggingface.co/ggerganov/whisper.cpp/tree/main) |
 | Whisperfile binary | [GitHub](https://github.com/mozilla-ai/llamafile/releases/download/0.9.3/whisperfile-0.9.3) |
 
@@ -388,6 +407,19 @@ models/giga-am-v3/
 └── vocab.txt
 ```
 
+**Qwen3-ASR** (directory):
+```
+models/qwen3-asr-0.6b/
+├── encoder.onnx          # Audio encoder (+ .data weight file)
+├── decoder_init.onnx     # Decoder prefill (+ .data weight file)
+├── decoder_step.onnx     # Decoder autoregressive step (+ .data weight file)
+├── embed_tokens.bin      # Embedding matrix (raw f32)
+├── config.json           # Model configuration
+└── tokenizer.json        # HuggingFace BPE tokenizer
+```
+
+Export scripts: [qwen3-asr-onnx](https://github.com/andrewleech/qwen3-asr-onnx).
+
 **Whisper**: single file (e.g. `whisper-medium-q4_1.bin`).
 
 ### Moonshine Variants
@@ -416,6 +448,7 @@ cargo run --example sense_voice --features onnx
 cargo run --example moonshine --features onnx
 cargo run --example moonshine_streaming --features onnx
 cargo run --example gigaam --features onnx
+cargo run --example qwen3 --features qwen3
 cargo run --example whisper --features whisper-cpp
 cargo run --example whisperfile --features whisperfile
 cargo run --example openai --features openai
@@ -425,6 +458,7 @@ Tests are also feature-gated. Models must be present locally; tests skip gracefu
 
 ```bash
 cargo test --features onnx
+cargo test --features qwen3
 cargo test --features whisper-cpp
 cargo test --features whisperfile
 cargo test --all-features
@@ -460,3 +494,4 @@ Parakeet int8 benchmarks:
 - [UsefulSensors](https://github.com/usefulsensors) for Moonshine
 - [FunASR](https://github.com/modelscope/FunASR) / [sherpa-onnx](https://github.com/k2-fsa/sherpa-onnx) for SenseVoice
 - [SberDevices](https://github.com/salute-developers/GigaAM) for GigaAM
+- [Alibaba Qwen Team](https://github.com/QwenLM/Qwen3) for Qwen3

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,8 @@
+// whisper.cpp's Vulkan backend requires Windows registry access (via advapi32.lib)
+// to correctly identify and initialize graphics drivers on Windows.
+fn main() {
+    let target = std::env::var("TARGET").unwrap_or_default();
+    if target.contains("windows") {
+        println!("cargo:rustc-link-lib=advapi32");
+    }
+}

--- a/examples/bench_compare.rs
+++ b/examples/bench_compare.rs
@@ -1,0 +1,343 @@
+//! Side-by-side inference timing benchmark for Qwen3-ASR and Parakeet TDT.
+//!
+//! Loads one or both models, runs warmup passes then N timed passes on the
+//! same audio file, and prints a summary table with load time, mean/min/max
+//! inference time, and real-time factor (RTF) for each engine.
+//!
+//! # Usage
+//!
+//! ```sh
+//! cargo run --example bench_compare --features qwen3 --release -- \
+//!     --qwen3 models/qwen3-asr-0.6b --audio samples/jfk.wav
+//! ```
+//!
+//! Both engines:
+//!
+//! ```sh
+//! cargo run --example bench_compare --features "qwen3,onnx" --release -- \
+//!     --qwen3 models/qwen3-asr-0.6b \
+//!     --parakeet models/parakeet-tdt-0.6b-v3-int8 \
+//!     --audio samples/jfk.wav
+//! ```
+//!
+//! # Flags
+//!
+//! | Flag | Default | Description |
+//! |---|---|---|
+//! | `--qwen3 <path>` | — | Path to Qwen3-ASR model directory |
+//! | `--parakeet <path>` | — | Path to Parakeet-TDT model directory |
+//! | `--audio <path>` | `samples/jfk.wav` | Input WAV file (16 kHz mono) |
+//! | `--qwen3-quant <q>` | `fp32` | Qwen3 quantization: fp32, fp16, int8, int4 |
+//! | `--parakeet-quant <q>` | `int8` | Parakeet quantization: fp32, fp16, int8 |
+//! | `--accelerator <a>` | `auto` | ORT accelerator: auto, cpu, cuda, directml, rocm, coreml, webgpu |
+//! | `--decoder-gpu` | off | Run decoder on GPU (sets TRANSCRIBE_DECODER_GPU=1) |
+//! | `--warmup <n>` | `1` | Number of warmup passes (not timed) |
+//! | `--runs <n>` | `3` | Number of timed passes |
+//!
+//! For more representative RTF numbers use a longer clip (30-60 s). Any 16 kHz
+//! mono WAV works; a suitable public-domain source is LibriSpeech test-clean:
+//! <https://www.openslr.org/12>
+
+use std::path::PathBuf;
+use std::time::{Duration, Instant};
+
+use transcribe_rs::audio::read_wav_samples;
+use transcribe_rs::onnx::Quantization;
+use transcribe_rs::{
+    set_decoder_gpu, set_ort_accelerator, OrtAccelerator, SpeechModel, TranscribeOptions,
+};
+
+#[cfg(feature = "qwen3")]
+use transcribe_rs::onnx::qwen3::Qwen3Model;
+
+#[cfg(feature = "onnx")]
+use transcribe_rs::onnx::parakeet::ParakeetModel;
+
+struct BenchResult {
+    label: String,
+    load_time: Duration,
+    times: Vec<Duration>,
+    text: String,
+}
+
+impl BenchResult {
+    fn mean_secs(&self) -> f64 {
+        self.times.iter().map(|d| d.as_secs_f64()).sum::<f64>() / self.times.len() as f64
+    }
+    fn min_secs(&self) -> f64 {
+        self.times
+            .iter()
+            .map(|d| d.as_secs_f64())
+            .fold(f64::INFINITY, f64::min)
+    }
+    fn max_secs(&self) -> f64 {
+        self.times
+            .iter()
+            .map(|d| d.as_secs_f64())
+            .fold(f64::NEG_INFINITY, f64::max)
+    }
+}
+
+fn bench_model(
+    label: &str,
+    model: &mut dyn SpeechModel,
+    samples: &[f32],
+    n_warmup: usize,
+    n_runs: usize,
+    load_time: Duration,
+) -> BenchResult {
+    let options = TranscribeOptions::default();
+
+    println!("--- {} ---", label);
+
+    for i in 0..n_warmup {
+        print!("  Warmup {}/{}... ", i + 1, n_warmup);
+        let t = Instant::now();
+        let r = model
+            .transcribe(samples, &options)
+            .expect("transcribe failed");
+        println!("{:.3}s → {:?}", t.elapsed().as_secs_f64(), r.text.trim());
+    }
+
+    let mut times = Vec::with_capacity(n_runs);
+    let mut last_text = String::new();
+    for i in 0..n_runs {
+        print!("  Run {}/{}... ", i + 1, n_runs);
+        let t = Instant::now();
+        let r = model
+            .transcribe(samples, &options)
+            .expect("transcribe failed");
+        let elapsed = t.elapsed();
+        times.push(elapsed);
+        last_text = r.text.trim().to_string();
+        println!("{:.3}s", elapsed.as_secs_f64());
+    }
+
+    println!();
+
+    BenchResult {
+        label: label.to_string(),
+        load_time,
+        times,
+        text: last_text,
+    }
+}
+
+fn parse_quantization(s: &str) -> Quantization {
+    match s.to_ascii_lowercase().as_str() {
+        "int8" | "i8" => Quantization::Int8,
+        "fp16" | "f16" => Quantization::FP16,
+        _ => Quantization::FP32,
+    }
+}
+
+struct Args {
+    qwen3_dir: Option<PathBuf>,
+    parakeet_dir: Option<PathBuf>,
+    audio_path: PathBuf,
+    qwen3_quant: Quantization,
+    parakeet_quant: Quantization,
+    accelerator: OrtAccelerator,
+    decoder_gpu: bool,
+    n_warmup: usize,
+    n_runs: usize,
+}
+
+fn print_help() {
+    eprintln!(
+        "\
+bench_compare — side-by-side inference benchmark for Qwen3-ASR and Parakeet TDT
+
+USAGE:
+    cargo run --example bench_compare --features qwen3 --release -- [OPTIONS]
+
+OPTIONS:
+    --qwen3 <PATH>           Path to Qwen3-ASR model directory
+    --parakeet <PATH>        Path to Parakeet-TDT model directory
+    --audio <PATH>           Input WAV file, 16 kHz mono [default: samples/jfk.wav]
+    --qwen3-quant <QUANT>    Qwen3 quantization: fp32, fp16, int8, int4 [default: fp32]
+    --parakeet-quant <QUANT> Parakeet quantization: fp32, fp16, int8 [default: int8]
+    --accelerator <ACCEL>    ORT accelerator: auto, cpu, cuda, directml, rocm,
+                             coreml, webgpu [default: auto]
+    --decoder-gpu            Run decoder sessions on GPU (default: CPU-only)
+    --warmup <N>             Number of warmup passes [default: 1]
+    --runs <N>               Number of timed passes [default: 3]
+    -h, --help               Print this help message
+
+At least one of --qwen3 or --parakeet must be provided."
+    );
+}
+
+fn parse_args() -> Args {
+    let args: Vec<String> = std::env::args().collect();
+    let mut a = Args {
+        qwen3_dir: None,
+        parakeet_dir: None,
+        audio_path: PathBuf::from("samples/jfk.wav"),
+        qwen3_quant: Quantization::FP32,
+        parakeet_quant: Quantization::Int8, // Parakeet ships as INT8 only
+        accelerator: OrtAccelerator::Auto,
+        decoder_gpu: false,
+        n_warmup: 1,
+        n_runs: 3,
+    };
+
+    let mut i = 1;
+    while i < args.len() {
+        let flag = args[i].as_str();
+        match flag {
+            "-h" | "--help" => {
+                print_help();
+                std::process::exit(0);
+            }
+            "--qwen3" | "--parakeet" | "--audio" | "--qwen3-quant" | "--parakeet-quant"
+            | "--accelerator" | "--warmup" | "--runs" => {
+                i += 1;
+                if i >= args.len() {
+                    eprintln!("Missing value for {flag}");
+                    std::process::exit(1);
+                }
+                match flag {
+                    "--qwen3" => a.qwen3_dir = Some(PathBuf::from(&args[i])),
+                    "--parakeet" => a.parakeet_dir = Some(PathBuf::from(&args[i])),
+                    "--audio" => a.audio_path = PathBuf::from(&args[i]),
+                    "--qwen3-quant" => a.qwen3_quant = parse_quantization(&args[i]),
+                    "--parakeet-quant" => a.parakeet_quant = parse_quantization(&args[i]),
+                    "--accelerator" => {
+                        a.accelerator = args[i].parse().unwrap_or_else(|e| {
+                            eprintln!("Invalid accelerator '{}': {e}", args[i]);
+                            std::process::exit(1);
+                        });
+                    }
+                    "--warmup" => a.n_warmup = args[i].parse().unwrap_or(1),
+                    "--runs" => a.n_runs = args[i].parse().unwrap_or(3),
+                    _ => unreachable!(),
+                }
+            }
+            "--decoder-gpu" => {
+                a.decoder_gpu = true;
+            }
+            _ => {
+                eprintln!("Unknown argument: {}", args[i]);
+                print_help();
+                std::process::exit(1);
+            }
+        }
+        i += 1;
+    }
+    a
+}
+
+fn main() {
+    env_logger::init();
+
+    let a = parse_args();
+
+    set_ort_accelerator(a.accelerator);
+    set_decoder_gpu(a.decoder_gpu);
+
+    let samples = read_wav_samples(&a.audio_path).unwrap_or_else(|e| {
+        eprintln!("Failed to read {}: {e}", a.audio_path.display());
+        std::process::exit(1);
+    });
+    let audio_duration = samples.len() as f64 / 16000.0;
+
+    println!("Audio: {} ({:.2}s)", a.audio_path.display(), audio_duration);
+    println!(
+        "Accelerator: {:?}  Decoder GPU: {}",
+        a.accelerator, a.decoder_gpu
+    );
+    println!("Warmup: {}  Runs: {}", a.n_warmup, a.n_runs);
+    println!();
+
+    let mut results: Vec<BenchResult> = Vec::new();
+
+    // Qwen3-ASR
+    #[cfg(feature = "qwen3")]
+    if let Some(ref dir) = a.qwen3_dir {
+        if !dir.exists() {
+            eprintln!("Qwen3 model not found: {}", dir.display());
+        } else {
+            print!(
+                "Loading Qwen3 ({:?}) from {}... ",
+                a.qwen3_quant,
+                dir.display()
+            );
+            let t0 = Instant::now();
+            match Qwen3Model::load(dir, &a.qwen3_quant) {
+                Ok(mut model) => {
+                    let load_time = t0.elapsed();
+                    println!("{:.3}s", load_time.as_secs_f64());
+                    let label = format!(
+                        "Qwen3-ASR {:?} ({})",
+                        a.qwen3_quant,
+                        dir.file_name().unwrap_or_default().to_string_lossy()
+                    );
+                    results.push(bench_model(
+                        &label, &mut model, &samples, a.n_warmup, a.n_runs, load_time,
+                    ));
+                }
+                Err(e) => eprintln!("Failed to load Qwen3: {e}"),
+            }
+        }
+    }
+
+    // Parakeet TDT
+    #[cfg(feature = "onnx")]
+    if let Some(ref dir) = a.parakeet_dir {
+        if !dir.exists() {
+            eprintln!("Parakeet model not found: {}", dir.display());
+        } else {
+            print!(
+                "Loading Parakeet ({:?}) from {}... ",
+                a.parakeet_quant,
+                dir.display()
+            );
+            let t0 = Instant::now();
+            match ParakeetModel::load(dir, &a.parakeet_quant) {
+                Ok(mut model) => {
+                    let load_time = t0.elapsed();
+                    println!("{:.3}s", load_time.as_secs_f64());
+                    let label = format!(
+                        "Parakeet-TDT {:?} ({})",
+                        a.parakeet_quant,
+                        dir.file_name().unwrap_or_default().to_string_lossy()
+                    );
+                    results.push(bench_model(
+                        &label, &mut model, &samples, a.n_warmup, a.n_runs, load_time,
+                    ));
+                }
+                Err(e) => eprintln!("Failed to load Parakeet: {e}"),
+            }
+        }
+    }
+
+    if results.is_empty() {
+        eprintln!("No models benchmarked. Provide --qwen3 and/or --parakeet paths.");
+        std::process::exit(1);
+    }
+
+    // Summary table
+    println!("=== Summary (audio: {:.2}s) ===", audio_duration);
+    println!(
+        "{:<36} {:>9} {:>9} {:>9} {:>9} {:>7}",
+        "Engine", "Load", "Mean", "Min", "Max", "RTF"
+    );
+    println!("{}", "-".repeat(82));
+    for r in &results {
+        let rtf = r.mean_secs() / audio_duration;
+        println!(
+            "{:<36} {:>8.3}s {:>8.3}s {:>8.3}s {:>8.3}s {:>6.2}x",
+            r.label,
+            r.load_time.as_secs_f64(),
+            r.mean_secs(),
+            r.min_secs(),
+            r.max_secs(),
+            rtf,
+        );
+    }
+    println!();
+    for r in &results {
+        println!("[{}] {:?}", r.label, r.text);
+    }
+}

--- a/examples/bench_compare.rs
+++ b/examples/bench_compare.rs
@@ -126,6 +126,7 @@ fn bench_model(
 fn parse_quantization(s: &str) -> Quantization {
     match s.to_ascii_lowercase().as_str() {
         "int8" | "i8" => Quantization::Int8,
+        "int4" | "i4" => Quantization::Int4,
         "fp16" | "f16" => Quantization::FP16,
         _ => Quantization::FP32,
     }

--- a/examples/canary.rs
+++ b/examples/canary.rs
@@ -34,7 +34,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         positional
             .get(1)
             .map(|s| s.as_str())
-            .unwrap_or("samples/jfk.wav"),
+            .unwrap_or("samples/dots.wav"),
     );
 
     let audio_duration = get_audio_duration(&wav_path)?;

--- a/examples/cohere.rs
+++ b/examples/cohere.rs
@@ -1,0 +1,58 @@
+use std::path::PathBuf;
+use std::time::Instant;
+
+use transcribe_rs::onnx::cohere::CohereModel;
+use transcribe_rs::onnx::Quantization;
+use transcribe_rs::SpeechModel;
+
+fn get_audio_duration(path: &PathBuf) -> Result<f64, Box<dyn std::error::Error>> {
+    let reader = hound::WavReader::open(path)?;
+    let spec = reader.spec();
+    let duration = reader.duration() as f64 / spec.sample_rate as f64;
+    Ok(duration)
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    env_logger::init();
+
+    let args: Vec<String> = std::env::args().collect();
+    let quant = args.get(1).map(|s| s.as_str()).unwrap_or("int8");
+
+    let (model_path, quantization) = match quant {
+        "int4" => ("models/cohere-int4", Quantization::Int4),
+        "int8" => ("models/cohere-int8", Quantization::Int8),
+        other => {
+            eprintln!("Unknown quantization: {other}. Use 'int4' or 'int8'.");
+            std::process::exit(1);
+        }
+    };
+
+    let model_path = PathBuf::from(model_path);
+    let wav_path = PathBuf::from("samples/dots.wav");
+
+    let audio_duration = get_audio_duration(&wav_path)?;
+    println!("Audio duration: {:.2}s", audio_duration);
+
+    println!("Using Cohere ONNX engine ({quant})");
+    println!("Loading model: {:?}", model_path);
+
+    let load_start = Instant::now();
+    let mut model = CohereModel::load(&model_path, &quantization)?;
+    let load_duration = load_start.elapsed();
+    println!("Model loaded in {:.2?}", load_duration);
+
+    println!("Transcribing file: {:?}", wav_path);
+    let transcribe_start = Instant::now();
+    let result = model.transcribe_file(&wav_path, &transcribe_rs::TranscribeOptions::default())?;
+    let transcribe_duration = transcribe_start.elapsed();
+    println!("Transcription completed in {:.2?}", transcribe_duration);
+
+    let speedup_factor = audio_duration / transcribe_duration.as_secs_f64();
+    println!(
+        "Real-time speedup: {:.2}x faster than real-time",
+        speedup_factor
+    );
+    println!("Transcription result:\n{}", result.text);
+
+    Ok(())
+}

--- a/examples/qwen3.rs
+++ b/examples/qwen3.rs
@@ -1,0 +1,46 @@
+use std::env;
+use std::path::PathBuf;
+use std::time::Instant;
+
+use transcribe_rs::onnx::qwen3::Qwen3Model;
+use transcribe_rs::onnx::Quantization;
+use transcribe_rs::SpeechModel;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    env_logger::init();
+
+    let args: Vec<String> = env::args().collect();
+    if args.len() < 3 {
+        eprintln!("Usage: {} <model_dir> <audio.wav>", args[0]);
+        std::process::exit(1);
+    }
+
+    let model_dir = PathBuf::from(&args[1]);
+    let wav_path = PathBuf::from(&args[2]);
+
+    // Read audio
+    let reader = hound::WavReader::open(&wav_path)?;
+    let spec = reader.spec();
+    let audio_duration = reader.duration() as f64 / spec.sample_rate as f64;
+    println!("Audio: {:.2}s", audio_duration);
+
+    let samples = transcribe_rs::audio::read_wav_samples(&wav_path)?;
+
+    // Load model
+    println!("Loading Qwen3-ASR model from {:?}", model_dir);
+    let load_start = Instant::now();
+    let mut model = Qwen3Model::load(&model_dir, &Quantization::default())?;
+    println!("Model loaded in {:.2?}", load_start.elapsed());
+
+    // Transcribe
+    let transcribe_start = Instant::now();
+    let result = model.transcribe(&samples, &transcribe_rs::TranscribeOptions::default())?;
+    let transcribe_duration = transcribe_start.elapsed();
+
+    println!("Transcription: {}", result.text);
+    println!("Completed in {:.2?}", transcribe_duration);
+    let speedup = audio_duration / transcribe_duration.as_secs_f64();
+    println!("Real-time factor: {:.2}x", speedup);
+
+    Ok(())
+}

--- a/examples/qwen3.rs
+++ b/examples/qwen3.rs
@@ -2,21 +2,32 @@ use std::env;
 use std::path::PathBuf;
 use std::time::Instant;
 
-use transcribe_rs::onnx::qwen3::Qwen3Model;
+use transcribe_rs::onnx::qwen3::{Qwen3Model, Qwen3Params};
 use transcribe_rs::onnx::Quantization;
-use transcribe_rs::SpeechModel;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     env_logger::init();
 
     let args: Vec<String> = env::args().collect();
     if args.len() < 3 {
-        eprintln!("Usage: {} <model_dir> <audio.wav>", args[0]);
+        eprintln!(
+            "Usage: {} <model_dir> <audio.wav> [fp32|fp16|int8|int4] [language] [chunk_seconds]",
+            args[0]
+        );
         std::process::exit(1);
     }
 
     let model_dir = PathBuf::from(&args[1]);
     let wav_path = PathBuf::from(&args[2]);
+    let quantization = args
+        .get(3)
+        .map(|value| parse_quantization(value))
+        .unwrap_or_else(|| infer_quantization_from_path(&model_dir));
+    let language = args.get(4).filter(|value| !value.is_empty()).cloned();
+    let chunk_seconds = args
+        .get(5)
+        .map(|value| parse_chunk_seconds(value))
+        .unwrap_or(55.0);
 
     // Read audio
     let reader = hound::WavReader::open(&wav_path)?;
@@ -27,20 +38,94 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let samples = transcribe_rs::audio::read_wav_samples(&wav_path)?;
 
     // Load model
-    println!("Loading Qwen3-ASR model from {:?}", model_dir);
+    println!(
+        "Loading Qwen3-ASR model from {:?} with {:?}",
+        model_dir, quantization
+    );
     let load_start = Instant::now();
-    let mut model = Qwen3Model::load(&model_dir, &Quantization::default())?;
+    let mut model = Qwen3Model::load(&model_dir, &quantization)?;
     println!("Model loaded in {:.2?}", load_start.elapsed());
+    println!(
+        "Language hint: {}; chunk size: {:.2}s",
+        language.as_deref().unwrap_or("auto"),
+        chunk_seconds
+    );
 
     // Transcribe
     let transcribe_start = Instant::now();
-    let result = model.transcribe(&samples, &transcribe_rs::TranscribeOptions::default())?;
+    let chunk_samples = (chunk_seconds * spec.sample_rate as f64).round() as usize;
+    let mut texts = Vec::new();
+    for (index, chunk) in samples.chunks(chunk_samples).enumerate() {
+        let chunk_start = index as f64 * chunk_seconds;
+        let chunk_duration = chunk.len() as f64 / spec.sample_rate as f64;
+        println!(
+            "Chunk {}: {:.2}s..{:.2}s ({:.2}s)",
+            index + 1,
+            chunk_start,
+            chunk_start + chunk_duration,
+            chunk_duration
+        );
+        let chunk_start_time = Instant::now();
+        let params = Qwen3Params {
+            language: language.clone(),
+            ..Default::default()
+        };
+        let result = model.transcribe_with(chunk, &params)?;
+        println!("Chunk {} transcription: {}", index + 1, result.text);
+        println!(
+            "Chunk {} completed in {:.2?}",
+            index + 1,
+            chunk_start_time.elapsed()
+        );
+        if !result.text.trim().is_empty() {
+            texts.push(result.text);
+        }
+    }
     let transcribe_duration = transcribe_start.elapsed();
+    let text = texts.join(" ");
 
-    println!("Transcription: {}", result.text);
+    println!("Transcription: {}", text);
     println!("Completed in {:.2?}", transcribe_duration);
     let speedup = audio_duration / transcribe_duration.as_secs_f64();
     println!("Real-time factor: {:.2}x", speedup);
 
     Ok(())
+}
+
+fn parse_chunk_seconds(value: &str) -> f64 {
+    let seconds = value.parse::<f64>().unwrap_or_else(|error| {
+        eprintln!("Invalid chunk_seconds {value:?}: {error}");
+        std::process::exit(2);
+    });
+    if !(0.0..=60.0).contains(&seconds) || seconds == 0.0 {
+        eprintln!("chunk_seconds must be greater than 0 and at most 60; got {seconds}");
+        std::process::exit(2);
+    }
+    seconds
+}
+
+fn parse_quantization(value: &str) -> Quantization {
+    match value.to_ascii_lowercase().as_str() {
+        "fp32" | "f32" => Quantization::FP32,
+        "fp16" | "f16" => Quantization::FP16,
+        "int8" | "i8" => Quantization::Int8,
+        "int4" | "i4" => Quantization::Int4,
+        other => {
+            eprintln!("Unknown quantization {other:?}; expected fp32, fp16, int8, or int4");
+            std::process::exit(2);
+        }
+    }
+}
+
+fn infer_quantization_from_path(model_dir: &std::path::Path) -> Quantization {
+    let path = model_dir.to_string_lossy().to_ascii_lowercase();
+    if path.contains("int4") || path.contains("i4") {
+        Quantization::Int4
+    } else if path.contains("int8") || path.contains("i8") {
+        Quantization::Int8
+    } else if path.contains("fp16") || path.contains("f16") {
+        Quantization::FP16
+    } else {
+        Quantization::default()
+    }
 }

--- a/src/accel.rs
+++ b/src/accel.rs
@@ -38,6 +38,9 @@ pub enum OrtAccelerator {
     CpuOnly = 1,
     /// NVIDIA CUDA (requires `ort-cuda` feature; adds ~800 MB to binary size).
     Cuda = 2,
+    /// NVIDIA TensorRT (requires `ort-tensorrt` feature; builds on CUDA with optimised graph compilation).
+    #[serde(rename = "tensorrt", alias = "tensor_rt")]
+    TensorRt = 7,
     /// Microsoft DirectML (Windows).
     #[serde(rename = "directml", alias = "direct_ml")]
     DirectMl = 3,
@@ -77,6 +80,9 @@ impl OrtAccelerator {
         #[cfg(feature = "ort-cuda")]
         v.push(OrtAccelerator::Cuda);
 
+        #[cfg(feature = "ort-tensorrt")]
+        v.push(OrtAccelerator::TensorRt);
+
         #[cfg(feature = "ort-directml")]
         v.push(OrtAccelerator::DirectMl);
 
@@ -101,6 +107,7 @@ impl OrtAccelerator {
             4 => Self::Rocm,
             5 => Self::CoreMl,
             6 => Self::WebGpu,
+            7 => Self::TensorRt,
             _ => Self::Auto,
         }
     }
@@ -118,6 +125,7 @@ impl fmt::Display for OrtAccelerator {
             Self::Auto => "auto",
             Self::CpuOnly => "cpu",
             Self::Cuda => "cuda",
+            Self::TensorRt => "tensorrt",
             Self::DirectMl => "directml",
             Self::Rocm => "rocm",
             Self::CoreMl => "coreml",
@@ -135,6 +143,7 @@ impl FromStr for OrtAccelerator {
             "auto" => Ok(Self::Auto),
             "cpu" | "cpu_only" | "cpuonly" => Ok(Self::CpuOnly),
             "cuda" => Ok(Self::Cuda),
+            "tensorrt" | "trt" | "tensor_rt" => Ok(Self::TensorRt),
             "directml" | "dml" => Ok(Self::DirectMl),
             "rocm" => Ok(Self::Rocm),
             "coreml" | "core_ml" => Ok(Self::CoreMl),
@@ -322,6 +331,7 @@ mod tests {
             OrtAccelerator::Auto,
             OrtAccelerator::CpuOnly,
             OrtAccelerator::Cuda,
+            OrtAccelerator::TensorRt,
             OrtAccelerator::DirectMl,
             OrtAccelerator::Rocm,
             OrtAccelerator::CoreMl,
@@ -347,6 +357,10 @@ mod tests {
             "cpu_only".parse::<OrtAccelerator>().unwrap(),
             OrtAccelerator::CpuOnly
         );
+        assert_eq!(
+            "trt".parse::<OrtAccelerator>().unwrap(),
+            OrtAccelerator::TensorRt
+        );
     }
 
     #[test]
@@ -360,6 +374,7 @@ mod tests {
             (OrtAccelerator::Auto, "\"auto\""),
             (OrtAccelerator::CpuOnly, "\"cpu\""),
             (OrtAccelerator::Cuda, "\"cuda\""),
+            (OrtAccelerator::TensorRt, "\"tensorrt\""),
             (OrtAccelerator::DirectMl, "\"directml\""),
             (OrtAccelerator::Rocm, "\"rocm\""),
             (OrtAccelerator::CoreMl, "\"coreml\""),
@@ -380,6 +395,8 @@ mod tests {
         assert_eq!(old_cpu, OrtAccelerator::CpuOnly);
         let old_dml: OrtAccelerator = serde_json::from_str("\"direct_ml\"").unwrap();
         assert_eq!(old_dml, OrtAccelerator::DirectMl);
+        let old_trt: OrtAccelerator = serde_json::from_str("\"tensor_rt\"").unwrap();
+        assert_eq!(old_trt, OrtAccelerator::TensorRt);
     }
 
     #[test]

--- a/src/accel.rs
+++ b/src/accel.rs
@@ -245,9 +245,19 @@ pub fn get_whisper_gpu_device() -> i32 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
 
-    /// RAII guard that restores Auto preference for all engines when dropped.
-    struct AccelGuard;
+    /// Tests that mutate global accelerator state must hold this lock.
+    static ACCEL_LOCK: Mutex<()> = Mutex::new(());
+
+    /// RAII guard that serialises access to global state and restores defaults when dropped.
+    struct AccelGuard(#[allow(dead_code)] std::sync::MutexGuard<'static, ()>);
+    impl AccelGuard {
+        fn new() -> Self {
+            let g = ACCEL_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+            Self(g)
+        }
+    }
     impl Drop for AccelGuard {
         fn drop(&mut self) {
             set_ort_accelerator(OrtAccelerator::Auto);
@@ -260,14 +270,14 @@ mod tests {
 
     #[test]
     fn ort_default_is_auto() {
-        let _g = AccelGuard;
+        let _g = AccelGuard::new();
         set_ort_accelerator(OrtAccelerator::Auto);
         assert_eq!(get_ort_accelerator(), OrtAccelerator::Auto);
     }
 
     #[test]
     fn ort_set_and_get() {
-        let _g = AccelGuard;
+        let _g = AccelGuard::new();
         set_ort_accelerator(OrtAccelerator::Cuda);
         assert_eq!(get_ort_accelerator(), OrtAccelerator::Cuda);
         set_ort_accelerator(OrtAccelerator::CpuOnly);
@@ -334,14 +344,14 @@ mod tests {
 
     #[test]
     fn whisper_default_is_auto() {
-        let _g = AccelGuard;
+        let _g = AccelGuard::new();
         set_whisper_accelerator(WhisperAccelerator::Auto);
         assert_eq!(get_whisper_accelerator(), WhisperAccelerator::Auto);
     }
 
     #[test]
     fn whisper_set_and_get() {
-        let _g = AccelGuard;
+        let _g = AccelGuard::new();
         set_whisper_accelerator(WhisperAccelerator::CpuOnly);
         assert_eq!(get_whisper_accelerator(), WhisperAccelerator::CpuOnly);
         set_whisper_accelerator(WhisperAccelerator::Gpu);
@@ -397,14 +407,14 @@ mod tests {
 
     #[test]
     fn gpu_device_default_is_auto() {
-        let _g = AccelGuard;
+        let _g = AccelGuard::new();
         set_whisper_gpu_device(GPU_DEVICE_AUTO);
         assert_eq!(get_whisper_gpu_device(), GPU_DEVICE_AUTO);
     }
 
     #[test]
     fn gpu_device_set_and_get() {
-        let _g = AccelGuard;
+        let _g = AccelGuard::new();
         set_whisper_gpu_device(1);
         assert_eq!(get_whisper_gpu_device(), 1);
         set_whisper_gpu_device(GPU_DEVICE_AUTO);

--- a/src/accel.rs
+++ b/src/accel.rs
@@ -52,6 +52,10 @@ pub enum OrtAccelerator {
     /// WebGPU via Dawn (Windows, Linux, WebAssembly).
     #[serde(rename = "webgpu")]
     WebGpu = 6,
+    /// XNNPACK CPU acceleration (ARM, x86_64). Optimised for Conv/Gemm/MatMul
+    /// kernels; uses its own threadpool independent of the session intra-op pool.
+    #[serde(rename = "xnnpack")]
+    Xnnpack = 8,
 }
 
 static ORT_ACCELERATOR: AtomicU8 = AtomicU8::new(OrtAccelerator::Auto as u8);
@@ -95,6 +99,9 @@ impl OrtAccelerator {
         #[cfg(feature = "ort-webgpu")]
         v.push(OrtAccelerator::WebGpu);
 
+        #[cfg(feature = "ort-xnnpack")]
+        v.push(OrtAccelerator::Xnnpack);
+
         v
     }
 
@@ -108,6 +115,7 @@ impl OrtAccelerator {
             5 => Self::CoreMl,
             6 => Self::WebGpu,
             7 => Self::TensorRt,
+            8 => Self::Xnnpack,
             _ => Self::Auto,
         }
     }
@@ -130,6 +138,7 @@ impl fmt::Display for OrtAccelerator {
             Self::Rocm => "rocm",
             Self::CoreMl => "coreml",
             Self::WebGpu => "webgpu",
+            Self::Xnnpack => "xnnpack",
         };
         f.write_str(s)
     }
@@ -148,6 +157,7 @@ impl FromStr for OrtAccelerator {
             "rocm" => Ok(Self::Rocm),
             "coreml" | "core_ml" => Ok(Self::CoreMl),
             "webgpu" | "web_gpu" => Ok(Self::WebGpu),
+            "xnnpack" => Ok(Self::Xnnpack),
             other => Err(format!("unknown ORT accelerator: {other}")),
         }
     }
@@ -336,6 +346,7 @@ mod tests {
             OrtAccelerator::Rocm,
             OrtAccelerator::CoreMl,
             OrtAccelerator::WebGpu,
+            OrtAccelerator::Xnnpack,
         ] {
             let s = pref.to_string();
             let parsed: OrtAccelerator = s.parse().unwrap();
@@ -379,6 +390,7 @@ mod tests {
             (OrtAccelerator::Rocm, "\"rocm\""),
             (OrtAccelerator::CoreMl, "\"coreml\""),
             (OrtAccelerator::WebGpu, "\"webgpu\""),
+            (OrtAccelerator::Xnnpack, "\"xnnpack\""),
         ] {
             let json = serde_json::to_string(&pref).unwrap();
             assert_eq!(json, expected, "serialize {:?}", pref);

--- a/src/accel.rs
+++ b/src/accel.rs
@@ -15,20 +15,40 @@ use serde::{Deserialize, Serialize};
 // ---------------------------------------------------------------------------
 
 /// Preferred hardware accelerator for ORT-based engines (SenseVoice, GigaAM, Parakeet, Moonshine).
+///
+/// Each variant requires its corresponding `ort-*` feature flag to be enabled at compile time.
+/// If the selected accelerator's feature is not enabled, session creation falls back to CPU
+/// with a log warning.
+///
+/// **Binary size note:** Enabling `ort-cuda` pulls in the CUDA execution provider libraries
+/// (~800 MB+), significantly increasing the final binary and its runtime dependencies
+/// (CUDA toolkit / cuDNN). Prefer `CpuOnly` or lighter providers unless GPU acceleration
+/// is specifically required.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
+#[non_exhaustive]
 #[repr(u8)]
 pub enum OrtAccelerator {
     /// Automatically select the best available execution provider (default).
+    /// DirectML and WebGPU are excluded from auto-selection because they
+    /// require sequential execution mode; set them explicitly to use.
     Auto = 0,
     /// Force CPU-only execution — no GPU providers.
+    #[serde(rename = "cpu", alias = "cpu_only")]
     CpuOnly = 1,
-    /// NVIDIA CUDA.
+    /// NVIDIA CUDA (requires `ort-cuda` feature; adds ~800 MB to binary size).
     Cuda = 2,
     /// Microsoft DirectML (Windows).
+    #[serde(rename = "directml", alias = "direct_ml")]
     DirectMl = 3,
     /// AMD ROCm.
     Rocm = 4,
+    /// Apple CoreML (macOS/iOS — Neural Engine, GPU, or CPU).
+    #[serde(rename = "coreml")]
+    CoreMl = 5,
+    /// WebGPU via Dawn (Windows, Linux, WebAssembly).
+    #[serde(rename = "webgpu")]
+    WebGpu = 6,
 }
 
 static ORT_ACCELERATOR: AtomicU8 = AtomicU8::new(OrtAccelerator::Auto as u8);
@@ -63,6 +83,12 @@ impl OrtAccelerator {
         #[cfg(feature = "ort-rocm")]
         v.push(OrtAccelerator::Rocm);
 
+        #[cfg(feature = "ort-coreml")]
+        v.push(OrtAccelerator::CoreMl);
+
+        #[cfg(feature = "ort-webgpu")]
+        v.push(OrtAccelerator::WebGpu);
+
         v
     }
 
@@ -73,6 +99,8 @@ impl OrtAccelerator {
             2 => Self::Cuda,
             3 => Self::DirectMl,
             4 => Self::Rocm,
+            5 => Self::CoreMl,
+            6 => Self::WebGpu,
             _ => Self::Auto,
         }
     }
@@ -92,6 +120,8 @@ impl fmt::Display for OrtAccelerator {
             Self::Cuda => "cuda",
             Self::DirectMl => "directml",
             Self::Rocm => "rocm",
+            Self::CoreMl => "coreml",
+            Self::WebGpu => "webgpu",
         };
         f.write_str(s)
     }
@@ -107,6 +137,8 @@ impl FromStr for OrtAccelerator {
             "cuda" => Ok(Self::Cuda),
             "directml" | "dml" => Ok(Self::DirectMl),
             "rocm" => Ok(Self::Rocm),
+            "coreml" | "core_ml" => Ok(Self::CoreMl),
+            "webgpu" | "web_gpu" => Ok(Self::WebGpu),
             other => Err(format!("unknown ORT accelerator: {other}")),
         }
     }
@@ -292,6 +324,8 @@ mod tests {
             OrtAccelerator::Cuda,
             OrtAccelerator::DirectMl,
             OrtAccelerator::Rocm,
+            OrtAccelerator::CoreMl,
+            OrtAccelerator::WebGpu,
         ] {
             let s = pref.to_string();
             let parsed: OrtAccelerator = s.parse().unwrap();
@@ -322,11 +356,30 @@ mod tests {
 
     #[test]
     fn ort_serde_roundtrip() {
-        let pref = OrtAccelerator::Cuda;
-        let json = serde_json::to_string(&pref).unwrap();
-        assert_eq!(json, "\"cuda\"");
-        let back: OrtAccelerator = serde_json::from_str(&json).unwrap();
-        assert_eq!(back, pref);
+        for (pref, expected) in [
+            (OrtAccelerator::Auto, "\"auto\""),
+            (OrtAccelerator::CpuOnly, "\"cpu\""),
+            (OrtAccelerator::Cuda, "\"cuda\""),
+            (OrtAccelerator::DirectMl, "\"directml\""),
+            (OrtAccelerator::Rocm, "\"rocm\""),
+            (OrtAccelerator::CoreMl, "\"coreml\""),
+            (OrtAccelerator::WebGpu, "\"webgpu\""),
+        ] {
+            let json = serde_json::to_string(&pref).unwrap();
+            assert_eq!(json, expected, "serialize {:?}", pref);
+            let back: OrtAccelerator = serde_json::from_str(&json).unwrap();
+            assert_eq!(back, pref, "deserialize {}", json);
+        }
+    }
+
+    #[test]
+    fn ort_serde_backward_compat() {
+        // Old snake_case forms from before the serde(rename) overrides
+        // must still deserialize for backward compatibility.
+        let old_cpu: OrtAccelerator = serde_json::from_str("\"cpu_only\"").unwrap();
+        assert_eq!(old_cpu, OrtAccelerator::CpuOnly);
+        let old_dml: OrtAccelerator = serde_json::from_str("\"direct_ml\"").unwrap();
+        assert_eq!(old_dml, OrtAccelerator::DirectMl);
     }
 
     #[test]

--- a/src/accel.rs
+++ b/src/accel.rs
@@ -155,7 +155,11 @@ impl WhisperAccelerator {
         #[allow(unused_mut)]
         let mut v = vec![WhisperAccelerator::CpuOnly];
 
-        #[cfg(any(feature = "whisper-metal", feature = "whisper-vulkan", feature = "whisper-cuda"))]
+        #[cfg(any(
+            feature = "whisper-metal",
+            feature = "whisper-vulkan",
+            feature = "whisper-cuda"
+        ))]
         v.push(WhisperAccelerator::Gpu);
 
         v

--- a/src/accel.rs
+++ b/src/accel.rs
@@ -6,7 +6,7 @@
 
 use std::fmt;
 use std::str::FromStr;
-use std::sync::atomic::{AtomicU8, Ordering};
+use std::sync::atomic::{AtomicI32, AtomicU8, Ordering};
 
 use serde::{Deserialize, Serialize};
 
@@ -211,6 +211,34 @@ impl FromStr for WhisperAccelerator {
 }
 
 // ---------------------------------------------------------------------------
+// Whisper GPU device selection
+// ---------------------------------------------------------------------------
+
+/// Auto-select: let the library pick the best GPU (default).
+pub const GPU_DEVICE_AUTO: i32 = -1;
+
+static WHISPER_GPU_DEVICE: AtomicI32 = AtomicI32::new(GPU_DEVICE_AUTO);
+
+/// Set the preferred GPU device index for whisper.cpp.
+///
+/// - `-1` (default, [`GPU_DEVICE_AUTO`]): automatically select the best device
+///   (prefers dedicated GPUs over integrated ones).
+/// - `0, 1, 2, …`: use a specific device by backend index.
+///
+/// Call before loading a Whisper model; takes effect on next model load.
+pub fn set_whisper_gpu_device(device: i32) {
+    WHISPER_GPU_DEVICE.store(device, Ordering::Relaxed);
+}
+
+/// Get the current whisper GPU device preference.
+///
+/// Returns [`GPU_DEVICE_AUTO`] (`-1`) for automatic selection, or a
+/// non-negative backend-specific device index.
+pub fn get_whisper_gpu_device() -> i32 {
+    WHISPER_GPU_DEVICE.load(Ordering::Relaxed)
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
@@ -218,12 +246,13 @@ impl FromStr for WhisperAccelerator {
 mod tests {
     use super::*;
 
-    /// RAII guard that restores Auto preference for both engines when dropped.
+    /// RAII guard that restores Auto preference for all engines when dropped.
     struct AccelGuard;
     impl Drop for AccelGuard {
         fn drop(&mut self) {
             set_ort_accelerator(OrtAccelerator::Auto);
             set_whisper_accelerator(WhisperAccelerator::Auto);
+            set_whisper_gpu_device(GPU_DEVICE_AUTO);
         }
     }
 
@@ -362,5 +391,23 @@ mod tests {
     #[test]
     fn whisper_from_u8_invalid_returns_auto() {
         assert_eq!(WhisperAccelerator::from_u8(255), WhisperAccelerator::Auto);
+    }
+
+    // -- GPU device tests --
+
+    #[test]
+    fn gpu_device_default_is_auto() {
+        let _g = AccelGuard;
+        set_whisper_gpu_device(GPU_DEVICE_AUTO);
+        assert_eq!(get_whisper_gpu_device(), GPU_DEVICE_AUTO);
+    }
+
+    #[test]
+    fn gpu_device_set_and_get() {
+        let _g = AccelGuard;
+        set_whisper_gpu_device(1);
+        assert_eq!(get_whisper_gpu_device(), 1);
+        set_whisper_gpu_device(GPU_DEVICE_AUTO);
+        assert_eq!(get_whisper_gpu_device(), GPU_DEVICE_AUTO);
     }
 }

--- a/src/accel.rs
+++ b/src/accel.rs
@@ -72,6 +72,22 @@ pub fn get_ort_accelerator() -> OrtAccelerator {
     OrtAccelerator::from_u8(ORT_ACCELERATOR.load(Ordering::Relaxed))
 }
 
+static DECODER_GPU: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+/// Enable GPU execution providers for decoder sessions.
+///
+/// By default, decoder sessions use CPU-only with arena allocator because
+/// sequential execution makes GPU kernel launch overhead net-negative for
+/// per-token latency at batch size 1. Set to `true` for GPU benchmarking.
+pub fn set_decoder_gpu(enable: bool) {
+    DECODER_GPU.store(enable, Ordering::Relaxed);
+}
+
+/// Get whether decoder sessions should use GPU execution providers.
+pub fn get_decoder_gpu() -> bool {
+    DECODER_GPU.load(Ordering::Relaxed)
+}
+
 impl OrtAccelerator {
     /// Return the list of ORT accelerators that are compiled-in for the current build.
     ///

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -7,6 +7,9 @@ use std::path::Path;
 
 use crate::TranscribeError;
 
+/// Number of samples per millisecond at 16 kHz.
+pub const SAMPLES_PER_MS: usize = 16;
+
 /// Read WAV file samples and convert them to the required format.
 ///
 /// This function reads a WAV file and converts it to the format expected by
@@ -92,4 +95,15 @@ pub fn read_wav_samples(wav_path: &Path) -> Result<Vec<f32>, TranscribeError> {
         .collect();
 
     Ok(samples?)
+}
+
+/// Prepend silence to audio samples.
+///
+/// Returns a new buffer with `silence_ms` milliseconds of zeros
+/// followed by the original samples. Assumes 16 kHz sample rate.
+pub fn prepend_silence(samples: &[f32], silence_ms: u32) -> Vec<f32> {
+    let silence_len = silence_ms as usize * SAMPLES_PER_MS;
+    let mut padded = vec![0.0f32; silence_len];
+    padded.extend_from_slice(samples);
+    padded
 }

--- a/src/decode/greedy.rs
+++ b/src/decode/greedy.rs
@@ -1,0 +1,127 @@
+/// Greedy autoregressive token selection with repetition detection.
+///
+/// Wraps the common argmax + EOS + repeat-guard pattern shared by all
+/// autoregressive decoder engines (Canary, Moonshine, Cohere).
+///
+/// Each engine still owns its KV cache and decoder session — this struct
+/// only handles token selection and stopping decisions.
+
+const DEFAULT_MAX_CONSECUTIVE_REPEATS: usize = 8;
+
+pub struct GreedyDecoder {
+    eos_id: i64,
+    max_consecutive_repeats: usize,
+    last_token: i64,
+    consecutive_count: usize,
+}
+
+impl GreedyDecoder {
+    pub fn new(eos_id: i64) -> Self {
+        Self {
+            eos_id,
+            max_consecutive_repeats: DEFAULT_MAX_CONSECUTIVE_REPEATS,
+            last_token: -1,
+            consecutive_count: 0,
+        }
+    }
+
+    pub fn with_max_repeats(mut self, n: usize) -> Self {
+        self.max_consecutive_repeats = n;
+        self
+    }
+
+    /// Given logits for the last decoder position, pick the next token.
+    ///
+    /// Returns `Some(token_id)` to continue decoding, or `None` to stop
+    /// (EOS reached or repetition limit hit).
+    pub fn next_token(&mut self, logits: &[f32]) -> Option<i64> {
+        let token = argmax(logits) as i64;
+
+        if token == self.eos_id {
+            return None;
+        }
+
+        if token == self.last_token {
+            self.consecutive_count += 1;
+            if self.consecutive_count > self.max_consecutive_repeats {
+                log::warn!(
+                    "Greedy decode: token {} repeated {} consecutive times, stopping",
+                    token,
+                    self.consecutive_count
+                );
+                return None;
+            }
+        } else {
+            self.consecutive_count = 1;
+        }
+
+        self.last_token = token;
+        Some(token)
+    }
+}
+
+fn argmax(logits: &[f32]) -> usize {
+    let mut max_idx = 0;
+    let mut max_val = f32::NEG_INFINITY;
+    for (i, &v) in logits.iter().enumerate() {
+        if v > max_val {
+            max_val = v;
+            max_idx = i;
+        }
+    }
+    max_idx
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_argmax() {
+        assert_eq!(argmax(&[1.0, 3.0, 2.0]), 1);
+        assert_eq!(argmax(&[-1.0, -3.0, -0.5]), 2);
+        assert_eq!(argmax(&[5.0]), 0);
+    }
+
+    #[test]
+    fn test_eos_stops() {
+        let mut dec = GreedyDecoder::new(2);
+        // logits where token 2 (EOS) wins
+        assert_eq!(dec.next_token(&[0.0, 0.0, 10.0, 0.0]), None);
+    }
+
+    #[test]
+    fn test_normal_token() {
+        let mut dec = GreedyDecoder::new(2);
+        assert_eq!(dec.next_token(&[0.0, 10.0, 0.0, 0.0]), Some(1));
+    }
+
+    #[test]
+    fn test_repeat_limit() {
+        let mut dec = GreedyDecoder::new(99).with_max_repeats(3);
+        let logits = [0.0, 10.0, 0.0]; // always picks token 1
+        assert_eq!(dec.next_token(&logits), Some(1)); // count=1
+        assert_eq!(dec.next_token(&logits), Some(1)); // count=2
+        assert_eq!(dec.next_token(&logits), Some(1)); // count=3
+        assert_eq!(dec.next_token(&logits), None); // count=4 > 3 → stop
+    }
+
+    #[test]
+    fn test_repeat_resets_on_different_token() {
+        let mut dec = GreedyDecoder::new(99).with_max_repeats(3);
+        assert_eq!(dec.next_token(&[0.0, 10.0, 0.0]), Some(1)); // count=1
+        assert_eq!(dec.next_token(&[0.0, 10.0, 0.0]), Some(1)); // count=2
+        assert_eq!(dec.next_token(&[10.0, 0.0, 0.0]), Some(0)); // different, count=1
+        assert_eq!(dec.next_token(&[0.0, 10.0, 0.0]), Some(1)); // count=1
+        assert_eq!(dec.next_token(&[0.0, 10.0, 0.0]), Some(1)); // count=2
+        assert_eq!(dec.next_token(&[0.0, 10.0, 0.0]), Some(1)); // count=3
+        assert_eq!(dec.next_token(&[0.0, 10.0, 0.0]), None); // count=4 > 3 → stop
+    }
+
+    #[test]
+    fn test_nan_handling() {
+        let mut dec = GreedyDecoder::new(99);
+        // NaN logits — argmax uses `>` which is false for NaN, so index 0 wins
+        assert_eq!(dec.next_token(&[f32::NAN, f32::NAN, f32::NAN]), Some(0));
+    }
+}

--- a/src/decode/mod.rs
+++ b/src/decode/mod.rs
@@ -1,7 +1,9 @@
 mod ctc;
+mod greedy;
 mod sentencepiece;
 pub mod tokens;
 
 pub use ctc::{ctc_greedy_decode, CtcDecoderResult};
+pub use greedy::GreedyDecoder;
 pub use sentencepiece::sentencepiece_to_text;
 pub use tokens::{load_vocab, SymbolTable};

--- a/src/decode/mod.rs
+++ b/src/decode/mod.rs
@@ -5,5 +5,5 @@ pub mod tokens;
 
 pub use ctc::{ctc_greedy_decode, CtcDecoderResult};
 pub use greedy::GreedyDecoder;
-pub use sentencepiece::sentencepiece_to_text;
+pub use sentencepiece::{parse_byte_token, sentencepiece_to_text};
 pub use tokens::{load_vocab, SymbolTable};

--- a/src/decode/sentencepiece.rs
+++ b/src/decode/sentencepiece.rs
@@ -11,3 +11,84 @@ pub fn sentencepiece_to_text(tokens: &[&str]) -> String {
     // Clean up contraction spacing (e.g. "can 't" → "can't")
     text.replace(" '", "'")
 }
+
+/// Parse a byte-level BPE token like `<0xE5>` into its byte value.
+///
+/// SentencePiece tokenizers emit these for characters outside the base vocabulary
+/// (e.g. CJK characters are split into individual UTF-8 bytes).
+pub fn parse_byte_token(token: &str) -> Option<u8> {
+    if token.starts_with("<0x") && token.ends_with('>') && token.len() == 6 {
+        let hex = &token[3..5];
+        u8::from_str_radix(hex, 16).ok()
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_byte_token_valid() {
+        assert_eq!(parse_byte_token("<0xE5>"), Some(0xE5));
+        assert_eq!(parse_byte_token("<0xB0>"), Some(0xB0));
+        assert_eq!(parse_byte_token("<0xBC>"), Some(0xBC));
+        assert_eq!(parse_byte_token("<0x00>"), Some(0x00));
+        assert_eq!(parse_byte_token("<0xFF>"), Some(0xFF));
+    }
+
+    #[test]
+    fn test_parse_byte_token_invalid() {
+        assert_eq!(parse_byte_token("hello"), None);
+        assert_eq!(parse_byte_token("<|en|>"), None);
+        assert_eq!(parse_byte_token("<0x>"), None);
+        assert_eq!(parse_byte_token("<0xEE"), None); // missing >
+        assert_eq!(parse_byte_token("<0xGG>"), None); // invalid hex
+    }
+
+    #[test]
+    fn test_byte_tokens_reassemble_chinese() {
+        // 尼 = E5 B0 BC, 豪 = E8 B1 AA
+        // Simulates what Cohere's decode_ids does with byte tokens
+        let tokens = vec!["<0xE5>", "<0xB0>", "<0xBC>", "豪", "。"];
+        let mut bytes: Vec<u8> = Vec::new();
+        for token in &tokens {
+            if let Some(byte_val) = parse_byte_token(token) {
+                bytes.push(byte_val);
+            } else {
+                bytes.extend(token.as_bytes());
+            }
+        }
+        let text = String::from_utf8_lossy(&bytes);
+        assert_eq!(text, "尼豪。");
+    }
+
+    #[test]
+    fn test_byte_tokens_full_cjk_sequence() {
+        // 你好 = E4 BD A0 E5 A5 BD
+        let tokens = vec!["<0xE4>", "<0xBD>", "<0xA0>", "<0xE5>", "<0xA5>", "<0xBD>"];
+        let mut bytes: Vec<u8> = Vec::new();
+        for token in &tokens {
+            if let Some(byte_val) = parse_byte_token(token) {
+                bytes.push(byte_val);
+            } else {
+                bytes.extend(token.as_bytes());
+            }
+        }
+        let text = String::from_utf8_lossy(&bytes);
+        assert_eq!(text, "你好");
+    }
+
+    #[test]
+    fn test_sentencepiece_to_text_basic() {
+        let tokens = vec![" Hello", " world"];
+        assert_eq!(sentencepiece_to_text(&tokens), "Hello world");
+    }
+
+    #[test]
+    fn test_sentencepiece_to_text_contractions() {
+        let tokens = vec![" can", " 't"];
+        assert_eq!(sentencepiece_to_text(&tokens), "can't");
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -36,14 +36,14 @@ impl From<serde_json::Error> for TranscribeError {
     }
 }
 
-#[cfg(feature = "onnx")]
+#[cfg(any(feature = "onnx", feature = "vad-silero"))]
 impl From<ort::Error> for TranscribeError {
     fn from(e: ort::Error) -> Self {
         TranscribeError::Inference(e.to_string())
     }
 }
 
-#[cfg(feature = "audio-features")]
+#[cfg(any(feature = "audio-features", feature = "vad-silero"))]
 impl From<ndarray::ShapeError> for TranscribeError {
     fn from(e: ndarray::ShapeError) -> Self {
         TranscribeError::Inference(e.to_string())

--- a/src/features/mel.rs
+++ b/src/features/mel.rs
@@ -79,7 +79,7 @@ fn compute_fbank(samples: &[f32], config: &MelConfig, sr: f32, f_max: f32) -> Ar
             1 + (samples.len() - frame_length) / frame_shift
         }
     } else {
-        (samples.len() + frame_shift - 1) / frame_shift
+        samples.len().div_ceil(frame_shift)
     };
 
     if num_frames == 0 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,6 +102,9 @@ pub mod features;
 #[cfg(feature = "onnx")]
 pub mod onnx;
 
+pub mod transcriber;
+pub mod vad;
+
 #[cfg(feature = "whisper-cpp")]
 pub mod whisper_cpp;
 #[cfg(feature = "whisperfile")]
@@ -174,7 +177,7 @@ pub trait SpeechModel: Send {
 ///
 /// Contains both the full transcribed text and detailed timing information
 /// for individual segments within the audio.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct TranscriptionResult {
     /// The complete transcribed text from the audio
     pub text: String,
@@ -186,7 +189,7 @@ pub struct TranscriptionResult {
 ///
 /// Represents a portion of the transcribed audio with start and end timestamps
 /// and the corresponding text content.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct TranscriptionSegment {
     /// Start time of the segment in seconds
     pub start: f32,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,8 @@
 //! - **Timestamped Results**: Detailed timing information for transcribed segments
 //! - **Unified API**: `SpeechModel` trait for all local engines
 //! - **Hardware Acceleration**: GPU support for ORT engines (`ort-cuda`, `ort-rocm`,
-//!   `ort-directml`) and whisper.cpp (Metal/Vulkan) via the [`accel`] module
+//!   `ort-directml`, `ort-coreml`, `ort-webgpu`) and whisper.cpp (Metal/Vulkan)
+//!   via the [`accel`] module
 //!
 //! ## Backend Categories
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 //!
 //! ## Features
 //!
-//! - **ONNX Models**: SenseVoice, GigaAM, Parakeet, Moonshine (requires `onnx` feature)
+//! - **ONNX Models**: SenseVoice, GigaAM, Parakeet, Moonshine (requires `onnx` feature); Qwen3-ASR (requires `qwen3` feature)
 //! - **Whisper**: OpenAI Whisper via GGML (requires `whisper-cpp` feature)
 //! - **Whisperfile**: Mozilla Whisperfile server (requires `whisperfile` feature)
 //! - **Remote**: OpenAI API (requires `openai` feature)
@@ -90,9 +90,9 @@ pub mod accel;
 pub mod audio;
 pub mod error;
 pub use accel::{
-    get_ort_accelerator, get_whisper_accelerator, get_whisper_gpu_device, set_ort_accelerator,
-    set_whisper_accelerator, set_whisper_gpu_device, OrtAccelerator, WhisperAccelerator,
-    GPU_DEVICE_AUTO,
+    get_decoder_gpu, get_ort_accelerator, get_whisper_accelerator, get_whisper_gpu_device,
+    set_decoder_gpu, set_ort_accelerator, set_whisper_accelerator, set_whisper_gpu_device,
+    OrtAccelerator, WhisperAccelerator, GPU_DEVICE_AUTO,
 };
 pub use error::TranscribeError;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,6 +145,15 @@ pub struct TranscribeOptions {
     pub language: Option<String>,
     /// Whether to translate the output to English (only supported by some engines).
     pub translate: bool,
+    /// Leading silence padding in milliseconds prepended before audio.
+    /// Some models (e.g. Parakeet) can drop the beginning of audio due to
+    /// mel spectrogram windowing. Set to `Some(0)` to explicitly disable.
+    /// When `None`, each engine applies its own default (e.g. Parakeet uses 250 ms).
+    pub leading_silence_ms: Option<u32>,
+    /// Trailing silence padding in milliseconds appended after audio.
+    /// Set to `Some(0)` to explicitly disable.
+    /// When `None`, each engine applies its own default (typically 0 ms).
+    pub trailing_silence_ms: Option<u32>,
 }
 
 /// Unified interface for speech-to-text models.
@@ -152,16 +161,78 @@ pub struct TranscribeOptions {
 /// Each model implements this trait to provide a common transcription API.
 /// Model-specific parameters are exposed via a separate `transcribe_with()` method
 /// on the concrete type.
+///
+/// Engines implement [`transcribe_raw`](SpeechModel::transcribe_raw) with their
+/// inference logic. The default [`transcribe`](SpeechModel::transcribe) method
+/// handles silence padding and timestamp adjustment automatically.
 pub trait SpeechModel: Send {
     /// Report this model's capabilities.
     fn capabilities(&self) -> ModelCapabilities;
 
-    /// Transcribe audio samples (16 kHz, mono, f32 in [-1, 1]).
-    fn transcribe(
+    /// Default leading silence in milliseconds for this engine.
+    ///
+    /// Override to set a non-zero default. For example, Parakeet returns 250
+    /// because its mel spectrogram preprocessor attenuates the start of audio.
+    fn default_leading_silence_ms(&self) -> u32 {
+        0
+    }
+
+    /// Default trailing silence in milliseconds for this engine.
+    fn default_trailing_silence_ms(&self) -> u32 {
+        0
+    }
+
+    /// Raw transcription — engines implement this with their inference logic.
+    ///
+    /// Callers should prefer [`transcribe`](SpeechModel::transcribe) which
+    /// handles silence padding automatically. Use this method directly only
+    /// when managing padding yourself (e.g. chunked transcription).
+    fn transcribe_raw(
         &mut self,
         samples: &[f32],
         options: &TranscribeOptions,
     ) -> Result<TranscriptionResult, TranscribeError>;
+
+    /// Transcribe audio samples (16 kHz, mono, f32 in [-1, 1]).
+    ///
+    /// Prepends/appends silence padding based on [`TranscribeOptions`] (or
+    /// engine defaults), runs [`transcribe_raw`](SpeechModel::transcribe_raw),
+    /// then adjusts segment timestamps to account for the leading padding.
+    fn transcribe(
+        &mut self,
+        samples: &[f32],
+        options: &TranscribeOptions,
+    ) -> Result<TranscriptionResult, TranscribeError> {
+        let lead_ms = options
+            .leading_silence_ms
+            .unwrap_or_else(|| self.default_leading_silence_ms());
+        let trail_ms = options
+            .trailing_silence_ms
+            .unwrap_or_else(|| self.default_trailing_silence_ms());
+
+        // Fast path: no padding needed.
+        if lead_ms == 0 && trail_ms == 0 {
+            return self.transcribe_raw(samples, options);
+        }
+
+        let mut buf = if lead_ms > 0 {
+            audio::prepend_silence(samples, lead_ms)
+        } else {
+            samples.to_vec()
+        };
+        if trail_ms > 0 {
+            let trail_len = trail_ms as usize * audio::SAMPLES_PER_MS;
+            buf.resize(buf.len() + trail_len, 0.0);
+        }
+
+        let mut result = self.transcribe_raw(&buf, options)?;
+
+        if lead_ms > 0 {
+            result.offset_timestamps(-(lead_ms as f32 / 1000.0));
+        }
+
+        Ok(result)
+    }
 
     /// Transcribe a WAV file (16 kHz, 16-bit, mono).
     fn transcribe_file(
@@ -184,6 +255,21 @@ pub struct TranscriptionResult {
     pub text: String,
     /// Individual segments with timing information
     pub segments: Option<Vec<TranscriptionSegment>>,
+}
+
+impl TranscriptionResult {
+    /// Shift all segment timestamps by `offset_secs`, clamping to zero.
+    ///
+    /// Use a negative offset to compensate for leading silence padding,
+    /// or a positive offset to place a chunk within a longer audio stream.
+    pub fn offset_timestamps(&mut self, offset_secs: f32) {
+        if let Some(segs) = &mut self.segments {
+            for seg in segs {
+                seg.start = (seg.start + offset_secs).max(0.0);
+                seg.end = (seg.end + offset_secs).max(0.0);
+            }
+        }
+    }
 }
 
 /// A single transcribed segment with timing information.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,8 +89,9 @@ pub mod accel;
 pub mod audio;
 pub mod error;
 pub use accel::{
-    get_ort_accelerator, get_whisper_accelerator, set_ort_accelerator, set_whisper_accelerator,
-    OrtAccelerator, WhisperAccelerator,
+    get_ort_accelerator, get_whisper_accelerator, get_whisper_gpu_device, set_ort_accelerator,
+    set_whisper_accelerator, set_whisper_gpu_device, OrtAccelerator, WhisperAccelerator,
+    GPU_DEVICE_AUTO,
 };
 pub use error::TranscribeError;
 

--- a/src/onnx/canary/decoder.rs
+++ b/src/onnx/canary/decoder.rs
@@ -4,6 +4,7 @@ use ort::value::ValueType;
 use ort::value::{DynValue, Tensor};
 
 use super::vocab::Vocab;
+use crate::decode::GreedyDecoder;
 use crate::TranscribeError;
 
 pub fn decode_autoregressive(
@@ -26,6 +27,7 @@ pub fn decode_autoregressive(
     let mut decoder_mems: DynValue = Tensor::from_array(empty_cache)?.into_dyn();
 
     let eos_id = vocab.eos_token_id();
+    let mut greedy = GreedyDecoder::new(eos_id);
     let mut all_tokens = prompt_tokens;
 
     // Limit decode steps so total tokens (prompt + generated) stays within
@@ -58,7 +60,7 @@ pub fn decode_autoregressive(
         ])?;
 
         // Extract logits in a scoped borrow, then release before remove()
-        let next_token = {
+        let last_logits = {
             let (logits_shape, logits_data) =
                 outputs["logits"].try_extract_tensor::<f32>().map_err(|e| {
                     TranscribeError::Inference(format!("Failed to extract logits: {e}"))
@@ -68,17 +70,18 @@ pub fn decode_autoregressive(
             let vocab_size = logits_shape[2] as usize;
 
             let last_step_offset = (seq_len - 1) * vocab_size;
-            let last_logits = &logits_data[last_step_offset..last_step_offset + vocab_size];
+            logits_data[last_step_offset..last_step_offset + vocab_size].to_vec()
+        };
 
-            argmax(last_logits) as i64
+        let next_token = match greedy.next_token(&last_logits) {
+            Some(t) => t,
+            None => {
+                log::debug!("Decode stopped at step {}", step);
+                break;
+            }
         };
 
         log::debug!("Step {}: predicted token ID {}", step, next_token);
-
-        if next_token == eos_id {
-            log::debug!("EOS token reached at step {}", step);
-            break;
-        }
 
         all_tokens.push(next_token);
 
@@ -127,29 +130,5 @@ fn extract_decoder_mems_shape(decoder: &Session) -> Result<(usize, usize), Trans
             "decoder_mems input is not a tensor: {:?}",
             other
         ))),
-    }
-}
-
-fn argmax(slice: &[f32]) -> usize {
-    let mut max_idx = 0;
-    let mut max_val = f32::NEG_INFINITY;
-    for (i, &v) in slice.iter().enumerate() {
-        if v > max_val {
-            max_val = v;
-            max_idx = i;
-        }
-    }
-    max_idx
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_argmax() {
-        assert_eq!(argmax(&[1.0, 3.0, 2.0]), 1);
-        assert_eq!(argmax(&[-1.0, -3.0, -0.5]), 2);
-        assert_eq!(argmax(&[5.0]), 0);
     }
 }

--- a/src/onnx/canary/decoder.rs
+++ b/src/onnx/canary/decoder.rs
@@ -106,7 +106,7 @@ fn extract_decoder_mems_shape(decoder: &Session) -> Result<(usize, usize), Trans
 
     match mems_input.dtype() {
         ValueType::Tensor { shape, .. } => {
-            let dims: &[i64] = &shape;
+            let dims: &[i64] = shape;
             if dims.len() != 4 {
                 return Err(TranscribeError::Inference(format!(
                     "Expected 4D decoder_mems, got {}D",

--- a/src/onnx/canary/mod.rs
+++ b/src/onnx/canary/mod.rs
@@ -271,7 +271,7 @@ impl SpeechModel for CanaryModel {
         }
     }
 
-    fn transcribe(
+    fn transcribe_raw(
         &mut self,
         samples: &[f32],
         options: &TranscribeOptions,

--- a/src/onnx/cohere/mod.rs
+++ b/src/onnx/cohere/mod.rs
@@ -10,7 +10,7 @@ use ort::session::SessionInputValue;
 use ort::value::DynValue;
 
 use super::{session, Quantization};
-use crate::decode::{load_vocab, sentencepiece_to_text, GreedyDecoder};
+use crate::decode::{load_vocab, parse_byte_token, GreedyDecoder};
 use crate::{
     ModelCapabilities, SpeechModel, TranscribeError, TranscribeOptions, TranscriptionResult,
 };
@@ -294,7 +294,7 @@ impl CohereModel {
     }
 
     fn decode_ids(&self, token_ids: &[i64]) -> String {
-        let pieces = token_ids
+        let tokens: Vec<&str> = token_ids
             .iter()
             .filter_map(|&id| self.vocab.get(id as usize))
             .filter(|token| {
@@ -304,9 +304,24 @@ impl CohereModel {
                     && token.as_str() != "<pad>"
             })
             .map(|token| token.as_str())
-            .collect::<Vec<_>>();
+            .collect();
 
-        sentencepiece_to_text(&pieces)
+        // Handle byte-level BPE tokens (<0xNN>) by collecting into a byte buffer.
+        // SentencePiece tokenizers emit these for characters outside the base vocabulary
+        // (e.g. CJK characters are split into individual UTF-8 bytes).
+        let mut bytes: Vec<u8> = Vec::new();
+        for token in &tokens {
+            if let Some(byte_val) = parse_byte_token(token) {
+                bytes.push(byte_val);
+            } else {
+                bytes.extend(token.as_bytes());
+            }
+        }
+
+        let text = String::from_utf8_lossy(&bytes);
+        let text = text.trim();
+        // Clean up contraction spacing (e.g. "can 't" → "can't")
+        text.replace(" '", "'")
     }
 
     fn decoder_input_name(&self, preferred: &str, fallbacks: &[&str]) -> String {

--- a/src/onnx/cohere/mod.rs
+++ b/src/onnx/cohere/mod.rs
@@ -1,0 +1,392 @@
+//! Cohere ONNX encoder/decoder transcription engine.
+
+use std::borrow::Cow;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use ndarray::{Array2, ArrayD, Ix3, IxDyn};
+use ort::session::Session;
+use ort::session::SessionInputValue;
+use ort::value::DynValue;
+
+use super::{session, Quantization};
+use crate::decode::{load_vocab, sentencepiece_to_text, GreedyDecoder};
+use crate::{
+    ModelCapabilities, SpeechModel, TranscribeError, TranscribeOptions, TranscriptionResult,
+};
+
+const SAMPLE_RATE: u32 = 16000;
+const NUM_DECODER_LAYERS: usize = 8;
+const NUM_HEADS: usize = 8;
+const HEAD_DIM: usize = 128;
+const MAX_SEQ_LEN: usize = 1024;
+const DEFAULT_MAX_NEW_TOKENS: usize = 512;
+
+const CAPABILITIES: ModelCapabilities = ModelCapabilities {
+    name: "Cohere",
+    engine_id: "cohere",
+    sample_rate: SAMPLE_RATE,
+    languages: &["en"],
+    supports_timestamps: false,
+    supports_translation: false,
+    supports_streaming: false,
+};
+
+#[derive(Debug, Clone, Default)]
+pub struct CohereParams {
+    /// Language hint for prompt tokens. Defaults to English.
+    pub language: Option<String>,
+    /// Translation is currently ignored by the local ONNX export.
+    pub translate: bool,
+    /// Maximum number of autoregressive tokens to emit per chunk.
+    pub max_new_tokens: Option<usize>,
+}
+
+pub struct CohereModel {
+    encoder: Session,
+    decoder: Session,
+    vocab: Vec<String>,
+    token_to_id: HashMap<String, i64>,
+    eos_id: i64,
+    encoder_input_name: String,
+    decoder_input_names: Vec<String>,
+}
+
+impl CohereModel {
+    pub fn load(model_dir: &Path, quantization: &Quantization) -> Result<Self, TranscribeError> {
+        let encoder_path = resolve_model_file(
+            model_dir,
+            encoder_candidates(quantization),
+            "cohere-encoder.int4.onnx",
+        )?;
+        let decoder_path = resolve_model_file(
+            model_dir,
+            decoder_candidates(quantization),
+            "cohere-decoder.int4.onnx",
+        )?;
+        let vocab_path =
+            resolve_model_file(model_dir, &["tokens.txt", "vocabulary.txt"], "tokens.txt")?;
+
+        log::info!("Loading Cohere encoder from {:?}...", encoder_path);
+        let encoder = session::create_session(&encoder_path)?;
+
+        log::info!("Loading Cohere decoder from {:?}...", decoder_path);
+        let decoder = session::create_session(&decoder_path)?;
+
+        let (vocab, _) = load_vocab(&vocab_path)?;
+        let token_to_id = vocab
+            .iter()
+            .enumerate()
+            .filter(|(_, token)| !token.is_empty())
+            .map(|(id, token)| (token.clone(), id as i64))
+            .collect::<HashMap<_, _>>();
+
+        let encoder_input_name = encoder
+            .inputs()
+            .first()
+            .map(|input| input.name().to_string())
+            .unwrap_or_else(|| "audio".to_string());
+        let decoder_input_names = decoder
+            .inputs()
+            .iter()
+            .map(|input| input.name().to_string())
+            .collect::<Vec<_>>();
+        let eos_id = token_to_id.get("<|endoftext|>").copied().unwrap_or(3);
+
+        Ok(Self {
+            encoder,
+            decoder,
+            vocab,
+            token_to_id,
+            eos_id,
+            encoder_input_name,
+            decoder_input_names,
+        })
+    }
+
+    pub fn transcribe_with(
+        &mut self,
+        samples: &[f32],
+        params: &CohereParams,
+    ) -> Result<TranscriptionResult, TranscribeError> {
+        if params.translate {
+            log::warn!(
+                "Cohere ONNX export does not support local translation; ignoring translate=true"
+            );
+        }
+
+        if samples.is_empty() {
+            return Ok(TranscriptionResult {
+                text: String::new(),
+                segments: None,
+            });
+        }
+
+        let prompt_ids = self.build_prompt_ids(params.language.as_deref());
+        let max_new_tokens = params
+            .max_new_tokens
+            .unwrap_or(DEFAULT_MAX_NEW_TOKENS)
+            .min(MAX_SEQ_LEN.saturating_sub(prompt_ids.len()));
+
+        let text = self.transcribe_chunk(samples, &prompt_ids, max_new_tokens)?;
+
+        Ok(TranscriptionResult {
+            text,
+            segments: None,
+        })
+    }
+
+    fn transcribe_chunk(
+        &mut self,
+        samples: &[f32],
+        prompt_ids: &[i64],
+        max_new_tokens: usize,
+    ) -> Result<String, TranscribeError> {
+        let audio = Array2::from_shape_vec((1, samples.len()), samples.to_vec())?.into_dyn();
+        let (cross_k, cross_v) = {
+            let mut encoder_outputs = self.encoder.run(vec![(
+                Cow::Owned(self.encoder_input_name.clone()),
+                ort::value::Value::from_array(audio)?.into_dyn(),
+            )])?;
+            let cross_k = remove_output(&mut encoder_outputs, "n_layer_cross_k")?;
+            let cross_v = remove_output(&mut encoder_outputs, "n_layer_cross_v")?;
+            (cross_k, cross_v)
+        };
+
+        // Resolve decoder input names once before the loop.
+        let token_name = self.decoder_input_name("tokens", &["input_ids"]);
+        let self_k_name = self.decoder_input_name(
+            "in_n_layer_self_k_cache",
+            &["past_key_values", "past_key_values.key"],
+        );
+        let self_v_name =
+            self.decoder_input_name("in_n_layer_self_v_cache", &["past_key_values.value"]);
+        let cross_k_name = self.decoder_input_name("n_layer_cross_k", &["encoder_kv_cache.key"]);
+        let cross_v_name = self.decoder_input_name("n_layer_cross_v", &["encoder_kv_cache.value"]);
+        let offset_name = self.decoder_input_name("offset", &["cache_position"]);
+
+        let mut greedy = GreedyDecoder::new(self.eos_id);
+        let mut generated_ids: Vec<i64> = Vec::new();
+        let mut current_tokens = prompt_ids.to_vec();
+        let mut offset = 0_i64;
+
+        let mut self_k_cache: DynValue =
+            ort::value::Value::from_array(ArrayD::<f32>::zeros(IxDyn(&[
+                NUM_DECODER_LAYERS,
+                1,
+                NUM_HEADS,
+                MAX_SEQ_LEN,
+                HEAD_DIM,
+            ])))?
+            .into_dyn();
+        let mut self_v_cache: DynValue =
+            ort::value::Value::from_array(ArrayD::<f32>::zeros(IxDyn(&[
+                NUM_DECODER_LAYERS,
+                1,
+                NUM_HEADS,
+                MAX_SEQ_LEN,
+                HEAD_DIM,
+            ])))?
+            .into_dyn();
+
+        for _ in 0..max_new_tokens {
+            let n_tokens = current_tokens.len();
+            let tokens = Array2::from_shape_vec((1, n_tokens), current_tokens.clone())?.into_dyn();
+            let offset_tensor = ndarray::arr0(offset).into_dyn();
+
+            // Build inputs: move self caches (replaced from output below),
+            // borrow cross caches (constant across the loop).
+            let inputs: Vec<(Cow<str>, SessionInputValue)> = vec![
+                (
+                    Cow::Borrowed(token_name.as_str()),
+                    SessionInputValue::from(ort::value::Value::from_array(tokens)?),
+                ),
+                (
+                    Cow::Borrowed(self_k_name.as_str()),
+                    SessionInputValue::from(self_k_cache),
+                ),
+                (
+                    Cow::Borrowed(self_v_name.as_str()),
+                    SessionInputValue::from(self_v_cache),
+                ),
+                (
+                    Cow::Borrowed(cross_k_name.as_str()),
+                    SessionInputValue::from(&cross_k),
+                ),
+                (
+                    Cow::Borrowed(cross_v_name.as_str()),
+                    SessionInputValue::from(&cross_v),
+                ),
+                (
+                    Cow::Borrowed(offset_name.as_str()),
+                    SessionInputValue::from(ort::value::Value::from_array(offset_tensor)?),
+                ),
+            ];
+
+            let mut decoder_outputs = self.decoder.run(inputs)?;
+
+            // Extract last-position logits in a scoped borrow, then release before remove().
+            let last_logits = {
+                let logits = decoder_outputs
+                    .get("logits")
+                    .ok_or_else(|| TranscribeError::Inference("Missing logits output".into()))?
+                    .try_extract_array::<f32>()?;
+                let logits = logits
+                    .into_dimensionality::<Ix3>()
+                    .map_err(|e| TranscribeError::Inference(e.to_string()))?;
+                let last_pos = logits.shape()[1].saturating_sub(1);
+                logits.slice(ndarray::s![0, last_pos, ..]).to_vec()
+            };
+
+            let next_token = match greedy.next_token(&last_logits) {
+                Some(t) => t,
+                None => break,
+            };
+
+            generated_ids.push(next_token);
+            current_tokens = vec![next_token];
+            offset += n_tokens as i64;
+
+            // Take KV caches directly from outputs (no data copy).
+            self_k_cache = remove_output(&mut decoder_outputs, "out_n_layer_self_k_cache")?;
+            self_v_cache = remove_output(&mut decoder_outputs, "out_n_layer_self_v_cache")?;
+        }
+
+        Ok(self.decode_ids(&generated_ids))
+    }
+
+    fn build_prompt_ids(&self, language: Option<&str>) -> Vec<i64> {
+        let requested = match language.unwrap_or("en") {
+            "auto" => "en",
+            "zh-Hans" | "zh-Hant" => "zh",
+            other => other,
+        };
+
+        let language_token = format!("<|{}|>", requested);
+        let chosen_language = if self.token_to_id.contains_key(&language_token) {
+            requested
+        } else {
+            "en"
+        };
+
+        [
+            "<|startofcontext|>".to_string(),
+            "<|startoftranscript|>".to_string(),
+            "<|emo:undefined|>".to_string(),
+            format!("<|{}|>", chosen_language),
+            format!("<|{}|>", chosen_language),
+            "<|pnc|>".to_string(),
+            "<|noitn|>".to_string(),
+            "<|notimestamp|>".to_string(),
+            "<|nodiarize|>".to_string(),
+        ]
+        .iter()
+        .filter_map(|token| {
+            let id = self.token_to_id.get(token).copied();
+            if id.is_none() {
+                log::warn!("Prompt token not found in vocab: {}", token);
+            }
+            id
+        })
+        .collect()
+    }
+
+    fn decode_ids(&self, token_ids: &[i64]) -> String {
+        let pieces = token_ids
+            .iter()
+            .filter_map(|&id| self.vocab.get(id as usize))
+            .filter(|token| {
+                !token.trim().is_empty()
+                    && !token.starts_with("<|")
+                    && token.as_str() != "<unk>"
+                    && token.as_str() != "<pad>"
+            })
+            .map(|token| token.as_str())
+            .collect::<Vec<_>>();
+
+        sentencepiece_to_text(&pieces)
+    }
+
+    fn decoder_input_name(&self, preferred: &str, fallbacks: &[&str]) -> String {
+        if self
+            .decoder_input_names
+            .iter()
+            .any(|name| name == preferred)
+        {
+            return preferred.to_string();
+        }
+
+        for fallback in fallbacks {
+            if self.decoder_input_names.iter().any(|name| name == fallback) {
+                return (*fallback).to_string();
+            }
+        }
+
+        preferred.to_string()
+    }
+}
+
+impl SpeechModel for CohereModel {
+    fn capabilities(&self) -> ModelCapabilities {
+        CAPABILITIES
+    }
+
+    fn transcribe_raw(
+        &mut self,
+        samples: &[f32],
+        options: &TranscribeOptions,
+    ) -> Result<TranscriptionResult, TranscribeError> {
+        self.transcribe_with(
+            samples,
+            &CohereParams {
+                language: options.language.clone(),
+                translate: options.translate,
+                max_new_tokens: None,
+            },
+        )
+    }
+}
+
+fn resolve_model_file(
+    model_dir: &Path,
+    candidates: &[&str],
+    missing_name: &str,
+) -> Result<PathBuf, TranscribeError> {
+    for base_dir in [model_dir.to_path_buf(), model_dir.join("onnx")] {
+        for candidate in candidates {
+            let path = base_dir.join(candidate);
+            if path.exists() {
+                return Ok(path);
+            }
+        }
+    }
+
+    Err(TranscribeError::ModelNotFound(model_dir.join(missing_name)))
+}
+
+fn encoder_candidates(quantization: &Quantization) -> &'static [&'static str] {
+    match quantization {
+        Quantization::Int4 => &["cohere-encoder.int4.onnx", "encoder_model.int4.onnx"],
+        Quantization::Int8 => &["cohere-encoder.int8.onnx", "encoder_model.int8.onnx"],
+        Quantization::FP16 => &["cohere-encoder.fp16.onnx", "encoder_model_fp16.onnx"],
+        Quantization::FP32 => &["cohere-encoder.onnx", "encoder_model.onnx"],
+    }
+}
+
+fn decoder_candidates(quantization: &Quantization) -> &'static [&'static str] {
+    match quantization {
+        Quantization::Int4 => &["cohere-decoder.int4.onnx", "decoder_model_merged.int4.onnx"],
+        Quantization::Int8 => &["cohere-decoder.int8.onnx", "decoder_model_merged.int8.onnx"],
+        Quantization::FP16 => &["cohere-decoder.fp16.onnx", "decoder_model_merged_fp16.onnx"],
+        Quantization::FP32 => &["cohere-decoder.onnx", "decoder_model_merged.onnx"],
+    }
+}
+
+fn remove_output(
+    outputs: &mut ort::session::SessionOutputs,
+    name: &str,
+) -> Result<DynValue, TranscribeError> {
+    outputs
+        .remove(name)
+        .ok_or_else(|| TranscribeError::Inference(format!("Missing expected output: {name}")))
+}

--- a/src/onnx/cohere/mod.rs
+++ b/src/onnx/cohere/mod.rs
@@ -26,7 +26,9 @@ const CAPABILITIES: ModelCapabilities = ModelCapabilities {
     name: "Cohere",
     engine_id: "cohere",
     sample_rate: SAMPLE_RATE,
-    languages: &["en"],
+    languages: &[
+        "en", "de", "fr", "it", "es", "pt", "el", "nl", "pl", "ar", "vi", "zh", "ja", "ko",
+    ],
     supports_timestamps: false,
     supports_translation: false,
     supports_streaming: false,

--- a/src/onnx/gigaam/mod.rs
+++ b/src/onnx/gigaam/mod.rs
@@ -166,7 +166,7 @@ impl SpeechModel for GigaAMModel {
         CAPABILITIES
     }
 
-    fn transcribe(
+    fn transcribe_raw(
         &mut self,
         samples: &[f32],
         _options: &TranscribeOptions,

--- a/src/onnx/mod.rs
+++ b/src/onnx/mod.rs
@@ -17,9 +17,11 @@ pub enum Quantization {
     FP32,
     FP16,
     Int8,
+    Int4,
 }
 
 pub mod canary;
+pub mod cohere;
 pub mod gigaam;
 pub mod moonshine;
 pub mod parakeet;

--- a/src/onnx/mod.rs
+++ b/src/onnx/mod.rs
@@ -26,3 +26,11 @@ pub mod gigaam;
 pub mod moonshine;
 pub mod parakeet;
 pub mod sense_voice;
+
+// qwen3 has a separate per-engine feature flag ("qwen3") rather than being enabled
+// unconditionally when "onnx" is active, because its ONNX export format (three session
+// files + embed_tokens.bin) and decode loop differ substantially from the other engines.
+// Gating it separately keeps the default "onnx" build lean until the model artifacts are
+// available.  The other engines share enough structure that separate flags add no value.
+#[cfg(feature = "qwen3")]
+pub mod qwen3;

--- a/src/onnx/moonshine/mod.rs
+++ b/src/onnx/moonshine/mod.rs
@@ -7,8 +7,9 @@ pub use streaming::{MoonshineStreamingParams, StreamingConfig, StreamingModel, S
 pub const SAMPLE_RATE: u32 = 16000;
 
 /// Moonshine model variant.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum MoonshineVariant {
+    #[default]
     Tiny,
     TinyAr,
     TinyZh,
@@ -61,11 +62,5 @@ impl MoonshineVariant {
             | MoonshineVariant::TinyKo
             | MoonshineVariant::TinyVi => 13,
         }
-    }
-}
-
-impl Default for MoonshineVariant {
-    fn default() -> Self {
-        MoonshineVariant::Tiny
     }
 }

--- a/src/onnx/moonshine/model.rs
+++ b/src/onnx/moonshine/model.rs
@@ -7,6 +7,7 @@ use std::fs::File;
 use std::io::BufReader;
 use std::path::Path;
 
+use crate::decode::GreedyDecoder;
 use crate::onnx::session;
 use crate::onnx::Quantization;
 use crate::{
@@ -179,6 +180,7 @@ impl MoonshineModel {
 
         let encoder_hidden_states = self.encode(&audio)?;
 
+        let mut greedy = GreedyDecoder::new(EOS_TOKEN_ID);
         let mut cache = KVCache::new(&self.variant);
         let mut tokens: Vec<i64> = vec![DECODER_START_TOKEN_ID];
         let mut input_ids = Array2::from_shape_vec((1, 1), vec![DECODER_START_TOKEN_ID])?;
@@ -232,18 +234,13 @@ impl MoonshineModel {
             let last_pos = logits_shape[1] - 1;
 
             let last_logits = logits.slice(ndarray::s![0, last_pos, ..]);
-            let next_token = last_logits
-                .iter()
-                .enumerate()
-                .max_by(|(_, a), (_, b)| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal))
-                .map(|(idx, _)| idx as i64)
-                .unwrap_or(EOS_TOKEN_ID);
+
+            let next_token = match greedy.next_token(last_logits.as_slice().unwrap_or(&[])) {
+                Some(t) => t,
+                None => break,
+            };
 
             tokens.push(next_token);
-
-            if next_token == EOS_TOKEN_ID {
-                break;
-            }
 
             input_ids = Array2::from_shape_vec((1, 1), vec![next_token])?;
             cache.update_from_outputs(&outputs, use_cache_branch)?;

--- a/src/onnx/moonshine/model.rs
+++ b/src/onnx/moonshine/model.rs
@@ -262,7 +262,7 @@ impl SpeechModel for MoonshineModel {
         CAPABILITIES
     }
 
-    fn transcribe(
+    fn transcribe_raw(
         &mut self,
         samples: &[f32],
         _options: &TranscribeOptions,

--- a/src/onnx/moonshine/model.rs
+++ b/src/onnx/moonshine/model.rs
@@ -7,7 +7,7 @@ use std::fs::File;
 use std::io::BufReader;
 use std::path::Path;
 
-use crate::decode::GreedyDecoder;
+use crate::decode::{parse_byte_token, GreedyDecoder};
 use crate::onnx::session;
 use crate::onnx::Quantization;
 use crate::{
@@ -417,7 +417,7 @@ impl MoonshineTokenizer {
         let mut bytes: Vec<u8> = Vec::new();
 
         for token in &tokens {
-            if let Some(byte_val) = Self::parse_byte_token(token) {
+            if let Some(byte_val) = parse_byte_token(token) {
                 bytes.push(byte_val);
             } else {
                 let decoded = token.replace('\u{2581}', " ");
@@ -429,14 +429,5 @@ impl MoonshineTokenizer {
         let text = text.strip_prefix(' ').unwrap_or(&text);
 
         Ok(text.to_string())
-    }
-
-    fn parse_byte_token(token: &str) -> Option<u8> {
-        if token.starts_with("<0x") && token.ends_with('>') && token.len() == 6 {
-            let hex = &token[3..5];
-            u8::from_str_radix(hex, 16).ok()
-        } else {
-            None
-        }
     }
 }

--- a/src/onnx/moonshine/model.rs
+++ b/src/onnx/moonshine/model.rs
@@ -168,7 +168,7 @@ impl MoonshineModel {
         max_length: usize,
     ) -> Result<Vec<i64>, TranscribeError> {
         let audio_duration = samples.len() as f32 / SAMPLE_RATE as f32;
-        if audio_duration < 0.1 || audio_duration > 64.0 {
+        if !(0.1..=64.0).contains(&audio_duration) {
             return Err(TranscribeError::Inference(format!(
                 "Audio duration must be between 0.1s and 64s, got {:.2}s",
                 audio_duration

--- a/src/onnx/moonshine/streaming.rs
+++ b/src/onnx/moonshine/streaming.rs
@@ -794,7 +794,7 @@ impl SpeechModel for StreamingModel {
         STREAMING_CAPABILITIES
     }
 
-    fn transcribe(
+    fn transcribe_raw(
         &mut self,
         samples: &[f32],
         _options: &TranscribeOptions,

--- a/src/onnx/moonshine/streaming.rs
+++ b/src/onnx/moonshine/streaming.rs
@@ -7,6 +7,7 @@ use std::fs::File;
 use std::io::Read;
 use std::path::Path;
 
+use crate::decode::GreedyDecoder;
 use crate::onnx::session;
 use crate::onnx::Quantization;
 use crate::{
@@ -293,6 +294,7 @@ impl StreamingModel {
                 Quantization::FP32 => None,
                 Quantization::FP16 => Some("fp16"),
                 Quantization::Int8 => Some("int8"),
+                Quantization::Int4 => Some("int4"),
             };
 
             let candidates: Vec<std::path::PathBuf> = if let Some(suffix) = suffix {
@@ -714,11 +716,11 @@ impl StreamingModel {
         Ok(outputs)
     }
 
-    fn decode_step_greedy(
+    fn decode_step_logits(
         &mut self,
         state: &mut StreamingState,
         token: i64,
-    ) -> Result<i64, TranscribeError> {
+    ) -> Result<Vec<f32>, TranscribeError> {
         let vocab_size = self.config.vocab_size;
         let outputs = self.run_decoder(state, token)?;
 
@@ -728,18 +730,7 @@ impl StreamingModel {
             .try_extract_array::<f32>()?;
 
         let logits_data = logits.as_slice().unwrap();
-        let vocab = &logits_data[..vocab_size];
-
-        let mut best_idx = 0u32;
-        let mut best_val = vocab[0];
-        for (i, &v) in vocab.iter().enumerate().skip(1) {
-            if v > best_val {
-                best_val = v;
-                best_idx = i as u32;
-            }
-        }
-
-        Ok(best_idx as i64)
+        Ok(logits_data[..vocab_size].to_vec())
     }
 
     fn generate(
@@ -771,15 +762,17 @@ impl StreamingModel {
             }
         };
 
+        let mut greedy = GreedyDecoder::new(self.config.eos_id);
         let mut tokens: Vec<i64> = Vec::new();
         let mut current_token = self.config.bos_id;
 
         for _step in 0..max_tokens {
-            let next_token = self.decode_step_greedy(&mut state, current_token)?;
+            let logits = self.decode_step_logits(&mut state, current_token)?;
 
-            if next_token == self.config.eos_id {
-                break;
-            }
+            let next_token = match greedy.next_token(&logits) {
+                Some(t) => t,
+                None => break,
+            };
 
             tokens.push(next_token);
             current_token = next_token;

--- a/src/onnx/parakeet/mod.rs
+++ b/src/onnx/parakeet/mod.rs
@@ -128,15 +128,24 @@ impl ParakeetModel {
         })
     }
 
+    /// Default leading silence in milliseconds.
+    const DEFAULT_LEADING_SILENCE_MS: u32 = 250;
+
     /// Transcribe with model-specific parameters.
+    ///
+    /// Applies leading silence padding (default 250 ms) and adjusts
+    /// timestamps, matching the behaviour of [`SpeechModel::transcribe`].
     pub fn transcribe_with(
         &mut self,
         samples: &[f32],
         params: &ParakeetParams,
     ) -> Result<TranscriptionResult, TranscribeError> {
         let granularity = params.timestamp_granularity.clone().unwrap_or_default();
-
-        self.infer(samples, &granularity)
+        let lead_ms = Self::DEFAULT_LEADING_SILENCE_MS;
+        let padded = crate::audio::prepend_silence(samples, lead_ms);
+        let mut result = self.infer(&padded, &granularity)?;
+        result.offset_timestamps(-(lead_ms as f32 / 1000.0));
+        Ok(result)
     }
 
     fn infer(
@@ -428,7 +437,11 @@ impl SpeechModel for ParakeetModel {
         CAPABILITIES
     }
 
-    fn transcribe(
+    fn default_leading_silence_ms(&self) -> u32 {
+        Self::DEFAULT_LEADING_SILENCE_MS
+    }
+
+    fn transcribe_raw(
         &mut self,
         samples: &[f32],
         _options: &TranscribeOptions,

--- a/src/onnx/qwen3/config.rs
+++ b/src/onnx/qwen3/config.rs
@@ -90,6 +90,14 @@ pub struct SpecialTokens {
     pub audio_start_token_id: i64,
     pub audio_end_token_id: i64,
     pub audio_pad_token_id: i64,
+    /// Token that separates the language prefix from the transcription text.
+    /// If absent from generated tokens, the model failed to produce a valid transcription.
+    #[serde(default = "default_asr_text_token_id")]
+    pub asr_text_token_id: i64,
+}
+
+fn default_asr_text_token_id() -> i64 {
+    151704
 }
 
 impl Qwen3AsrConfig {

--- a/src/onnx/qwen3/config.rs
+++ b/src/onnx/qwen3/config.rs
@@ -1,0 +1,188 @@
+use serde::Deserialize;
+use std::fs;
+use std::path::Path;
+
+use crate::TranscribeError;
+
+/// Top-level model configuration loaded from `config.json`.
+// Fields are deserialized from config.json; not all are used at runtime.
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+pub struct Qwen3AsrConfig {
+    pub encoder: EncoderConfig,
+    pub decoder: DecoderConfig,
+    pub mel: Qwen3MelParams,
+    pub special_tokens: SpecialTokens,
+    /// Storage dtype of `embed_tokens.bin`.
+    #[serde(default)]
+    pub embed_tokens_dtype: EmbedDtype,
+}
+
+/// Storage dtype for `embed_tokens.bin`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum EmbedDtype {
+    /// 32-bit IEEE 754 float (4 bytes per element).
+    Float32,
+    /// 16-bit IEEE 754 half-precision float (2 bytes per element).
+    Float16,
+}
+
+impl Default for EmbedDtype {
+    fn default() -> Self {
+        Self::Float32
+    }
+}
+
+impl EmbedDtype {
+    /// Bytes per element for this dtype.
+    pub fn bytes_per_element(self) -> usize {
+        match self {
+            Self::Float32 => 4,
+            Self::Float16 => 2,
+        }
+    }
+}
+
+// Fields are deserialized from config.json; not all are used at runtime.
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+pub struct EncoderConfig {
+    pub num_mel_bins: usize,
+    pub output_dim: usize,
+}
+
+// Fields are deserialized from config.json; not all are used at runtime.
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+pub struct DecoderConfig {
+    pub num_layers: usize,
+    pub hidden_size: usize,
+    pub num_attention_heads: usize,
+    pub num_key_value_heads: usize,
+    pub head_dim: usize,
+    pub vocab_size: usize,
+}
+
+/// Mel spectrogram parameters from config.json, validated against the compiled-in constants
+/// in `mel.rs` at model load time.
+// Named `Qwen3MelParams` (not `MelConfig`) to avoid collision with `crate::features::MelConfig`.
+// Fields are deserialized from config.json; not all are used at runtime.
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+pub struct Qwen3MelParams {
+    pub sample_rate: u32,
+    pub n_fft: usize,
+    pub hop_length: usize,
+    pub n_mels: usize,
+    pub fmin: f64,
+    pub fmax: f64,
+}
+
+// Fields are deserialized from config.json; not all are used at runtime.
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+pub struct SpecialTokens {
+    pub eos_token_ids: Vec<i64>,
+    pub pad_token_id: i64,
+    pub im_start_token_id: i64,
+    pub im_end_token_id: i64,
+    pub audio_start_token_id: i64,
+    pub audio_end_token_id: i64,
+    pub audio_pad_token_id: i64,
+}
+
+impl Qwen3AsrConfig {
+    pub fn load(model_dir: &Path) -> Result<Self, TranscribeError> {
+        let config_path = model_dir.join("config.json");
+        let data = fs::read_to_string(&config_path)?;
+        let config: Self = serde_json::from_str(&data)?;
+        Ok(config)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_deserialize_config() {
+        let json = r#"{
+            "model_type": "qwen3_asr",
+            "encoder": {
+                "num_layers": 18, "hidden_size": 896, "num_heads": 14,
+                "ffn_dim": 3584, "conv_channels": 480, "output_dim": 1024,
+                "downsample_factor": 8, "num_mel_bins": 128
+            },
+            "decoder": {
+                "num_layers": 28, "hidden_size": 1024, "num_attention_heads": 16,
+                "num_key_value_heads": 8, "head_dim": 128, "intermediate_size": 3072,
+                "vocab_size": 151936, "rope_theta": 1000000, "rms_norm_eps": 1e-6,
+                "tie_word_embeddings": true,
+                "rope_scaling": { "mrope_section": [24, 20, 20], "interleaved": true }
+            },
+            "mel": {
+                "sample_rate": 16000, "n_fft": 400, "hop_length": 160,
+                "n_mels": 128, "fmin": 0, "fmax": 8000
+            },
+            "special_tokens": {
+                "eos_token_ids": [151643, 151645],
+                "pad_token_id": 151643,
+                "im_start_token_id": 151644,
+                "im_end_token_id": 151645,
+                "audio_start_token_id": 151669,
+                "audio_end_token_id": 151670,
+                "audio_pad_token_id": 151676,
+                "asr_text_token_id": 151704
+            },
+            "embed_tokens_shape": [151936, 1024],
+            "embed_tokens_dtype": "float32"
+        }"#;
+
+        let config: Qwen3AsrConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(config.decoder.num_layers, 28);
+        assert_eq!(config.decoder.vocab_size, 151936);
+        assert_eq!(config.mel.n_mels, 128);
+        assert_eq!(config.special_tokens.eos_token_ids, vec![151643, 151645]);
+        assert_eq!(config.embed_tokens_dtype, EmbedDtype::Float32);
+    }
+
+    #[test]
+    fn test_embed_dtype_float16() {
+        let json = r#"{
+            "encoder": { "num_layers": 18, "hidden_size": 896, "num_heads": 14, "ffn_dim": 3584, "conv_channels": 480, "output_dim": 1024, "downsample_factor": 8, "num_mel_bins": 128 },
+            "decoder": { "num_layers": 28, "hidden_size": 1024, "num_attention_heads": 16, "num_key_value_heads": 8, "head_dim": 128, "intermediate_size": 3072, "vocab_size": 151936, "rope_theta": 1000000, "rms_norm_eps": 1e-6, "tie_word_embeddings": true, "rope_scaling": { "mrope_section": [24, 20, 20], "interleaved": true } },
+            "mel": { "sample_rate": 16000, "n_fft": 400, "hop_length": 160, "n_mels": 128, "fmin": 0, "fmax": 8000 },
+            "special_tokens": { "eos_token_ids": [151643, 151645], "pad_token_id": 151643, "im_start_token_id": 151644, "im_end_token_id": 151645, "audio_start_token_id": 151669, "audio_end_token_id": 151670, "audio_pad_token_id": 151676 },
+            "embed_tokens_dtype": "float16"
+        }"#;
+        let config: Qwen3AsrConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(config.embed_tokens_dtype, EmbedDtype::Float16);
+        assert_eq!(config.embed_tokens_dtype.bytes_per_element(), 2);
+    }
+
+    #[test]
+    fn test_embed_dtype_default_when_missing() {
+        let json = r#"{
+            "encoder": { "num_layers": 18, "hidden_size": 896, "num_heads": 14, "ffn_dim": 3584, "conv_channels": 480, "output_dim": 1024, "downsample_factor": 8, "num_mel_bins": 128 },
+            "decoder": { "num_layers": 28, "hidden_size": 1024, "num_attention_heads": 16, "num_key_value_heads": 8, "head_dim": 128, "intermediate_size": 3072, "vocab_size": 151936, "rope_theta": 1000000, "rms_norm_eps": 1e-6, "tie_word_embeddings": true, "rope_scaling": { "mrope_section": [24, 20, 20], "interleaved": true } },
+            "mel": { "sample_rate": 16000, "n_fft": 400, "hop_length": 160, "n_mels": 128, "fmin": 0, "fmax": 8000 },
+            "special_tokens": { "eos_token_ids": [151643, 151645], "pad_token_id": 151643, "im_start_token_id": 151644, "im_end_token_id": 151645, "audio_start_token_id": 151669, "audio_end_token_id": 151670, "audio_pad_token_id": 151676 }
+        }"#;
+        let config: Qwen3AsrConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(config.embed_tokens_dtype, EmbedDtype::Float32);
+    }
+
+    #[test]
+    fn test_embed_dtype_unknown_rejected() {
+        let json = r#"{
+            "encoder": { "num_layers": 18, "hidden_size": 896, "num_heads": 14, "ffn_dim": 3584, "conv_channels": 480, "output_dim": 1024, "downsample_factor": 8, "num_mel_bins": 128 },
+            "decoder": { "num_layers": 28, "hidden_size": 1024, "num_attention_heads": 16, "num_key_value_heads": 8, "head_dim": 128, "intermediate_size": 3072, "vocab_size": 151936, "rope_theta": 1000000, "rms_norm_eps": 1e-6, "tie_word_embeddings": true, "rope_scaling": { "mrope_section": [24, 20, 20], "interleaved": true } },
+            "mel": { "sample_rate": 16000, "n_fft": 400, "hop_length": 160, "n_mels": 128, "fmin": 0, "fmax": 8000 },
+            "special_tokens": { "eos_token_ids": [151643, 151645], "pad_token_id": 151643, "im_start_token_id": 151644, "im_end_token_id": 151645, "audio_start_token_id": 151669, "audio_end_token_id": 151670, "audio_pad_token_id": 151676 },
+            "embed_tokens_dtype": "bfloat16"
+        }"#;
+        let result = serde_json::from_str::<Qwen3AsrConfig>(json);
+        assert!(result.is_err(), "bfloat16 should be rejected");
+    }
+}

--- a/src/onnx/qwen3/engine.rs
+++ b/src/onnx/qwen3/engine.rs
@@ -5,6 +5,7 @@
 //! - `engine.rs` — wraps `Qwen3AsrModel`, adapts it to the `SpeechModel` trait (capabilities,
 //!   options, language-prefix stripping). Keeps `model.rs` free of library-level concerns.
 
+use std::collections::HashMap;
 use std::path::Path;
 
 use crate::onnx::Quantization;
@@ -33,6 +34,9 @@ const CAPABILITIES: ModelCapabilities = ModelCapabilities {
 /// is always `None`).
 pub struct Qwen3Model {
     inner: Qwen3AsrModel,
+    /// Cache of language name → token IDs. Populated on first use of each
+    /// language, then reused for all subsequent transcriptions.
+    language_cache: HashMap<String, Vec<i64>>,
 }
 
 impl Qwen3Model {
@@ -40,7 +44,10 @@ impl Qwen3Model {
     pub fn load(model_dir: &Path, quantization: &Quantization) -> Result<Self, TranscribeError> {
         let inner = Qwen3AsrModel::load(model_dir, quantization)?;
         log::info!("Loaded Qwen3-ASR model from {:?}", model_dir);
-        Ok(Self { inner })
+        Ok(Self {
+            inner,
+            language_cache: HashMap::new(),
+        })
     }
 
     /// Transcribe with explicit per-call parameters.
@@ -49,12 +56,47 @@ impl Qwen3Model {
         samples: &[f32],
         params: &Qwen3Params,
     ) -> Result<TranscriptionResult, TranscribeError> {
-        let raw = self.inner.transcribe(samples, params.max_tokens)?;
+        // Encode language on first use, then borrow from cache.
+        // Treat empty strings as None (no language conditioning).
+        let lang_key = params.language.as_deref().filter(|s| !s.is_empty());
+        if let Some(lang) = lang_key {
+            self.ensure_language_cached(lang);
+        }
+        let lang_tokens = lang_key
+            .and_then(|lang| self.language_cache.get(lang))
+            .map(|v| v.as_slice());
+
+        let raw = self
+            .inner
+            .transcribe(samples, params.max_tokens, lang_tokens)?;
+        log::debug!("Qwen3-ASR raw decoder output: {:?}", raw);
         let text = strip_language_prefix(&raw);
+        log::debug!("Qwen3-ASR after strip_language_prefix: {:?}", text);
         Ok(TranscriptionResult {
             text,
             segments: None,
         })
+    }
+
+    /// Ensure language token IDs are in the cache, encoding on first use.
+    ///
+    /// Normalizes BCP-47 codes ("en" → "English") before tokenizing, then
+    /// encodes ` {Name}` (with leading space) to match the official Qwen3-ASR
+    /// template where "language" is followed by ` English`, ` Chinese`, etc.
+    fn ensure_language_cached(&mut self, language: &str) {
+        if self.language_cache.contains_key(language) {
+            return;
+        }
+        let normalized = normalize_language(language);
+        let spaced = format!(" {normalized}");
+        let tokens = self.inner.encode_language(&spaced);
+        log::info!(
+            "Qwen3-ASR: encoded language {:?} → {:?} → {:?} (cached for reuse)",
+            language,
+            normalized,
+            tokens
+        );
+        self.language_cache.insert(language.to_string(), tokens);
     }
 }
 
@@ -63,13 +105,22 @@ impl Qwen3Model {
 pub struct Qwen3Params {
     /// Maximum number of decoder tokens to generate.
     ///
-    /// 512 tokens is sufficient for approximately 60 s of typical English audio.
+    /// Default: 512, sufficient for approximately 60 s of typical English audio.
     pub max_tokens: usize,
+
+    /// Language hint (e.g. "English", "en", "zh"). When set, the assistant
+    /// prefix is forced to `language {Name}<asr_text>`, skipping language
+    /// detection entirely. Accepts either full English names ("English") or
+    /// BCP-47 codes ("en") — codes are normalized to names automatically.
+    pub language: Option<String>,
 }
 
 impl Default for Qwen3Params {
     fn default() -> Self {
-        Self { max_tokens: 512 }
+        Self {
+            max_tokens: 512,
+            language: None,
+        }
     }
 }
 
@@ -83,18 +134,16 @@ impl SpeechModel for Qwen3Model {
         samples: &[f32],
         options: &TranscribeOptions,
     ) -> Result<TranscriptionResult, TranscribeError> {
-        if let Some(ref lang) = options.language {
-            log::warn!(
-                "Qwen3-ASR: language hint {:?} is not supported; the model auto-detects language",
-                lang
-            );
-        }
         if options.translate {
             log::warn!(
                 "Qwen3-ASR: translate is not supported; the model produces transcription only"
             );
         }
-        self.transcribe_with(samples, &Qwen3Params::default())
+        let params = Qwen3Params {
+            language: options.language.clone(),
+            ..Default::default()
+        };
+        self.transcribe_with(samples, &params)
     }
 }
 

--- a/src/onnx/qwen3/engine.rs
+++ b/src/onnx/qwen3/engine.rs
@@ -1,0 +1,381 @@
+//! `SpeechModel` implementation for Qwen3-ASR (batch mode).
+//!
+//! Two-layer structure:
+//! - `model.rs` — raw ONNX inference (encoder, decoder, KV-cache) returning plain Rust types.
+//! - `engine.rs` — wraps `Qwen3AsrModel`, adapts it to the `SpeechModel` trait (capabilities,
+//!   options, language-prefix stripping). Keeps `model.rs` free of library-level concerns.
+
+use std::path::Path;
+
+use crate::onnx::Quantization;
+use crate::{
+    ModelCapabilities, SpeechModel, TranscribeError, TranscribeOptions, TranscriptionResult,
+};
+
+use super::model::Qwen3AsrModel;
+
+const CAPABILITIES: ModelCapabilities = ModelCapabilities {
+    name: "Qwen3-ASR",
+    engine_id: "qwen3",
+    sample_rate: 16000,
+    languages: &[], // multilingual: supports many languages
+    supports_timestamps: false,
+    supports_translation: false,
+    supports_streaming: false,
+};
+
+/// Batch transcription model backed by Qwen3-ASR.
+///
+/// Processes complete audio in a single encoder-decoder pass, suitable for
+/// the standard record-then-transcribe workflow.
+///
+/// This model does not produce timestamp segments (`TranscriptionResult.segments`
+/// is always `None`).
+pub struct Qwen3Model {
+    inner: Qwen3AsrModel,
+}
+
+impl Qwen3Model {
+    /// Load a Qwen3-ASR model from `model_dir` with the given quantization.
+    pub fn load(model_dir: &Path, quantization: &Quantization) -> Result<Self, TranscribeError> {
+        let inner = Qwen3AsrModel::load(model_dir, quantization)?;
+        log::info!("Loaded Qwen3-ASR model from {:?}", model_dir);
+        Ok(Self { inner })
+    }
+
+    /// Transcribe with explicit per-call parameters.
+    pub fn transcribe_with(
+        &mut self,
+        samples: &[f32],
+        params: &Qwen3Params,
+    ) -> Result<TranscriptionResult, TranscribeError> {
+        let raw = self.inner.transcribe(samples, params.max_tokens)?;
+        let text = strip_language_prefix(&raw);
+        Ok(TranscriptionResult {
+            text,
+            segments: None,
+        })
+    }
+}
+
+/// Per-call parameters for Qwen3-ASR transcription.
+#[derive(Debug, Clone)]
+pub struct Qwen3Params {
+    /// Maximum number of decoder tokens to generate.
+    ///
+    /// 512 tokens is sufficient for approximately 60 s of typical English audio.
+    pub max_tokens: usize,
+}
+
+impl Default for Qwen3Params {
+    fn default() -> Self {
+        Self { max_tokens: 512 }
+    }
+}
+
+impl SpeechModel for Qwen3Model {
+    fn capabilities(&self) -> ModelCapabilities {
+        CAPABILITIES
+    }
+
+    fn transcribe(
+        &mut self,
+        samples: &[f32],
+        options: &TranscribeOptions,
+    ) -> Result<TranscriptionResult, TranscribeError> {
+        if let Some(ref lang) = options.language {
+            log::warn!(
+                "Qwen3-ASR: language hint {:?} is not supported; the model auto-detects language",
+                lang
+            );
+        }
+        if options.translate {
+            log::warn!(
+                "Qwen3-ASR: translate is not supported; the model produces transcription only"
+            );
+        }
+        self.transcribe_with(samples, &Qwen3Params::default())
+    }
+}
+
+/// Normalize a BCP-47 / ISO 639-1 language code to the full English name
+/// expected by the Qwen3-ASR prompt template.
+///
+/// If the input is already a full name (e.g. "English") or is not recognized,
+/// it is returned unchanged. Mirrors the `ISO639_1_SUPPORTED_LANGS` mapping
+/// in the official Qwen3-ASR inference code.
+fn normalize_language(code: &str) -> &str {
+    match code {
+        "en" => "English",
+        "zh" | "zh-Hans" | "zh-Hant" => "Chinese",
+        "ja" => "Japanese",
+        "ko" => "Korean",
+        "yue" => "Cantonese",
+        "fr" => "French",
+        "es" => "Spanish",
+        "de" => "German",
+        "it" => "Italian",
+        "pt" => "Portuguese",
+        "ru" => "Russian",
+        "ar" => "Arabic",
+        "hi" => "Hindi",
+        "th" => "Thai",
+        "vi" => "Vietnamese",
+        "id" => "Indonesian",
+        "ms" => "Malay",
+        "tr" => "Turkish",
+        "nl" => "Dutch",
+        "pl" => "Polish",
+        "sv" => "Swedish",
+        "no" => "Norwegian",
+        "da" => "Danish",
+        "fi" => "Finnish",
+        "cs" => "Czech",
+        "ro" => "Romanian",
+        "hu" => "Hungarian",
+        "el" => "Greek",
+        "he" => "Hebrew",
+        "uk" => "Ukrainian",
+        "bg" => "Bulgarian",
+        "hr" => "Croatian",
+        "sk" => "Slovak",
+        "sl" => "Slovenian",
+        "lt" => "Lithuanian",
+        "lv" => "Latvian",
+        "et" => "Estonian",
+        "sr" => "Serbian",
+        "tl" => "Tagalog",
+        "my" => "Burmese",
+        "bo" => "Tibetan",
+        "ug" => "Uyghur",
+        "mn" => "Mongolian",
+        "am" => "Amharic",
+        "sw" => "Swahili",
+        "kk" => "Kazakh",
+        "uz" => "Uzbek",
+        "az" => "Azerbaijani",
+        "ka" => "Georgian",
+        "hy" => "Armenian",
+        "ne" => "Nepali",
+        "bn" => "Bengali",
+        "ta" => "Tamil",
+        "te" => "Telugu",
+        "ur" => "Urdu",
+        "fa" => "Persian",
+        "lo" => "Lao",
+        "km" => "Khmer",
+        "ca" => "Catalan",
+        "gl" => "Galician",
+        "eu" => "Basque",
+        "af" => "Afrikaans",
+        other => other, // Already a full name or unknown — pass through
+    }
+}
+
+/// Known language names emitted by Qwen3-ASR as the prefix tag.
+const KNOWN_LANGUAGES: &[&str] = &[
+    "English",
+    "Chinese",
+    "Japanese",
+    "Korean",
+    "Cantonese",
+    "French",
+    "Spanish",
+    "German",
+    "Italian",
+    "Portuguese",
+    "Russian",
+    "Arabic",
+    "Hindi",
+    "Thai",
+    "Vietnamese",
+    "Indonesian",
+    "Malay",
+    "Turkish",
+    "Dutch",
+    "Polish",
+    "Swedish",
+    "Norwegian",
+    "Danish",
+    "Finnish",
+    "Czech",
+    "Romanian",
+    "Hungarian",
+    "Greek",
+    "Hebrew",
+    "Ukrainian",
+    "Bulgarian",
+    "Croatian",
+    "Slovak",
+    "Slovenian",
+    "Lithuanian",
+    "Latvian",
+    "Estonian",
+    "Serbian",
+    "Tagalog",
+    "Burmese",
+    "Tibetan",
+    "Uyghur",
+    "Mongolian",
+    "Amharic",
+    "Swahili",
+    "Kazakh",
+    "Uzbek",
+    "Azerbaijani",
+    "Georgian",
+    "Armenian",
+    "Nepali",
+    "Bengali",
+    "Tamil",
+    "Telugu",
+    "Urdu",
+    "Persian",
+    "Lao",
+    "Khmer",
+    "Catalan",
+    "Galician",
+    "Basque",
+    "Afrikaans",
+];
+
+/// Strip the language identification prefix that Qwen3-ASR generates.
+///
+/// The model outputs `language <Name>\n<transcription>` where `\n` is GPT-2
+/// BPE token 198. Occasionally the newline is absent: `language <Name><text>`.
+/// We try the newline split first (handles unknown languages automatically),
+/// then fall back to known language name matching for the no-newline case.
+///
+/// Known limitation: if the transcribed text starts with a substring that
+/// matches a language name (e.g. "Georgian" → "Georgia is..."), the boundary
+/// detection is ambiguous. This is inherent to the model's output format
+/// when no separator character is present.
+fn strip_language_prefix(text: &str) -> String {
+    if let Some(rest) = text.strip_prefix("language ") {
+        // Primary: split on newline (the model's standard delimiter)
+        if let Some(newline_pos) = rest.find('\n') {
+            return rest[newline_pos + 1..].to_string();
+        }
+        // Fallback: match known language name (no newline separator)
+        for lang in KNOWN_LANGUAGES {
+            if let Some(after) = rest.strip_prefix(lang) {
+                return after.to_string();
+            }
+        }
+        // Unknown language without newline: preserve text rather than drop it
+        log::warn!(
+            "Qwen3-ASR: unrecognised language prefix with no newline separator; raw output: {:?}",
+            rest
+        );
+        return rest.to_string();
+    }
+    text.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_strip_language_prefix_with_newline() {
+        assert_eq!(
+            strip_language_prefix("language English\nHello world"),
+            "Hello world"
+        );
+    }
+
+    #[test]
+    fn test_strip_language_prefix_without_newline() {
+        assert_eq!(
+            strip_language_prefix("language EnglishHello world"),
+            "Hello world"
+        );
+    }
+
+    #[test]
+    fn test_strip_language_prefix_without_newline_starts_uppercase() {
+        assert_eq!(
+            strip_language_prefix("language EnglishAre there more features?"),
+            "Are there more features?"
+        );
+    }
+
+    #[test]
+    fn test_strip_language_prefix_body_starts_with_language_name() {
+        // Transcript begins with a language name — verify we strip only the prefix tag.
+        assert_eq!(
+            strip_language_prefix("language EnglishEnglish is a language"),
+            "English is a language"
+        );
+    }
+
+    #[test]
+    fn test_strip_language_prefix_chinese_with_newline() {
+        assert_eq!(
+            strip_language_prefix("language Chinese\n你好世界"),
+            "你好世界"
+        );
+    }
+
+    #[test]
+    fn test_strip_language_prefix_chinese_without_newline() {
+        assert_eq!(
+            strip_language_prefix("language Chinese你好世界"),
+            "你好世界"
+        );
+    }
+
+    #[test]
+    fn test_strip_language_prefix_no_text() {
+        assert_eq!(strip_language_prefix("language English"), "");
+    }
+
+    #[test]
+    fn test_strip_language_prefix_no_prefix() {
+        assert_eq!(strip_language_prefix("Hello world"), "Hello world");
+    }
+
+    #[test]
+    fn test_strip_language_prefix_empty() {
+        assert_eq!(strip_language_prefix(""), "");
+    }
+
+    #[test]
+    fn test_strip_language_prefix_preserves_newlines_in_body() {
+        assert_eq!(
+            strip_language_prefix("language English\nline one\nline two"),
+            "line one\nline two"
+        );
+    }
+
+    #[test]
+    fn test_strip_language_prefix_unknown_language_with_newline() {
+        assert_eq!(strip_language_prefix("language Klingon\nQapla!"), "Qapla!");
+    }
+
+    #[test]
+    fn test_strip_language_prefix_unknown_language_without_newline() {
+        // Unknown language without newline: text preserved (not dropped)
+        assert_eq!(strip_language_prefix("language Klingon"), "Klingon");
+    }
+
+    #[test]
+    fn test_normalize_language_maps_codes() {
+        assert_eq!(normalize_language("en"), "English");
+        assert_eq!(normalize_language("zh"), "Chinese");
+        assert_eq!(normalize_language("zh-Hans"), "Chinese");
+        assert_eq!(normalize_language("ja"), "Japanese");
+        assert_eq!(normalize_language("ko"), "Korean");
+        assert_eq!(normalize_language("yue"), "Cantonese");
+        assert_eq!(normalize_language("af"), "Afrikaans");
+    }
+
+    #[test]
+    fn test_normalize_language_passthrough() {
+        // Full names pass through unchanged
+        assert_eq!(normalize_language("English"), "English");
+        assert_eq!(normalize_language("Chinese"), "Chinese");
+        // Unknown codes pass through
+        assert_eq!(normalize_language("unknown"), "unknown");
+        assert_eq!(normalize_language("Klingon"), "Klingon");
+    }
+}

--- a/src/onnx/qwen3/engine.rs
+++ b/src/onnx/qwen3/engine.rs
@@ -78,7 +78,7 @@ impl SpeechModel for Qwen3Model {
         CAPABILITIES
     }
 
-    fn transcribe(
+    fn transcribe_raw(
         &mut self,
         samples: &[f32],
         options: &TranscribeOptions,

--- a/src/onnx/qwen3/mel.rs
+++ b/src/onnx/qwen3/mel.rs
@@ -1,0 +1,304 @@
+//! Whisper-compatible log-mel spectrogram extraction.
+//!
+//! Parameters: 128 mel bins, Hann window, n_fft=400, hop=160, Slaney mel scale.
+//! This differs from SenseVoice's FBANK (80 bins, Hamming, HTK mel, pre-emphasis)
+//! and cannot be shared.
+//!
+//! TODO: `crate::features::mel` uses HTK-scale normalization and f32 arithmetic.
+//! Qwen3-ASR requires Slaney-scale normalization and f64 arithmetic (to match
+//! Whisper's feature extractor). Merging the two would require a `MelScale` enum
+//! in the shared module; leave that to a follow-up contribution.
+
+// Multi-array indexed loops are clearer than iterator chains here.
+#![allow(clippy::needless_range_loop)]
+
+use ndarray::Array3;
+use rustfft::{num_complex::Complex, FftPlanner};
+use std::f64::consts::PI;
+use std::sync::LazyLock;
+
+const SAMPLE_RATE: f64 = 16000.0;
+pub(crate) const N_FFT: usize = 400;
+pub(crate) const HOP_LENGTH: usize = 160;
+pub(crate) const N_MELS: usize = 128;
+const FMIN: f64 = 0.0;
+const FMAX: f64 = 8000.0;
+
+/// Cached Hann window (400 f64 values) — deterministic, computed once.
+static HANN_WINDOW: LazyLock<Vec<f64>> = LazyLock::new(|| hann_window(N_FFT));
+
+/// Cached Slaney mel filterbank (128×201 f64 matrix) — deterministic, computed once.
+static MEL_FILTERS: LazyLock<Vec<Vec<f64>>> =
+    LazyLock::new(|| slaney_mel_filterbank(SAMPLE_RATE, N_FFT, N_MELS, FMIN, FMAX));
+
+/// Compute Whisper-compatible log-mel spectrogram.
+///
+/// Input: 1-D f32 audio samples at 16kHz.
+/// Output: `Array3<f32>` shape `[1, 128, T]`.
+pub fn log_mel_spectrogram(audio: &[f32]) -> Array3<f32> {
+    if audio.len() <= N_FFT / 2 {
+        return Array3::zeros((1, N_MELS, 0));
+    }
+
+    let mel_filters = &*MEL_FILTERS;
+    let window = &*HANN_WINDOW;
+    let num_fft_bins = N_FFT / 2 + 1;
+
+    // Number of STFT frames (torch.stft default: centered, pad_mode reflect not needed
+    // since we match the Python output exactly by computing the same frame count)
+    let num_frames = audio.len() / HOP_LENGTH + 1;
+    // num_frames >= 1 always (integer division + 1). The guard above (audio.len() > N_FFT/2)
+    // ensures time_steps = num_frames - 1 >= 0 and that the reflect padding indices are valid.
+    debug_assert!(num_frames >= 1);
+
+    let mut planner = FftPlanner::new();
+    let fft = planner.plan_fft_forward(N_FFT);
+
+    // Compute magnitude-squared spectrogram
+    let mut magnitudes = vec![vec![0.0f64; num_frames]; num_fft_bins];
+
+    for frame_idx in 0..num_frames {
+        let center = frame_idx * HOP_LENGTH;
+        let mut fft_input: Vec<Complex<f64>> = Vec::with_capacity(N_FFT);
+
+        for i in 0..N_FFT {
+            let sample_idx = center as isize + i as isize - (N_FFT / 2) as isize;
+            let sample = if sample_idx < 0 {
+                // Reflect padding: index -1 → audio[1], -2 → audio[2], etc.
+                // Invariant: N_FFT/2 < audio.len() (guaranteed by early-return at top).
+                let reflect_idx = (-sample_idx) as usize;
+                debug_assert!(
+                    reflect_idx < audio.len(),
+                    "reflect_idx {reflect_idx} out of bounds"
+                );
+                audio[reflect_idx] as f64
+            } else if (sample_idx as usize) >= audio.len() {
+                // Reflect padding from the right end.
+                let overshoot = sample_idx as usize - audio.len();
+                if audio.len() > 1 && overshoot < audio.len() {
+                    debug_assert!(
+                        overshoot < audio.len().saturating_sub(1),
+                        "right reflect: overshoot {overshoot} >= audio.len()-1 ({})",
+                        audio.len() - 1
+                    );
+                    audio[audio.len().saturating_sub(2).saturating_sub(overshoot)] as f64
+                } else {
+                    // audio is a single sample or overshoot exceeds the buffer — no valid
+                    // reflect index. This should not occur for normal 16 kHz audio (guarded
+                    // by the early-return at the top of log_mel_spectrogram).
+                    log::warn!(
+                        "mel: right-reflect padding out of range \
+                         (audio_len={}, overshoot={}); zeroing frame {} sample {}",
+                        audio.len(),
+                        overshoot,
+                        frame_idx,
+                        i
+                    );
+                    0.0
+                }
+            } else {
+                audio[sample_idx as usize] as f64
+            };
+            fft_input.push(Complex::new(sample * window[i], 0.0));
+        }
+
+        fft.process(&mut fft_input);
+
+        for k in 0..num_fft_bins {
+            magnitudes[k][frame_idx] = fft_input[k].norm_sqr();
+        }
+    }
+
+    // Drop last STFT frame (WhisperFeatureExtractor quirk)
+    let time_steps = num_frames - 1;
+
+    // Apply mel filterbank: mel_spec[m][t] = sum_k(filters[m][k] * magnitudes[k][t])
+    let mut mel_spec = vec![vec![0.0f64; time_steps]; N_MELS];
+    for m in 0..N_MELS {
+        for k in 0..num_fft_bins {
+            if mel_filters[m][k] != 0.0 {
+                for t in 0..time_steps {
+                    mel_spec[m][t] += mel_filters[m][k] * magnitudes[k][t];
+                }
+            }
+        }
+    }
+
+    // Log scale with clamping and normalization
+    let mut log_spec = vec![vec![0.0f32; time_steps]; N_MELS];
+    let mut global_max: f32 = f32::NEG_INFINITY;
+
+    for m in 0..N_MELS {
+        for t in 0..time_steps {
+            let val = (mel_spec[m][t].max(1e-10).log10()) as f32;
+            log_spec[m][t] = val;
+            if val > global_max {
+                global_max = val;
+            }
+        }
+    }
+
+    // Dynamic range clipping and normalization
+    let floor = global_max - 8.0;
+    for m in 0..N_MELS {
+        for t in 0..time_steps {
+            log_spec[m][t] = (log_spec[m][t].max(floor) + 4.0) / 4.0;
+        }
+    }
+
+    // Pack into [1, N_MELS, time_steps]
+    let mut result = Array3::<f32>::zeros((1, N_MELS, time_steps));
+    for m in 0..N_MELS {
+        for t in 0..time_steps {
+            result[[0, m, t]] = log_spec[m][t];
+        }
+    }
+    result
+}
+
+/// Hann window of given length.
+fn hann_window(length: usize) -> Vec<f64> {
+    (0..length)
+        .map(|i| 0.5 * (1.0 - (2.0 * PI * i as f64 / length as f64).cos()))
+        .collect()
+}
+
+/// Slaney-normalized mel filterbank matching `librosa.filters.mel(norm='slaney')`.
+///
+/// Below 1kHz: linear spacing in Hz.
+/// Above 1kHz: logarithmic spacing.
+/// Each filter is area-normalized (divided by its bandwidth in Hz).
+fn slaney_mel_filterbank(
+    sr: f64,
+    n_fft: usize,
+    n_mels: usize,
+    fmin: f64,
+    fmax: f64,
+) -> Vec<Vec<f64>> {
+    let num_fft_bins = n_fft / 2 + 1;
+
+    // Slaney mel scale: linear below 1kHz, log above
+    let f_sp = 200.0 / 3.0; // 66.667 Hz
+    let min_log_hz = 1000.0;
+    let min_log_mel = (min_log_hz - 0.0) / f_sp; // 15.0
+    let log_step = 6.4_f64.ln() / 27.0; // step in log region
+
+    let hz_to_mel = |hz: f64| -> f64 {
+        if hz < min_log_hz {
+            hz / f_sp
+        } else {
+            min_log_mel + (hz / min_log_hz).ln() / log_step
+        }
+    };
+
+    let mel_to_hz = |mel: f64| -> f64 {
+        if mel < min_log_mel {
+            mel * f_sp
+        } else {
+            min_log_hz * ((mel - min_log_mel) * log_step).exp()
+        }
+    };
+
+    let mel_min = hz_to_mel(fmin);
+    let mel_max = hz_to_mel(fmax);
+
+    // n_mels + 2 uniformly spaced points in mel domain
+    let n_points = n_mels + 2;
+    let mel_points: Vec<f64> = (0..n_points)
+        .map(|i| mel_min + (mel_max - mel_min) * i as f64 / (n_points - 1) as f64)
+        .collect();
+    let hz_points: Vec<f64> = mel_points.iter().map(|&m| mel_to_hz(m)).collect();
+
+    // FFT bin frequencies
+    let fft_freqs: Vec<f64> = (0..num_fft_bins)
+        .map(|k| k as f64 * sr / n_fft as f64)
+        .collect();
+
+    let mut filters = vec![vec![0.0f64; num_fft_bins]; n_mels];
+
+    for m in 0..n_mels {
+        let left = hz_points[m];
+        let center = hz_points[m + 1];
+        let right = hz_points[m + 2];
+
+        // Slaney normalization: divide by bandwidth in Hz
+        let enorm = 2.0 / (right - left);
+
+        for k in 0..num_fft_bins {
+            let freq = fft_freqs[k];
+            if freq > left && freq < center {
+                filters[m][k] = enorm * (freq - left) / (center - left);
+            } else if freq >= center && freq < right {
+                filters[m][k] = enorm * (right - freq) / (right - center);
+            }
+        }
+    }
+
+    filters
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_hann_window_endpoints() {
+        let w = hann_window(400);
+        assert_eq!(w.len(), 400);
+        // Hann window: w[0] = 0, w[N/2] = 1
+        assert!(w[0].abs() < 1e-10);
+        assert!((w[200] - 1.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_mel_filterbank_shape() {
+        let filters = slaney_mel_filterbank(16000.0, 400, 128, 0.0, 8000.0);
+        assert_eq!(filters.len(), 128);
+        assert_eq!(filters[0].len(), 201); // n_fft/2 + 1
+    }
+
+    #[test]
+    fn test_mel_filterbank_nonzero() {
+        let filters = slaney_mel_filterbank(16000.0, 400, 128, 0.0, 8000.0);
+        // Each filter should have at least some nonzero entries
+        for (i, filter) in filters.iter().enumerate() {
+            let sum: f64 = filter.iter().sum();
+            assert!(sum > 0.0, "Filter {} has zero sum", i);
+        }
+    }
+
+    #[test]
+    fn test_log_mel_spectrogram_very_short() {
+        // audio.len() <= N_FFT / 2 (200 samples) triggers the early-return path
+        let audio = vec![0.0f32; 100];
+        let mel = log_mel_spectrogram(&audio);
+        assert_eq!(mel.shape(), &[1, 128, 0]);
+    }
+
+    #[test]
+    fn test_log_mel_spectrogram_shape() {
+        // 1 second of silence
+        let audio = vec![0.0f32; 16000];
+        let mel = log_mel_spectrogram(&audio);
+        assert_eq!(mel.shape()[0], 1);
+        assert_eq!(mel.shape()[1], 128);
+        // Expected frames: 16000 / 160 + 1 - 1 = 100
+        assert_eq!(mel.shape()[2], 100);
+    }
+
+    #[test]
+    fn test_log_mel_spectrogram_sine_wave() {
+        // 440 Hz sine wave for 0.5s — should produce energy in low mel bins
+        let n = 8000;
+        let audio: Vec<f32> = (0..n)
+            .map(|i| (2.0 * std::f32::consts::PI * 440.0 * i as f32 / 16000.0).sin())
+            .collect();
+        let mel = log_mel_spectrogram(&audio);
+        assert_eq!(mel.shape()[0], 1);
+        assert_eq!(mel.shape()[1], 128);
+        // Should have non-trivial values (not all identical)
+        let min = mel.iter().cloned().fold(f32::INFINITY, f32::min);
+        let max = mel.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
+        assert!(max > min, "Mel spectrogram should have dynamic range");
+    }
+}

--- a/src/onnx/qwen3/mod.rs
+++ b/src/onnx/qwen3/mod.rs
@@ -1,0 +1,36 @@
+//! Qwen3-ASR speech recognition engine (batch mode).
+//!
+//! Implements [`SpeechModel`](crate::SpeechModel) for multilingual batch transcription.
+//!
+//! # Requirements
+//!
+//! The model directory must contain:
+//! - `encoder.onnx` (+ `.data`) -- audio encoder
+//! - `decoder_init.onnx` (+ `.data`) -- decoder prefill (embedding table in graph)
+//! - `decoder_step.onnx` (+ `.data`) -- decoder autoregressive step (embedding table in graph)
+//! - `config.json` -- model configuration
+//! - `tokenizer.json` -- HuggingFace BPE tokenizer
+//!
+//! # Model output format
+//!
+//! The decoder produces a language identification prefix followed by the
+//! transcription. The standard format uses a newline token (GPT-2 BPE token
+//! ID 198, which decodes to `\n`) as the delimiter:
+//!
+//! ```text
+//! language English\n<transcription text>
+//! ```
+//!
+//! The engine layer ([`engine::strip_language_prefix`]) removes this prefix
+//! before returning the final text. It tries the newline split first (handles
+//! unknown languages automatically), then falls back to matching known
+//! language names for the rare no-newline case.
+
+mod config;
+mod engine;
+mod mel;
+mod model;
+mod prompt;
+mod tokenizer;
+
+pub use engine::{Qwen3Model, Qwen3Params};

--- a/src/onnx/qwen3/model.rs
+++ b/src/onnx/qwen3/model.rs
@@ -291,6 +291,22 @@ impl Qwen3AsrModel {
             );
         }
 
+        // The model should produce `language <Name> <asr_text> <transcription>`.
+        // If the <asr_text> separator token is absent, the decoder failed to produce
+        // a valid transcription (e.g. degenerate "ology" output from int4 quantization
+        // noise on non-speech audio). Return empty string rather than garbage.
+        let asr_text_id = self.config.special_tokens.asr_text_token_id;
+        if !output_tokens.contains(&asr_text_id) {
+            let preview: Vec<_> = output_tokens.iter().take(20).collect();
+            log::warn!(
+                "Qwen3-ASR: no <asr_text> token in output ({} tokens, first 20: {:?}); \
+                 returning empty transcription",
+                output_tokens.len(),
+                preview,
+            );
+            return Ok(String::new());
+        }
+
         Ok(self.tokenizer.decode(&output_tokens))
     }
 

--- a/src/onnx/qwen3/model.rs
+++ b/src/onnx/qwen3/model.rs
@@ -218,6 +218,12 @@ impl Qwen3AsrModel {
         for _ in 1..max_tokens {
             // Embedding lookup from cached FP32 table (fast ndarray row copy).
             let token_embed = {
+                if current_token < 0 {
+                    return Err(TranscribeError::Inference(format!(
+                        "decoder produced negative token ID: {}",
+                        current_token
+                    )));
+                }
                 let id = current_token as usize;
                 if id >= self.embed_tokens.nrows() {
                     return Err(TranscribeError::Inference(format!(

--- a/src/onnx/qwen3/model.rs
+++ b/src/onnx/qwen3/model.rs
@@ -1,0 +1,545 @@
+//! Core ONNX inference for Qwen3-ASR: encoder, decoder prefill, and autoregressive decode.
+
+use ndarray::{Array1, Array2, Array3, ArrayD, Ix3, IxDyn};
+use ort::session::Session;
+use ort::value::{DynValue, TensorRef};
+use std::path::Path;
+
+use crate::onnx::{session, Quantization};
+use crate::TranscribeError;
+
+use super::config::Qwen3AsrConfig;
+use super::mel::{self, log_mel_spectrogram};
+use super::prompt::{build_prompt_ids, get_audio_pad_range, get_feat_extract_output_lengths};
+use super::tokenizer::Qwen3Tokenizer;
+
+pub struct Qwen3AsrModel {
+    encoder: Session,
+    decoder_init: Session,
+    decoder_step: Session,
+    /// Embedding matrix cached for fast per-step lookup. Loaded from
+    /// `embed_tokens.bin` (FP32 cache). decoder_init contains the embedding
+    /// table in its graph for the prefill scatter, but decoder_step accepts
+    /// pre-looked-up `input_embeds` to avoid loading the embedding table
+    /// into the hot decode loop session.
+    embed_tokens: Array2<f32>,
+    config: Qwen3AsrConfig,
+    tokenizer: Qwen3Tokenizer,
+}
+
+impl Qwen3AsrModel {
+    pub fn load(model_dir: &Path, quantization: &Quantization) -> Result<Self, TranscribeError> {
+        let config = Qwen3AsrConfig::load(model_dir)?;
+        let tokenizer =
+            Qwen3Tokenizer::new(model_dir).map_err(|e| TranscribeError::Config(e.to_string()))?;
+
+        {
+            let st = &config.special_tokens;
+            let valid = st.pad_token_id >= 0
+                && st.im_start_token_id >= 0
+                && st.im_end_token_id >= 0
+                && st.audio_start_token_id >= 0
+                && st.audio_end_token_id >= 0
+                && st.audio_pad_token_id >= 0
+                && !st.eos_token_ids.is_empty()
+                && st.eos_token_ids.iter().all(|&id| id >= 0);
+            if !valid {
+                return Err(TranscribeError::Config(
+                    "config.json: special_tokens contains negative or missing IDs".into(),
+                ));
+            }
+        }
+
+        if config.mel.n_mels != mel::N_MELS {
+            return Err(TranscribeError::Config(format!(
+                "Qwen3-ASR: expected n_mels={}, got {}",
+                mel::N_MELS,
+                config.mel.n_mels
+            )));
+        }
+        if config.mel.n_fft != mel::N_FFT {
+            return Err(TranscribeError::Config(format!(
+                "Qwen3-ASR: expected n_fft={}, got {}",
+                mel::N_FFT,
+                config.mel.n_fft
+            )));
+        }
+        if config.mel.hop_length != mel::HOP_LENGTH {
+            return Err(TranscribeError::Config(format!(
+                "Qwen3-ASR: expected hop_length={}, got {}",
+                mel::HOP_LENGTH,
+                config.mel.hop_length
+            )));
+        }
+
+        let encoder_path = session::resolve_model_path(model_dir, "encoder", quantization);
+        if !encoder_path.exists() {
+            return Err(TranscribeError::ModelNotFound(encoder_path));
+        }
+
+        // 0 = ORT default (all cores). Decoder runs sequentially (one step
+        // per token) so fewer threads can reduce synchronization overhead,
+        // but the optimal count is host-dependent.
+        let decoder_threads: usize = 0;
+
+        log::info!("Loading Qwen3-ASR encoder from {:?}", encoder_path);
+        let encoder = session::create_session(&encoder_path)?;
+
+        let decoder_init_path =
+            session::resolve_model_path(model_dir, "decoder_init", quantization);
+        let decoder_step_path =
+            session::resolve_model_path(model_dir, "decoder_step", quantization);
+        if !decoder_init_path.exists() {
+            return Err(TranscribeError::ModelNotFound(decoder_init_path));
+        }
+        if !decoder_step_path.exists() {
+            return Err(TranscribeError::ModelNotFound(decoder_step_path));
+        }
+        log::info!(
+            "Loading Qwen3-ASR decoder from {:?} + {:?}",
+            decoder_init_path,
+            decoder_step_path
+        );
+        let decoder_init = session::create_decoder_session(&decoder_init_path, decoder_threads)?;
+        let decoder_step = session::create_decoder_session(&decoder_step_path, decoder_threads)?;
+
+        // Load embedding cache for fast per-step lookup. decoder_step accepts
+        // input_embeds (pre-looked-up), so the embedding table is not in its
+        // ORT session, keeping the step working set small.
+        // Storage dtype (FP16 or FP32) is read from config.embed_tokens_dtype.
+        let embed_path = model_dir.join("embed_tokens.bin");
+        if !embed_path.exists() {
+            return Err(TranscribeError::ModelNotFound(embed_path));
+        }
+        log::info!("Loading embedding cache from {:?}", embed_path);
+        let embed_tokens = load_embed_cache(&embed_path, &config)?;
+        log::info!("Embedding cache: {:?}", embed_tokens.shape());
+
+        Ok(Self {
+            encoder,
+            decoder_init,
+            decoder_step,
+            embed_tokens,
+            config,
+            tokenizer,
+        })
+    }
+
+    /// Run the encoder on a mel spectrogram.
+    fn encode(&mut self, mel: &Array3<f32>) -> Result<Array3<f32>, TranscribeError> {
+        let mel_dyn = mel.view().into_dyn();
+        let inputs = ort::inputs![
+            "mel" => TensorRef::from_array_view(mel_dyn.view())?,
+        ];
+        let outputs = self.encoder.run(inputs)?;
+
+        let features = outputs
+            .get("audio_features")
+            .ok_or_else(|| TranscribeError::Inference("Missing 'audio_features' output".into()))?
+            .try_extract_array::<f32>()?;
+
+        Ok(features.to_owned().into_dimensionality::<Ix3>()?)
+    }
+
+    /// Run greedy decoding on audio features, returning decoded text.
+    ///
+    /// The decoder graph contains the embedding table. We pass `input_ids` (token IDs)
+    /// and `audio_features` + `audio_offset` to decoder_init; the graph handles
+    /// embedding lookup and audio feature substitution internally. For autoregressive
+    /// steps, decoder_step receives a single `input_ids` token.
+    fn greedy_decode(
+        &mut self,
+        audio_features: &Array3<f32>,
+        max_tokens: usize,
+    ) -> Result<String, TranscribeError> {
+        // Cap to prevent unbounded KV cache growth from unchecked callers.
+        let max_tokens = max_tokens.min(4096);
+        let audio_token_count = audio_features.shape()[1];
+        let prompt_ids = build_prompt_ids(&self.config.special_tokens, audio_token_count);
+        let seq_len = prompt_ids.len();
+
+        let (audio_start, _) =
+            get_audio_pad_range(&prompt_ids, self.config.special_tokens.audio_pad_token_id)
+                .map_err(TranscribeError::Inference)?;
+
+        let input_ids = Array2::<i64>::from_shape_vec((1, seq_len), prompt_ids.clone())?;
+        let position_ids = Array2::<i64>::from_shape_fn((1, seq_len), |(_, j)| j as i64);
+        let audio_offset = Array1::<i64>::from_elem(1, audio_start as i64);
+        let ids_dyn = input_ids.into_dyn();
+        let pos_dyn = position_ids.into_dyn();
+        let audio_dyn = audio_features.view().into_dyn();
+        let offset_dyn = audio_offset.into_dyn();
+
+        // Prefill: decoder_init handles embedding lookup + audio scatter internally.
+        let (mut current_token, mut keys, mut values) = {
+            let inputs = ort::inputs![
+                "input_ids"        => TensorRef::from_array_view(ids_dyn.view())?,
+                "position_ids"     => TensorRef::from_array_view(pos_dyn.view())?,
+                "audio_features"   => TensorRef::from_array_view(audio_dyn.view())?,
+                "audio_offset"     => TensorRef::from_array_view(offset_dyn.view())?,
+            ];
+            let mut init_outputs = self.decoder_init.run(inputs)?;
+
+            let logits = init_outputs
+                .get("logits")
+                .ok_or_else(|| {
+                    TranscribeError::Inference("Missing 'logits' from decoder_init".into())
+                })?
+                .try_extract_array::<f32>()?;
+            let last_pos = logits.shape()[1].checked_sub(1).ok_or_else(|| {
+                TranscribeError::Inference("decoder_init returned empty logits sequence".into())
+            })?;
+            let token = argmax_slice(&logits, last_pos)?;
+            // Release borrow on init_outputs so remove() can take KV cache by value.
+            drop(logits);
+            let keys: DynValue = init_outputs.remove("present_keys").ok_or_else(|| {
+                TranscribeError::Inference("Missing 'present_keys' from decoder_init".into())
+            })?;
+            let values: DynValue = init_outputs.remove("present_values").ok_or_else(|| {
+                TranscribeError::Inference("Missing 'present_values' from decoder_init".into())
+            })?;
+            (token, keys, values)
+        };
+
+        let mut output_tokens = vec![current_token];
+
+        if self
+            .config
+            .special_tokens
+            .eos_token_ids
+            .contains(&current_token)
+        {
+            return Ok(self.tokenizer.decode(&output_tokens));
+        }
+
+        let hidden_size = self.config.decoder.hidden_size;
+        let mut pos = seq_len as i64;
+
+        for _ in 1..max_tokens {
+            // Embedding lookup from cached FP32 table (fast ndarray row copy).
+            let token_embed = {
+                let id = current_token as usize;
+                if id >= self.embed_tokens.nrows() {
+                    return Err(TranscribeError::Inference(format!(
+                        "token ID {} exceeds embedding rows {}",
+                        id,
+                        self.embed_tokens.nrows()
+                    )));
+                }
+                let row = self.embed_tokens.row(id);
+                let mut arr = Array3::<f32>::zeros((1, 1, hidden_size));
+                arr.slice_mut(ndarray::s![0, 0, ..]).assign(&row);
+                arr.into_dyn()
+            };
+
+            let step_pos = ArrayD::<i64>::from_shape_vec(IxDyn(&[1, 1]), vec![pos])?;
+
+            // Pass KV cache by value: DynValue implements Into<SessionInputValue>,
+            // so ORT can reference the memory directly without an extra ndarray copy.
+            let step_inputs = ort::inputs![
+                "input_embeds"  => TensorRef::from_array_view(token_embed.view())?,
+                "position_ids"  => TensorRef::from_array_view(step_pos.view())?,
+                "past_keys"     => keys,
+                "past_values"   => values,
+            ];
+            let mut step_outputs = self.decoder_step.run(step_inputs)?;
+
+            let step_logits = step_outputs
+                .get("logits")
+                .ok_or_else(|| {
+                    TranscribeError::Inference("Missing 'logits' from decoder_step".into())
+                })?
+                .try_extract_array::<f32>()?;
+
+            current_token = argmax_slice(&step_logits, 0)?;
+            output_tokens.push(current_token);
+            pos += 1;
+            // Release borrow on step_outputs so remove() can take KV cache by value.
+            drop(step_logits);
+            keys = step_outputs.remove("present_keys").ok_or_else(|| {
+                TranscribeError::Inference("Missing 'present_keys' from step".into())
+            })?;
+            values = step_outputs.remove("present_values").ok_or_else(|| {
+                TranscribeError::Inference("Missing 'present_values' from step".into())
+            })?;
+
+            if self
+                .config
+                .special_tokens
+                .eos_token_ids
+                .contains(&current_token)
+            {
+                break;
+            }
+        }
+
+        if !self
+            .config
+            .special_tokens
+            .eos_token_ids
+            .contains(&current_token)
+        {
+            log::warn!(
+                "Qwen3-ASR: max_tokens ({}) reached without EOS token",
+                max_tokens
+            );
+        }
+
+        Ok(self.tokenizer.decode(&output_tokens))
+    }
+
+    /// Full transcription pipeline: audio samples → raw decoded text.
+    ///
+    /// Returns the raw model output including the language prefix. The caller
+    /// (engine layer) is responsible for stripping the prefix.
+    pub fn transcribe(
+        &mut self,
+        samples: &[f32],
+        max_tokens: usize,
+    ) -> Result<String, TranscribeError> {
+        // Qwen3-ASR is designed for utterance-level audio (mel chunk_length = 30 s).
+        const MAX_SAMPLES: usize = 60 * 16_000;
+        if samples.len() > MAX_SAMPLES {
+            return Err(TranscribeError::Inference(format!(
+                "audio too long: {} samples ({:.1} s); maximum is 60 s",
+                samples.len(),
+                samples.len() as f32 / 16_000.0,
+            )));
+        }
+
+        let mel = log_mel_spectrogram(samples);
+        let mel_frames = mel.shape()[2];
+        let audio_tokens = get_feat_extract_output_lengths(mel_frames);
+        log::debug!(
+            "Mel frames: {}, encoder output tokens: {}",
+            mel_frames,
+            audio_tokens
+        );
+
+        if audio_tokens == 0 {
+            return Ok(String::new());
+        }
+
+        let audio_features = self.encode(&mel)?;
+        log::debug!("Audio features shape: {:?}", audio_features.shape());
+
+        let encoder_frames = audio_features.shape()[1];
+        if encoder_frames != audio_tokens {
+            return Err(TranscribeError::Inference(format!(
+                "Qwen3-ASR encoder produced {} frames, expected {} from mel formula \
+                 (mel_frames={}, audio_tokens={})",
+                encoder_frames, audio_tokens, mel_frames, audio_tokens
+            )));
+        }
+
+        self.greedy_decode(&audio_features, max_tokens)
+    }
+}
+
+/// Load the embedding cache from a raw binary file.
+///
+/// Shape `[vocab_size, hidden_size]`, row-major. The storage dtype is read from
+/// `config.embed_tokens_dtype` ("float16" or "float32"). FP16 data is cast to
+/// f32 on load.
+fn load_embed_cache(path: &Path, config: &Qwen3AsrConfig) -> Result<Array2<f32>, TranscribeError> {
+    use super::config::EmbedDtype;
+
+    let vocab_size = config.decoder.vocab_size;
+    let hidden_size = config.decoder.hidden_size;
+    let n_elements = vocab_size * hidden_size;
+    let bpe = config.embed_tokens_dtype.bytes_per_element();
+    let expected_bytes = n_elements * bpe;
+
+    let file_size = path.metadata()?.len() as usize;
+    if file_size != expected_bytes {
+        return Err(TranscribeError::Config(format!(
+            "embed_tokens.bin size {} != expected {} ({}x{}x{}, dtype={:?})",
+            file_size, expected_bytes, vocab_size, hidden_size, bpe, config.embed_tokens_dtype
+        )));
+    }
+
+    let data = std::fs::read(path)?;
+
+    let float_data: Vec<f32> = match config.embed_tokens_dtype {
+        EmbedDtype::Float16 => {
+            log::info!(
+                "Loading FP16 embedding cache ({} MB)",
+                file_size / (1024 * 1024)
+            );
+            data.chunks_exact(2)
+                .map(|chunk| f16_to_f32(u16::from_le_bytes([chunk[0], chunk[1]])))
+                .collect()
+        }
+        EmbedDtype::Float32 => {
+            log::info!(
+                "Loading FP32 embedding cache ({} MB)",
+                file_size / (1024 * 1024)
+            );
+            data.chunks_exact(4)
+                .map(|chunk| f32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]))
+                .collect()
+        }
+    };
+
+    Ok(Array2::from_shape_vec(
+        (vocab_size, hidden_size),
+        float_data,
+    )?)
+}
+
+/// Convert an IEEE 754 half-precision float (u16) to f32.
+#[inline]
+fn f16_to_f32(h: u16) -> f32 {
+    let sign = ((h >> 15) & 1) as u32;
+    let exp = ((h >> 10) & 0x1F) as u32;
+    let frac = (h & 0x3FF) as u32;
+
+    if exp == 0 {
+        if frac == 0 {
+            // ±0
+            f32::from_bits(sign << 31)
+        } else {
+            // Subnormal: normalize
+            let mut e = exp;
+            let mut f = frac;
+            while f & 0x400 == 0 {
+                f <<= 1;
+                e += 1;
+            }
+            f &= 0x3FF;
+            let exp32 = 127 - 15 - e + 1;
+            f32::from_bits((sign << 31) | (exp32 << 23) | (f << 13))
+        }
+    } else if exp == 31 {
+        // Inf / NaN
+        f32::from_bits((sign << 31) | (0xFF << 23) | (frac << 13))
+    } else {
+        // Normal
+        let exp32 = exp + 127 - 15;
+        f32::from_bits((sign << 31) | (exp32 << 23) | (frac << 13))
+    }
+}
+
+/// Argmax over a 3D logits array at `[0, pos, :]`.
+///
+/// Returns `TranscribeError::Inference` if the array does not have shape `[1, T, vocab]`
+/// or if `pos >= T`.
+fn argmax_slice(logits: &ndarray::ArrayViewD<'_, f32>, pos: usize) -> Result<i64, TranscribeError> {
+    let shape = logits.shape();
+    if logits.ndim() != 3 || shape[0] != 1 {
+        return Err(TranscribeError::Inference(format!(
+            "argmax_slice: expected shape [1, T, vocab], got {:?}",
+            shape
+        )));
+    }
+    if pos >= shape[1] {
+        return Err(TranscribeError::Inference(format!(
+            "argmax_slice: pos {} out of range for sequence length {}",
+            pos, shape[1]
+        )));
+    }
+
+    let vocab_size = shape[2];
+
+    // Use contiguous slice for cache-friendly linear scan.
+    // ORT output tensors are row-major, so [0, pos, :] is a contiguous block.
+    // This enables LLVM to auto-vectorize the argmax with AVX-512.
+    let row = logits.slice(ndarray::s![0, pos, ..]);
+    if let Some(slice) = row.as_slice() {
+        let best_idx = slice
+            .iter()
+            .enumerate()
+            .fold((0usize, f32::NEG_INFINITY), |(bi, bv), (i, &v)| {
+                if v > bv {
+                    (i, v)
+                } else {
+                    (bi, bv)
+                }
+            })
+            .0;
+        return Ok(best_idx as i64);
+    }
+
+    // Fallback: non-contiguous layout (should not occur with ORT CPU output tensors)
+    let mut best_idx = 0i64;
+    let mut best_val = f32::NEG_INFINITY;
+    for v in 0..vocab_size {
+        let val = logits[[0, pos, v]];
+        if val > best_val {
+            best_val = val;
+            best_idx = v as i64;
+        }
+    }
+    Ok(best_idx)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::f16_to_f32;
+
+    #[test]
+    fn f16_positive_zero() {
+        assert_eq!(f16_to_f32(0x0000), 0.0f32);
+        assert!(f16_to_f32(0x0000).is_sign_positive());
+    }
+
+    #[test]
+    fn f16_negative_zero() {
+        assert_eq!(f16_to_f32(0x8000), -0.0f32);
+        assert!(f16_to_f32(0x8000).is_sign_negative());
+    }
+
+    #[test]
+    fn f16_one() {
+        assert_eq!(f16_to_f32(0x3C00), 1.0f32);
+    }
+
+    #[test]
+    fn f16_negative_one() {
+        assert_eq!(f16_to_f32(0xBC00), -1.0f32);
+    }
+
+    #[test]
+    fn f16_positive_infinity() {
+        assert_eq!(f16_to_f32(0x7C00), f32::INFINITY);
+    }
+
+    #[test]
+    fn f16_negative_infinity() {
+        assert_eq!(f16_to_f32(0xFC00), f32::NEG_INFINITY);
+    }
+
+    #[test]
+    fn f16_nan() {
+        assert!(f16_to_f32(0x7E00).is_nan());
+    }
+
+    #[test]
+    fn f16_smallest_subnormal() {
+        // 2^-24 ≈ 5.96e-8
+        let val = f16_to_f32(0x0001);
+        assert!(val > 0.0);
+        assert!((val - 5.960_464_5e-8).abs() < 1e-12);
+    }
+
+    #[test]
+    fn f16_largest_subnormal() {
+        // 0x03FF = 0.000_111_111_111_1 * 2^-14 ≈ 6.098e-5
+        let val = f16_to_f32(0x03FF);
+        assert!(val > 0.0);
+        assert!((val - 6.097_555e-5).abs() < 1e-9);
+    }
+
+    #[test]
+    fn f16_max_finite() {
+        // 0x7BFF = 65504.0
+        assert_eq!(f16_to_f32(0x7BFF), 65504.0f32);
+    }
+
+    #[test]
+    fn f16_common_values() {
+        assert_eq!(f16_to_f32(0x4000), 2.0f32);
+        assert_eq!(f16_to_f32(0x3800), 0.5f32);
+        assert!((f16_to_f32(0x3555) - 0.3333).abs() < 0.001);
+    }
+}

--- a/src/onnx/qwen3/model.rs
+++ b/src/onnx/qwen3/model.rs
@@ -10,7 +10,9 @@ use crate::TranscribeError;
 
 use super::config::Qwen3AsrConfig;
 use super::mel::{self, log_mel_spectrogram};
-use super::prompt::{build_prompt_ids, get_audio_pad_range, get_feat_extract_output_lengths};
+use super::prompt::{
+    build_prompt_ids_with_language, get_audio_pad_range, get_feat_extract_output_lengths,
+};
 use super::tokenizer::Qwen3Tokenizer;
 
 pub struct Qwen3AsrModel {
@@ -41,6 +43,7 @@ impl Qwen3AsrModel {
                 && st.audio_start_token_id >= 0
                 && st.audio_end_token_id >= 0
                 && st.audio_pad_token_id >= 0
+                && st.asr_text_token_id >= 0
                 && !st.eos_token_ids.is_empty()
                 && st.eos_token_ids.iter().all(|&id| id >= 0);
             if !valid {
@@ -151,11 +154,16 @@ impl Qwen3AsrModel {
         &mut self,
         audio_features: &Array3<f32>,
         max_tokens: usize,
+        language_token_ids: Option<&[i64]>,
     ) -> Result<String, TranscribeError> {
         // Cap to prevent unbounded KV cache growth from unchecked callers.
         let max_tokens = max_tokens.min(4096);
         let audio_token_count = audio_features.shape()[1];
-        let prompt_ids = build_prompt_ids(&self.config.special_tokens, audio_token_count);
+        let prompt_ids = build_prompt_ids_with_language(
+            &self.config.special_tokens,
+            audio_token_count,
+            language_token_ids,
+        );
         let seq_len = prompt_ids.len();
 
         let (audio_start, _) =
@@ -279,12 +287,12 @@ impl Qwen3AsrModel {
             }
         }
 
-        if !self
+        let eos_reached = self
             .config
             .special_tokens
             .eos_token_ids
-            .contains(&current_token)
-        {
+            .contains(&current_token);
+        if !eos_reached {
             log::warn!(
                 "Qwen3-ASR: max_tokens ({}) reached without EOS token",
                 max_tokens
@@ -292,11 +300,19 @@ impl Qwen3AsrModel {
         }
 
         // The model should produce `language <Name> <asr_text> <transcription>`.
-        // If the <asr_text> separator token is absent, the decoder failed to produce
-        // a valid transcription (e.g. degenerate "ology" output from int4 quantization
-        // noise on non-speech audio). Return empty string rather than garbage.
+        // If the <asr_text> separator token is absent AND the model completed
+        // normally (EOS seen), the decoder failed to produce a valid transcription
+        // (e.g. degenerate "ology" output from int4 quantization noise on
+        // non-speech audio). Return empty string rather than garbage.
+        //
+        // When max_tokens truncated the output, the <asr_text> token may simply
+        // not have been reached yet — this is not degenerate, just truncated.
+        //
+        // When language_token_ids is provided, <asr_text> was forced into the
+        // prompt (not generated), so it won't appear in output_tokens — skip
+        // the guard in that case.
         let asr_text_id = self.config.special_tokens.asr_text_token_id;
-        if !output_tokens.contains(&asr_text_id) {
+        if language_token_ids.is_none() && eos_reached && !output_tokens.contains(&asr_text_id) {
             let preview: Vec<_> = output_tokens.iter().take(20).collect();
             log::warn!(
                 "Qwen3-ASR: no <asr_text> token in output ({} tokens, first 20: {:?}); \
@@ -318,6 +334,7 @@ impl Qwen3AsrModel {
         &mut self,
         samples: &[f32],
         max_tokens: usize,
+        language_token_ids: Option<&[i64]>,
     ) -> Result<String, TranscribeError> {
         // Qwen3-ASR is designed for utterance-level audio (mel chunk_length = 30 s).
         const MAX_SAMPLES: usize = 60 * 16_000;
@@ -354,7 +371,15 @@ impl Qwen3AsrModel {
             )));
         }
 
-        self.greedy_decode(&audio_features, max_tokens)
+        self.greedy_decode(&audio_features, max_tokens, language_token_ids)
+    }
+
+    /// Encode a language name to token IDs using the tokenizer.
+    ///
+    /// Returns the token IDs for the language name (e.g. "English" → \[22574\]).
+    /// The caller should cache the result for reuse across transcriptions.
+    pub fn encode_language(&self, language: &str) -> Vec<i64> {
+        self.tokenizer.encode(language)
     }
 }
 

--- a/src/onnx/qwen3/prompt.rs
+++ b/src/onnx/qwen3/prompt.rs
@@ -1,7 +1,12 @@
 //! Prompt template construction for Qwen3-ASR.
 //!
-//! Builds the token ID sequence:
+//! Builds the token ID sequence for the chat-style prompt that Qwen3-ASR expects.
+//! Standard prompt (no language hint):
 //!   `<|im_start|>system\n<|im_end|>\n<|im_start|>user\n<|audio_start|><|audio_pad|>*N<|audio_end|><|im_end|>\n<|im_start|>assistant\n`
+//!
+//! With language hint (official Qwen3-ASR template):
+//!   `...<|im_start|>assistant\nlanguage {Name}<asr_text>`
+//! This forces the model to skip language detection and go straight to transcription.
 
 use super::config::SpecialTokens;
 
@@ -13,6 +18,8 @@ const SYSTEM_TOKEN_ID: i64 = 9125; // "system"
 const USER_TOKEN_ID: i64 = 882; // "user"
 const ASSISTANT_TOKEN_ID: i64 = 77091; // "assistant"
 const NEWLINE_TOKEN_ID: i64 = 198; // "\n"
+/// Token for "language" — the fixed prefix of the assistant's language tag.
+const LANGUAGE_TOKEN_ID: i64 = 11528; // "language"
 
 /// Compute the number of encoder output tokens from a mel frame count.
 ///
@@ -28,10 +35,39 @@ pub fn get_feat_extract_output_lengths(input_lengths: usize) -> usize {
 
 /// Build the complete prompt token ID sequence for ASR transcription.
 ///
-/// `audio_token_count` is the number of encoder output tokens (use
-/// `get_feat_extract_output_lengths(mel_frames)` to compute from mel frame count).
-pub fn build_prompt_ids(special_tokens: &SpecialTokens, audio_token_count: usize) -> Vec<i64> {
-    let mut ids = Vec::with_capacity(audio_token_count + 15);
+/// This builds the standard prompt with an empty system turn and no language
+/// hint. Equivalent to `build_prompt_ids_with_language(st, n, None)`.
+#[cfg(test)]
+pub(crate) fn build_prompt_ids(
+    special_tokens: &SpecialTokens,
+    audio_token_count: usize,
+) -> Vec<i64> {
+    build_prompt_ids_with_language(special_tokens, audio_token_count, None)
+}
+
+/// Build a prompt with optional language hint using the official Qwen3-ASR template.
+///
+/// When `language_token_ids` is provided, the assistant prefix is extended with
+/// `language {Name}<asr_text>`, forcing the model to skip language detection and
+/// begin transcription immediately. This matches the official Qwen3-ASR inference
+/// template (see `qwen_asr/core/vllm_backend/qwen3_asr.py`).
+///
+/// The forced `<asr_text>` token also prevents degenerate output (e.g. "ology")
+/// from int4 quantization noise on non-speech audio, since the model never gets
+/// the chance to produce a wrong first token.
+///
+/// `language_token_ids` should be the tokenized form of ` {Name}` (with leading
+/// space) — e.g. `encode(" English")` → `[6364]`. The "language" prefix token
+/// is added automatically.
+///
+/// When `language_token_ids` is `None`, builds the standard prompt with no
+/// language hint (model auto-detects language).
+pub fn build_prompt_ids_with_language(
+    special_tokens: &SpecialTokens,
+    audio_token_count: usize,
+    language_token_ids: Option<&[i64]>,
+) -> Vec<i64> {
+    let mut ids = Vec::with_capacity(audio_token_count + 20);
 
     // System turn (empty content)
     ids.push(special_tokens.im_start_token_id);
@@ -60,6 +96,15 @@ pub fn build_prompt_ids(special_tokens: &SpecialTokens, audio_token_count: usize
     ids.push(special_tokens.im_start_token_id);
     ids.push(ASSISTANT_TOKEN_ID);
     ids.push(NEWLINE_TOKEN_ID);
+
+    // Language hint: force "language {Name}<asr_text>" as assistant prefix.
+    // This pre-fills the assistant's response so the model skips language
+    // detection and begins transcription after <asr_text>.
+    if let Some(lang_ids) = language_token_ids {
+        ids.push(LANGUAGE_TOKEN_ID); // "language"
+        ids.extend_from_slice(lang_ids); // " English" (with leading space)
+        ids.push(special_tokens.asr_text_token_id); // <asr_text>
+    }
 
     ids
 }
@@ -102,7 +147,7 @@ mod tests {
     fn test_encoder_output_lengths() {
         assert_eq!(get_feat_extract_output_lengths(0), 0);
         assert_eq!(get_feat_extract_output_lengths(1), 1);
-        assert_eq!(get_feat_extract_output_lengths(99), 13); // boundary: last frame before window
+        assert_eq!(get_feat_extract_output_lengths(99), 13);
         assert_eq!(get_feat_extract_output_lengths(100), 13);
         assert_eq!(get_feat_extract_output_lengths(200), 26);
         assert_eq!(get_feat_extract_output_lengths(997), 130);
@@ -113,30 +158,25 @@ mod tests {
         let st = test_special_tokens();
         let ids = build_prompt_ids(&st, 10);
 
-        // Should start with im_start, system, newline, im_end, newline
         assert_eq!(ids[0], st.im_start_token_id);
         assert_eq!(ids[1], SYSTEM_TOKEN_ID);
         assert_eq!(ids[2], NEWLINE_TOKEN_ID);
         assert_eq!(ids[3], st.im_end_token_id);
         assert_eq!(ids[4], NEWLINE_TOKEN_ID);
 
-        // User turn
         assert_eq!(ids[5], st.im_start_token_id);
         assert_eq!(ids[6], USER_TOKEN_ID);
         assert_eq!(ids[7], NEWLINE_TOKEN_ID);
         assert_eq!(ids[8], st.audio_start_token_id);
 
-        // 10 audio_pad tokens at positions 9..19
         for i in 9..19 {
             assert_eq!(ids[i], st.audio_pad_token_id);
         }
 
-        // audio_end, im_end, newline
         assert_eq!(ids[19], st.audio_end_token_id);
         assert_eq!(ids[20], st.im_end_token_id);
         assert_eq!(ids[21], NEWLINE_TOKEN_ID);
 
-        // Assistant turn
         assert_eq!(ids[22], st.im_start_token_id);
         assert_eq!(ids[23], ASSISTANT_TOKEN_ID);
         assert_eq!(ids[24], NEWLINE_TOKEN_ID);
@@ -152,5 +192,42 @@ mod tests {
         assert_eq!(start, 9);
         assert_eq!(end, 19);
         assert_eq!(end - start, 10);
+    }
+
+    #[test]
+    fn test_build_prompt_ids_with_language() {
+        let st = test_special_tokens();
+        // " English" (with leading space) as the reference tokenizer produces
+        let lang_ids: &[i64] = &[6364];
+        let ids = build_prompt_ids_with_language(&st, 5, Some(lang_ids));
+
+        // Standard prompt structure up to assistant turn
+        assert_eq!(ids[0], st.im_start_token_id); // system turn
+        assert_eq!(ids[3], st.im_end_token_id);
+        assert_eq!(ids[5], st.im_start_token_id); // user turn
+        assert_eq!(ids[8], st.audio_start_token_id);
+        for i in 9..14 {
+            assert_eq!(ids[i], st.audio_pad_token_id); // 5 audio tokens
+        }
+        assert_eq!(ids[14], st.audio_end_token_id);
+        assert_eq!(ids[15], st.im_end_token_id);
+
+        // Assistant turn with forced language prefix
+        assert_eq!(ids[17], st.im_start_token_id);
+        assert_eq!(ids[18], ASSISTANT_TOKEN_ID);
+        assert_eq!(ids[19], NEWLINE_TOKEN_ID);
+        assert_eq!(ids[20], LANGUAGE_TOKEN_ID); // "language"
+        assert_eq!(ids[21], 6364); // " English"
+        assert_eq!(ids[22], st.asr_text_token_id); // <asr_text>
+
+        assert_eq!(ids.len(), 23); // 20 standard + 3 language hint
+    }
+
+    #[test]
+    fn test_language_none_matches_standard_prompt() {
+        let st = test_special_tokens();
+        let standard = build_prompt_ids(&st, 10);
+        let with_none = build_prompt_ids_with_language(&st, 10, None);
+        assert_eq!(standard, with_none);
     }
 }

--- a/src/onnx/qwen3/prompt.rs
+++ b/src/onnx/qwen3/prompt.rs
@@ -94,6 +94,7 @@ mod tests {
             audio_start_token_id: 151669,
             audio_end_token_id: 151670,
             audio_pad_token_id: 151676,
+            asr_text_token_id: 151704,
         }
     }
 

--- a/src/onnx/qwen3/prompt.rs
+++ b/src/onnx/qwen3/prompt.rs
@@ -1,0 +1,155 @@
+//! Prompt template construction for Qwen3-ASR.
+//!
+//! Builds the token ID sequence:
+//!   `<|im_start|>system\n<|im_end|>\n<|im_start|>user\n<|audio_start|><|audio_pad|>*N<|audio_end|><|im_end|>\n<|im_start|>assistant\n`
+
+use super::config::SpecialTokens;
+
+/// Well-known text token IDs from the Qwen3-ASR tokenizer vocabulary.
+/// These are fixed across all Qwen3/Qwen2.5 tokenizer versions — they map to
+/// the English words "system", "user", "assistant" and the newline character in
+/// the base GPT-2 BPE vocabulary that Qwen inherits.
+const SYSTEM_TOKEN_ID: i64 = 9125; // "system"
+const USER_TOKEN_ID: i64 = 882; // "user"
+const ASSISTANT_TOKEN_ID: i64 = 77091; // "assistant"
+const NEWLINE_TOKEN_ID: i64 = 198; // "\n"
+
+/// Compute the number of encoder output tokens from a mel frame count.
+///
+/// Matches the native Qwen3-ASR formula: windowed conv with 100-frame windows,
+/// three stride-2 conv layers on the remainder, 13 tokens per full window.
+pub fn get_feat_extract_output_lengths(input_lengths: usize) -> usize {
+    let leave = input_lengths % 100;
+    let mut t = leave.div_ceil(2);
+    t = t.div_ceil(2);
+    t = t.div_ceil(2);
+    t + (input_lengths / 100) * 13
+}
+
+/// Build the complete prompt token ID sequence for ASR transcription.
+///
+/// `audio_token_count` is the number of encoder output tokens (use
+/// `get_feat_extract_output_lengths(mel_frames)` to compute from mel frame count).
+pub fn build_prompt_ids(special_tokens: &SpecialTokens, audio_token_count: usize) -> Vec<i64> {
+    let mut ids = Vec::with_capacity(audio_token_count + 15);
+
+    // System turn (empty content)
+    ids.push(special_tokens.im_start_token_id);
+    ids.push(SYSTEM_TOKEN_ID);
+    ids.push(NEWLINE_TOKEN_ID);
+    ids.push(special_tokens.im_end_token_id);
+    ids.push(NEWLINE_TOKEN_ID);
+
+    // User turn with audio
+    ids.push(special_tokens.im_start_token_id);
+    ids.push(USER_TOKEN_ID);
+    ids.push(NEWLINE_TOKEN_ID);
+    ids.push(special_tokens.audio_start_token_id);
+
+    // Audio pad tokens — replaced by encoder output embeddings at runtime
+    ids.extend(std::iter::repeat_n(
+        special_tokens.audio_pad_token_id,
+        audio_token_count,
+    ));
+
+    ids.push(special_tokens.audio_end_token_id);
+    ids.push(special_tokens.im_end_token_id);
+    ids.push(NEWLINE_TOKEN_ID);
+
+    // Assistant turn prefix
+    ids.push(special_tokens.im_start_token_id);
+    ids.push(ASSISTANT_TOKEN_ID);
+    ids.push(NEWLINE_TOKEN_ID);
+
+    ids
+}
+
+/// Find the `[start, end)` range of `audio_pad` token positions in the prompt.
+pub fn get_audio_pad_range(
+    prompt_ids: &[i64],
+    audio_pad_token_id: i64,
+) -> Result<(usize, usize), String> {
+    let start = prompt_ids
+        .iter()
+        .position(|&id| id == audio_pad_token_id)
+        .ok_or_else(|| "No audio_pad tokens in prompt".to_string())?;
+    let end = prompt_ids
+        .iter()
+        .rposition(|&id| id == audio_pad_token_id)
+        .ok_or_else(|| "No audio_pad tokens in prompt".to_string())?
+        + 1;
+    Ok((start, end))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_special_tokens() -> SpecialTokens {
+        SpecialTokens {
+            eos_token_ids: vec![151643, 151645],
+            pad_token_id: 151643,
+            im_start_token_id: 151644,
+            im_end_token_id: 151645,
+            audio_start_token_id: 151669,
+            audio_end_token_id: 151670,
+            audio_pad_token_id: 151676,
+        }
+    }
+
+    #[test]
+    fn test_encoder_output_lengths() {
+        assert_eq!(get_feat_extract_output_lengths(0), 0);
+        assert_eq!(get_feat_extract_output_lengths(1), 1);
+        assert_eq!(get_feat_extract_output_lengths(99), 13); // boundary: last frame before window
+        assert_eq!(get_feat_extract_output_lengths(100), 13);
+        assert_eq!(get_feat_extract_output_lengths(200), 26);
+        assert_eq!(get_feat_extract_output_lengths(997), 130);
+    }
+
+    #[test]
+    fn test_build_prompt_ids_structure() {
+        let st = test_special_tokens();
+        let ids = build_prompt_ids(&st, 10);
+
+        // Should start with im_start, system, newline, im_end, newline
+        assert_eq!(ids[0], st.im_start_token_id);
+        assert_eq!(ids[1], SYSTEM_TOKEN_ID);
+        assert_eq!(ids[2], NEWLINE_TOKEN_ID);
+        assert_eq!(ids[3], st.im_end_token_id);
+        assert_eq!(ids[4], NEWLINE_TOKEN_ID);
+
+        // User turn
+        assert_eq!(ids[5], st.im_start_token_id);
+        assert_eq!(ids[6], USER_TOKEN_ID);
+        assert_eq!(ids[7], NEWLINE_TOKEN_ID);
+        assert_eq!(ids[8], st.audio_start_token_id);
+
+        // 10 audio_pad tokens at positions 9..19
+        for i in 9..19 {
+            assert_eq!(ids[i], st.audio_pad_token_id);
+        }
+
+        // audio_end, im_end, newline
+        assert_eq!(ids[19], st.audio_end_token_id);
+        assert_eq!(ids[20], st.im_end_token_id);
+        assert_eq!(ids[21], NEWLINE_TOKEN_ID);
+
+        // Assistant turn
+        assert_eq!(ids[22], st.im_start_token_id);
+        assert_eq!(ids[23], ASSISTANT_TOKEN_ID);
+        assert_eq!(ids[24], NEWLINE_TOKEN_ID);
+
+        assert_eq!(ids.len(), 25); // 15 fixed + 10 audio_pad
+    }
+
+    #[test]
+    fn test_audio_pad_range() {
+        let st = test_special_tokens();
+        let ids = build_prompt_ids(&st, 10);
+        let (start, end) = get_audio_pad_range(&ids, st.audio_pad_token_id).unwrap();
+        assert_eq!(start, 9);
+        assert_eq!(end, 19);
+        assert_eq!(end - start, 10);
+    }
+}

--- a/src/onnx/qwen3/tokenizer.rs
+++ b/src/onnx/qwen3/tokenizer.rs
@@ -1,8 +1,15 @@
-//! Decode-only BPE tokenizer for Qwen3-ASR.
+//! BPE tokenizer for Qwen3-ASR (encode + decode).
 //!
-//! Parses `tokenizer.json` (HuggingFace format) and decodes token IDs to text
-//! using the GPT-2 byte-level BPE mapping. No dependency on the `tokenizers`
-//! crate (follows Moonshine's pattern for Windows build compatibility).
+//! Parses `tokenizer.json` (HuggingFace format) and provides both encoding
+//! (text → token IDs) and decoding (token IDs → text) using the GPT-2
+//! byte-level BPE mapping. No dependency on the `tokenizers` crate (follows
+//! Moonshine's pattern for Windows build compatibility).
+//!
+//! Encoding uses greedy longest-match on the byte-level vocabulary. This does
+//! not apply BPE merge rules, so results may differ from the reference tokenizer
+//! on rare subword boundaries. For the short, common English text used in
+//! language-conditioned prompts (e.g. "English", "Chinese"), this produces
+//! identical output to the reference.
 
 use std::collections::{HashMap, HashSet};
 use std::fs;
@@ -10,10 +17,15 @@ use std::path::Path;
 
 use crate::TranscribeError;
 
-/// Decode-only tokenizer that maps token IDs to text.
+/// BPE tokenizer that maps between token IDs and text.
 pub struct Qwen3Tokenizer {
     /// Maps token ID to raw byte sequence (after GPT-2 unicode-to-byte decode).
     id_to_bytes: HashMap<u32, Vec<u8>>,
+    /// Maps raw byte sequence to token ID (reverse of `id_to_bytes`).
+    /// Used for greedy longest-match encoding.
+    bytes_to_id: HashMap<Vec<u8>, u32>,
+    /// Maximum token length in bytes (for bounding the greedy search).
+    max_token_len: usize,
     /// Set of special token IDs to skip during decode.
     special_token_ids: HashSet<u32>,
 }
@@ -69,10 +81,67 @@ impl Qwen3Tokenizer {
             }
         }
 
+        // Build reverse map for encoding (bytes → id).
+        // For duplicate byte sequences, prefer the lower token ID.
+        let mut bytes_to_id: HashMap<Vec<u8>, u32> = HashMap::new();
+        let mut max_token_len = 0usize;
+        for (&id, bytes) in &id_to_bytes {
+            max_token_len = max_token_len.max(bytes.len());
+            bytes_to_id
+                .entry(bytes.clone())
+                .and_modify(|existing| {
+                    if id < *existing {
+                        *existing = id;
+                    }
+                })
+                .or_insert(id);
+        }
+
         Ok(Self {
             id_to_bytes,
+            bytes_to_id,
+            max_token_len,
             special_token_ids,
         })
+    }
+
+    /// Encode a text string to token IDs using greedy longest-match.
+    ///
+    /// This does not apply BPE merge rules — it greedily matches the longest
+    /// vocabulary entry at each position. For common English words and language
+    /// names this produces identical results to the reference BPE tokenizer.
+    /// Results may differ on rare subword boundaries.
+    pub(crate) fn encode(&self, text: &str) -> Vec<i64> {
+        let bytes = text.as_bytes();
+        let mut ids = Vec::new();
+        let mut pos = 0;
+
+        while pos < bytes.len() {
+            // Greedy longest match: try decreasing lengths from max_token_len
+            let max_len = self.max_token_len.min(bytes.len() - pos);
+            let mut matched = false;
+            for len in (1..=max_len).rev() {
+                let candidate = &bytes[pos..pos + len];
+                if let Some(&id) = self.bytes_to_id.get(candidate) {
+                    ids.push(id as i64);
+                    pos += len;
+                    matched = true;
+                    break;
+                }
+            }
+            if !matched {
+                // Skip unrecognized byte (shouldn't happen with GPT-2 BPE
+                // which has single-byte entries for all 256 byte values)
+                log::warn!(
+                    "Qwen3 tokenizer encode: no match for byte 0x{:02x} at position {}",
+                    bytes[pos],
+                    pos
+                );
+                pos += 1;
+            }
+        }
+
+        ids
     }
 
     /// Decode a sequence of token IDs to a string, skipping special tokens.

--- a/src/onnx/qwen3/tokenizer.rs
+++ b/src/onnx/qwen3/tokenizer.rs
@@ -1,0 +1,179 @@
+//! Decode-only BPE tokenizer for Qwen3-ASR.
+//!
+//! Parses `tokenizer.json` (HuggingFace format) and decodes token IDs to text
+//! using the GPT-2 byte-level BPE mapping. No dependency on the `tokenizers`
+//! crate (follows Moonshine's pattern for Windows build compatibility).
+
+use std::collections::{HashMap, HashSet};
+use std::fs;
+use std::path::Path;
+
+use crate::TranscribeError;
+
+/// Decode-only tokenizer that maps token IDs to text.
+pub struct Qwen3Tokenizer {
+    /// Maps token ID to raw byte sequence (after GPT-2 unicode-to-byte decode).
+    id_to_bytes: HashMap<u32, Vec<u8>>,
+    /// Set of special token IDs to skip during decode.
+    special_token_ids: HashSet<u32>,
+}
+
+impl Qwen3Tokenizer {
+    pub fn new(model_dir: &Path) -> Result<Self, TranscribeError> {
+        let tokenizer_path = model_dir.join("tokenizer.json");
+        // Reads the entire tokenizer.json into memory. Typical Qwen/GPT-2 tokenizer files
+        // are ~2 MB; this is acceptable for a one-time model-load operation.
+        let file = fs::File::open(&tokenizer_path)?;
+        let reader = std::io::BufReader::new(file);
+        let json: serde_json::Value = serde_json::from_reader(reader)?;
+
+        let byte_decoder = build_gpt2_byte_decoder();
+
+        // Build id → bytes vocabulary from model.vocab
+        let mut id_to_bytes = HashMap::new();
+        if let Some(model) = json.get("model") {
+            if let Some(vocab) = model.get("vocab").and_then(|v| v.as_object()) {
+                for (token_str, id_val) in vocab {
+                    if let Some(id) = id_val.as_u64() {
+                        let bytes = decode_token_string(token_str, &byte_decoder);
+                        id_to_bytes.insert(id as u32, bytes);
+                    }
+                }
+            }
+        }
+
+        if id_to_bytes.is_empty() {
+            return Err(TranscribeError::Config(
+                "No vocabulary found in tokenizer.json".into(),
+            ));
+        }
+
+        log::info!(
+            "Loaded {} tokens from Qwen3-ASR vocabulary",
+            id_to_bytes.len()
+        );
+
+        // Collect special token IDs from added_tokens
+        let mut special_token_ids = HashSet::new();
+        if let Some(added_tokens) = json.get("added_tokens").and_then(|v| v.as_array()) {
+            for token in added_tokens {
+                let is_special = token
+                    .get("special")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false);
+                if is_special {
+                    if let Some(id) = token.get("id").and_then(|v| v.as_u64()) {
+                        special_token_ids.insert(id as u32);
+                    }
+                }
+            }
+        }
+
+        Ok(Self {
+            id_to_bytes,
+            special_token_ids,
+        })
+    }
+
+    /// Decode a sequence of token IDs to a string, skipping special tokens.
+    pub fn decode(&self, token_ids: &[i64]) -> String {
+        let mut bytes = Vec::new();
+        for &id in token_ids {
+            if id < 0 {
+                log::warn!("Qwen3 tokenizer: skipping negative token ID {}", id);
+                continue;
+            }
+            let id_u32 = id as u32;
+            if self.special_token_ids.contains(&id_u32) {
+                continue;
+            }
+            if let Some(token_bytes) = self.id_to_bytes.get(&id_u32) {
+                bytes.extend_from_slice(token_bytes);
+            }
+        }
+        String::from_utf8_lossy(&bytes).into_owned()
+    }
+}
+
+/// Build the GPT-2 unicode-to-byte decoder table.
+///
+/// GPT-2 BPE uses a mapping from byte values (0-255) to printable Unicode characters
+/// to avoid control characters in the vocabulary. This builds the inverse mapping.
+fn build_gpt2_byte_decoder() -> HashMap<char, u8> {
+    let mut byte_encoder: HashMap<u8, char> = HashMap::new();
+
+    // Printable ASCII ranges that map to themselves
+    // '!' (33) through '~' (126)
+    for b in b'!'..=b'~' {
+        byte_encoder.insert(b, b as char);
+    }
+    // Latin-1 supplement range: 161-172, 174-255
+    for b in 0xa1u8..=0xacu8 {
+        byte_encoder.insert(b, b as char);
+    }
+    for b in 0xaeu8..=0xffu8 {
+        byte_encoder.insert(b, b as char);
+    }
+
+    // Remaining bytes get mapped to Unicode starting at 256
+    let mut n = 256u32;
+    for b in 0u8..=255u8 {
+        if let std::collections::hash_map::Entry::Vacant(e) = byte_encoder.entry(b) {
+            e.insert(char::from_u32(n).unwrap());
+            n += 1;
+        }
+    }
+
+    // Invert: char → byte
+    byte_encoder.into_iter().map(|(b, c)| (c, b)).collect()
+}
+
+/// Decode a GPT-2 BPE token string to raw bytes.
+fn decode_token_string(token_str: &str, byte_decoder: &HashMap<char, u8>) -> Vec<u8> {
+    token_str
+        .chars()
+        .filter_map(|c| byte_decoder.get(&c).copied())
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_gpt2_byte_decoder_coverage() {
+        let decoder = build_gpt2_byte_decoder();
+        // Should have exactly 256 entries (one per byte value)
+        assert_eq!(decoder.len(), 256);
+    }
+
+    #[test]
+    fn test_gpt2_ascii_passthrough() {
+        let decoder = build_gpt2_byte_decoder();
+        // Printable ASCII (0x21-0x7E) maps to itself
+        assert_eq!(decoder[&'A'], b'A');
+        assert_eq!(decoder[&'z'], b'z');
+        assert_eq!(decoder[&'0'], b'0');
+        // Space (0x20) is NOT in the printable range, so it maps to a Unicode
+        // char > 0xFF. Verify it round-trips correctly through encode → decode.
+        let space_exists = decoder.values().any(|&b| b == 0x20);
+        assert!(
+            space_exists,
+            "Space byte should be represented in the decoder"
+        );
+    }
+
+    #[test]
+    fn test_gpt2_space_mapping() {
+        // GPT-2 encodes space (0x20) as 'Ġ' (U+0120).
+        let decoder = build_gpt2_byte_decoder();
+        assert_eq!(decoder[&'\u{0120}'], 0x20);
+    }
+
+    #[test]
+    fn test_decode_token_string_simple() {
+        let decoder = build_gpt2_byte_decoder();
+        let bytes = decode_token_string("Hello", &decoder);
+        assert_eq!(bytes, b"Hello");
+    }
+}

--- a/src/onnx/qwen3/tokenizer.rs
+++ b/src/onnx/qwen3/tokenizer.rs
@@ -119,7 +119,7 @@ fn build_gpt2_byte_decoder() -> HashMap<char, u8> {
     let mut n = 256u32;
     for b in 0u8..=255u8 {
         if let std::collections::hash_map::Entry::Vacant(e) = byte_encoder.entry(b) {
-            e.insert(char::from_u32(n).unwrap());
+            e.insert(char::from_u32(n).expect("BPE byte range always valid Unicode"));
             n += 1;
         }
     }

--- a/src/onnx/sense_voice/mod.rs
+++ b/src/onnx/sense_voice/mod.rs
@@ -424,7 +424,7 @@ impl SpeechModel for SenseVoiceModel {
         CAPABILITIES
     }
 
-    fn transcribe(
+    fn transcribe_raw(
         &mut self,
         samples: &[f32],
         options: &TranscribeOptions,

--- a/src/onnx/session.rs
+++ b/src/onnx/session.rs
@@ -4,6 +4,8 @@ use ort::ep::CoreML;
 use ort::ep::DirectML;
 #[cfg(feature = "ort-rocm")]
 use ort::ep::ROCm;
+#[cfg(feature = "ort-tensorrt")]
+use ort::ep::TensorRT;
 #[cfg(feature = "ort-webgpu")]
 use ort::ep::WebGPU;
 use ort::ep::CPU;
@@ -31,6 +33,18 @@ fn execution_providers() -> Vec<ort::ep::ExecutionProviderDispatch> {
             #[cfg(not(feature = "ort-cuda"))]
             log::warn!(
                 "Accelerator set to CUDA but ort-cuda feature is not enabled; falling back to CPU"
+            );
+        }
+        OrtAccelerator::TensorRt => {
+            #[cfg(feature = "ort-tensorrt")]
+            {
+                eps.push(TensorRT::default().build());
+                // CUDA as fallback for ops TensorRT doesn't support
+                eps.push(CUDA::default().build());
+            }
+            #[cfg(not(feature = "ort-tensorrt"))]
+            log::warn!(
+                "Accelerator set to TensorRT but ort-tensorrt feature is not enabled; falling back to CPU"
             );
         }
         OrtAccelerator::DirectMl => {
@@ -71,6 +85,9 @@ fn execution_providers() -> Vec<ort::ep::ExecutionProviderDispatch> {
             // to opt in.
             // Ref: https://onnxruntime.ai/docs/execution-providers/DirectML-ExecutionProvider.html
             //      https://onnxruntime.ai/docs/execution-providers/WebGPU-ExecutionProvider.html
+            // TensorRT before CUDA so it gets first crack; CUDA handles unsupported ops.
+            #[cfg(feature = "ort-tensorrt")]
+            eps.push(TensorRT::default().build());
             #[cfg(feature = "ort-cuda")]
             eps.push(CUDA::default().build());
             #[cfg(feature = "ort-rocm")]

--- a/src/onnx/session.rs
+++ b/src/onnx/session.rs
@@ -8,11 +8,11 @@ use ort::ep::ROCm;
 use ort::ep::TensorRT;
 #[cfg(feature = "ort-webgpu")]
 use ort::ep::WebGPU;
-#[cfg(feature = "ort-xnnpack")]
-use ort::ep::XNNPACK;
 use ort::ep::CPU;
 #[cfg(feature = "ort-cuda")]
 use ort::ep::CUDA;
+#[cfg(feature = "ort-xnnpack")]
+use ort::ep::XNNPACK;
 
 use ort::session::builder::GraphOptimizationLevel;
 use ort::session::Session;

--- a/src/onnx/session.rs
+++ b/src/onnx/session.rs
@@ -1,10 +1,14 @@
-use ort::execution_providers::CPUExecutionProvider;
-#[cfg(feature = "ort-cuda")]
-use ort::execution_providers::CUDAExecutionProvider;
+#[cfg(feature = "ort-coreml")]
+use ort::ep::CoreML;
 #[cfg(feature = "ort-directml")]
-use ort::execution_providers::DirectMLExecutionProvider;
+use ort::ep::DirectML;
 #[cfg(feature = "ort-rocm")]
-use ort::execution_providers::ROCmExecutionProvider;
+use ort::ep::ROCm;
+#[cfg(feature = "ort-webgpu")]
+use ort::ep::WebGPU;
+use ort::ep::CPU;
+#[cfg(feature = "ort-cuda")]
+use ort::ep::CUDA;
 
 use ort::session::builder::GraphOptimizationLevel;
 use ort::session::Session;
@@ -13,7 +17,7 @@ use std::path::Path;
 use crate::accel::{get_ort_accelerator, OrtAccelerator};
 
 /// Build the execution provider list based on the global accelerator preference.
-fn execution_providers() -> Vec<ort::execution_providers::ExecutionProviderDispatch> {
+fn execution_providers() -> Vec<ort::ep::ExecutionProviderDispatch> {
     let pref = get_ort_accelerator();
     let mut eps = Vec::new();
 
@@ -23,7 +27,7 @@ fn execution_providers() -> Vec<ort::execution_providers::ExecutionProviderDispa
         }
         OrtAccelerator::Cuda => {
             #[cfg(feature = "ort-cuda")]
-            eps.push(CUDAExecutionProvider::default().build());
+            eps.push(CUDA::default().build());
             #[cfg(not(feature = "ort-cuda"))]
             log::warn!(
                 "Accelerator set to CUDA but ort-cuda feature is not enabled; falling back to CPU"
@@ -31,39 +35,65 @@ fn execution_providers() -> Vec<ort::execution_providers::ExecutionProviderDispa
         }
         OrtAccelerator::DirectMl => {
             #[cfg(feature = "ort-directml")]
-            eps.push(DirectMLExecutionProvider::default().build());
+            eps.push(DirectML::default().build());
             #[cfg(not(feature = "ort-directml"))]
             log::warn!("Accelerator set to DirectML but ort-directml feature is not enabled; falling back to CPU");
         }
         OrtAccelerator::Rocm => {
             #[cfg(feature = "ort-rocm")]
-            eps.push(ROCmExecutionProvider::default().build());
+            eps.push(ROCm::default().build());
             #[cfg(not(feature = "ort-rocm"))]
             log::warn!(
                 "Accelerator set to ROCm but ort-rocm feature is not enabled; falling back to CPU"
             );
         }
+        OrtAccelerator::CoreMl => {
+            #[cfg(feature = "ort-coreml")]
+            eps.push(CoreML::default().build());
+            #[cfg(not(feature = "ort-coreml"))]
+            log::warn!(
+                "Accelerator set to CoreML but ort-coreml feature is not enabled; falling back to CPU"
+            );
+        }
+        OrtAccelerator::WebGpu => {
+            #[cfg(feature = "ort-webgpu")]
+            eps.push(WebGPU::default().build());
+            #[cfg(not(feature = "ort-webgpu"))]
+            log::warn!(
+                "Accelerator set to WebGPU but ort-webgpu feature is not enabled; falling back to CPU"
+            );
+        }
         OrtAccelerator::Auto => {
             // Add compiled-in GPU EPs in priority order.
-            // DirectML is excluded from Auto because it requires
+            // DirectML and WebGPU are excluded from Auto because they require
             // parallel_execution(false) and memory_pattern(false),
-            // which would penalize other backends. Use
-            // OrtAccelerator::DirectMl explicitly for DirectML.
+            // which would penalize other backends. Use the explicit variant
+            // to opt in.
+            // Ref: https://onnxruntime.ai/docs/execution-providers/DirectML-ExecutionProvider.html
+            //      https://onnxruntime.ai/docs/execution-providers/WebGPU-ExecutionProvider.html
             #[cfg(feature = "ort-cuda")]
-            eps.push(CUDAExecutionProvider::default().build());
+            eps.push(CUDA::default().build());
             #[cfg(feature = "ort-rocm")]
-            eps.push(ROCmExecutionProvider::default().build());
+            eps.push(ROCm::default().build());
+            // CoreML is safe for Auto on macOS — analogous to CUDA on NVIDIA
+            // and ROCm on AMD. It does not require sequential execution or
+            // disabled memory patterns.
+            #[cfg(feature = "ort-coreml")]
+            eps.push(CoreML::default().build());
         }
     }
 
     // CPU is always the final fallback
-    eps.push(CPUExecutionProvider::default().build());
+    eps.push(CPU::default().build());
     eps
 }
 
-/// Returns true if DirectML is the explicitly selected execution provider.
-fn directml_active() -> bool {
-    get_ort_accelerator() == OrtAccelerator::DirectMl && cfg!(feature = "ort-directml")
+/// Returns true if the selected execution provider requires sequential execution
+/// and disabled memory patterns (DirectML, WebGPU).
+fn requires_sequential_session() -> bool {
+    let pref = get_ort_accelerator();
+    (pref == OrtAccelerator::DirectMl && cfg!(feature = "ort-directml"))
+        || (pref == OrtAccelerator::WebGpu && cfg!(feature = "ort-webgpu"))
 }
 
 /// Internal session builder with full control over threading and EP selection.
@@ -81,8 +111,8 @@ fn build_session(
         }
     }
 
-    // DirectML requires parallel_execution(false) and memory_pattern(false)
-    let use_parallel = if directml_active() {
+    // DirectML and WebGPU require parallel_execution(false) and memory_pattern(false)
+    let use_parallel = if requires_sequential_session() {
         false
     } else {
         parallel_execution
@@ -90,7 +120,7 @@ fn build_session(
 
     builder = builder.with_parallel_execution(use_parallel)?;
 
-    if directml_active() {
+    if requires_sequential_session() {
         builder = builder.with_memory_pattern(false)?;
     }
 

--- a/src/onnx/session.rs
+++ b/src/onnx/session.rs
@@ -8,6 +8,8 @@ use ort::ep::ROCm;
 use ort::ep::TensorRT;
 #[cfg(feature = "ort-webgpu")]
 use ort::ep::WebGPU;
+#[cfg(feature = "ort-xnnpack")]
+use ort::ep::XNNPACK;
 use ort::ep::CPU;
 #[cfg(feature = "ort-cuda")]
 use ort::ep::CUDA;
@@ -77,6 +79,27 @@ fn execution_providers() -> Vec<ort::ep::ExecutionProviderDispatch> {
                 "Accelerator set to WebGPU but ort-webgpu feature is not enabled; falling back to CPU"
             );
         }
+        OrtAccelerator::Xnnpack => {
+            #[cfg(feature = "ort-xnnpack")]
+            {
+                // XNNPACK manages its own threadpool. Configure it with the
+                // available logical core count; the session-level intra-op
+                // pool is forced to 1 in build_session() when XNNPACK is
+                // active to avoid contention.
+                let n = std::thread::available_parallelism()
+                    .map(|n| n.get())
+                    .unwrap_or(1);
+                if let Some(nz) = core::num::NonZeroUsize::new(n) {
+                    eps.push(XNNPACK::default().with_intra_op_num_threads(nz).build());
+                } else {
+                    eps.push(XNNPACK::default().build());
+                }
+            }
+            #[cfg(not(feature = "ort-xnnpack"))]
+            log::warn!(
+                "Accelerator set to XNNPACK but ort-xnnpack feature is not enabled; falling back to CPU"
+            );
+        }
         OrtAccelerator::Auto => {
             // Add compiled-in GPU EPs in priority order.
             // DirectML and WebGPU are excluded from Auto because they require
@@ -113,6 +136,14 @@ fn requires_sequential_session() -> bool {
         || (pref == OrtAccelerator::WebGpu && cfg!(feature = "ort-webgpu"))
 }
 
+/// Returns true if the XNNPACK EP is selected and compiled in. XNNPACK runs
+/// its own threadpool, so the session intra-op pool should be reduced to a
+/// single non-spinning thread to avoid contention.
+fn is_xnnpack_active() -> bool {
+    let pref = get_ort_accelerator();
+    pref == OrtAccelerator::Xnnpack && cfg!(feature = "ort-xnnpack")
+}
+
 /// Internal session builder with full control over threading and EP selection.
 fn build_session(
     path: &Path,
@@ -122,7 +153,12 @@ fn build_session(
     let mut builder =
         Session::builder()?.with_optimization_level(GraphOptimizationLevel::Level3)?;
 
-    if let Some(n) = intra_threads {
+    if is_xnnpack_active() {
+        // See ort::ep::XNNPACK docs: disable session intra-op spinning and
+        // force a single intra-op thread when XNNPACK is the active EP.
+        builder = builder.with_intra_op_spinning(false)?;
+        builder = builder.with_intra_threads(1)?;
+    } else if let Some(n) = intra_threads {
         if n > 0 {
             builder = builder.with_intra_threads(n)?;
         }

--- a/src/onnx/session.rs
+++ b/src/onnx/session.rs
@@ -169,6 +169,7 @@ pub fn resolve_model_path(
         super::Quantization::FP32 => None,
         super::Quantization::FP16 => Some("fp16"),
         super::Quantization::Int8 => Some("int8"),
+        super::Quantization::Int4 => Some("int4"),
     };
 
     if let Some(suffix) = suffix {

--- a/src/onnx/session.rs
+++ b/src/onnx/session.rs
@@ -319,9 +319,7 @@ pub fn create_decoder_session(path: &Path, num_threads: usize) -> Result<Session
             );
         }
         builder
-            .with_execution_providers([CPU::default()
-                .with_arena_allocator(true)
-                .build()])?
+            .with_execution_providers([CPU::default().with_arena_allocator(true).build()])?
             .commit_from_file(path)?
     };
 

--- a/src/onnx/session.rs
+++ b/src/onnx/session.rs
@@ -319,7 +319,7 @@ pub fn create_decoder_session(path: &Path, num_threads: usize) -> Result<Session
             );
         }
         builder
-            .with_execution_providers([CPUExecutionProvider::default()
+            .with_execution_providers([CPU::default()
                 .with_arena_allocator(true)
                 .build()])?
             .commit_from_file(path)?

--- a/src/onnx/session.rs
+++ b/src/onnx/session.rs
@@ -231,12 +231,7 @@ pub fn resolve_model_path(
             log::info!("Loading {} model: {}", suffix, path.display());
             return path;
         }
-        log::warn!(
-            "{} model not found at {}, falling back to {}.onnx",
-            suffix,
-            path.display(),
-            name
-        );
+        log::info!("No {} variant for {}, using {}.onnx", suffix, name, name);
     }
 
     dir.join(format!("{}.onnx", name))
@@ -286,4 +281,64 @@ pub fn read_metadata_float_vec(
         }
         None => Ok(None),
     }
+}
+
+/// Session for autoregressive decoders: sequential execution, configurable
+/// intra-op threads.
+///
+/// By default forces CPU-only with arena allocator — sequential execution makes
+/// GPU kernel launch overhead net-negative for per-token latency at batch size 1.
+///
+/// Call [`crate::set_decoder_gpu(true)`] to use the global accelerator preference
+/// for decoder sessions (for GPU benchmarking).
+///
+/// Thread count resolution:
+/// 1. `num_threads` if > 0
+/// 2. Global `set_ort_intra_threads` if > 0
+/// 3. ORT default (all cores)
+pub fn create_decoder_session(path: &Path, num_threads: usize) -> Result<Session, ort::Error> {
+    let use_gpu = crate::accel::get_decoder_gpu();
+
+    let mut builder = Session::builder()?
+        .with_optimization_level(GraphOptimizationLevel::Level3)?
+        .with_parallel_execution(false)?;
+    if num_threads > 0 {
+        builder = builder.with_intra_threads(num_threads)?;
+    }
+
+    let session = if use_gpu {
+        log::info!("Decoder session using global accelerator (TRANSCRIBE_DECODER_GPU=1)");
+        builder
+            .with_execution_providers(execution_providers())?
+            .commit_from_file(path)?
+    } else {
+        if get_ort_accelerator() != OrtAccelerator::CpuOnly {
+            log::info!(
+                "Decoder session uses CPU-only (sequential execution); \
+                 set TRANSCRIBE_DECODER_GPU=1 to override"
+            );
+        }
+        builder
+            .with_execution_providers([CPUExecutionProvider::default()
+                .with_arena_allocator(true)
+                .build()])?
+            .commit_from_file(path)?
+    };
+
+    for input in session.inputs() {
+        log::info!(
+            "Model input: name={}, type={:?}",
+            input.name(),
+            input.dtype()
+        );
+    }
+    for output in session.outputs() {
+        log::info!(
+            "Model output: name={}, type={:?}",
+            output.name(),
+            output.dtype()
+        );
+    }
+
+    Ok(session)
 }

--- a/src/transcriber/energy_adaptive_chunked.rs
+++ b/src/transcriber/energy_adaptive_chunked.rs
@@ -1,0 +1,442 @@
+use crate::{SpeechModel, TranscribeError, TranscribeOptions, TranscriptionResult};
+
+use super::merge::merge_sequential_with_separator;
+use super::{rms_energy, transcribe_padded, Transcriber, SAMPLE_RATE};
+
+/// Configuration for [`EnergyAdaptiveChunked`].
+pub struct EnergyAdaptiveConfig {
+    /// Target chunk duration in seconds (e.g. 30.0). The actual chunk
+    /// will be within `target ± search_window` of this value.
+    pub target_chunk_secs: f32,
+    /// Scan +/- this far from the target for a low-energy split point
+    /// (e.g. 3.0). Set to 0.0 for fixed-duration chunks.
+    pub search_window_secs: f32,
+    /// Seconds of silence to prepend and append to each chunk before
+    /// transcription.
+    pub padding_secs: f32,
+    /// Minimum chunk duration in seconds. Chunks shorter than this are
+    /// zero-padded before transcription. Remainders shorter than this
+    /// in `finish()` are skipped entirely (unlike [`VadChunkedConfig::min_chunk_secs`]
+    /// which carries short speech forward to merge with the next region).
+    pub min_chunk_secs: f32,
+    /// Frame size in samples for energy analysis when searching for
+    /// split points. Smaller values give finer temporal resolution;
+    /// larger values are faster to scan. Default: 480 (30ms at 16kHz).
+    pub frame_size: usize,
+    /// Separator inserted between chunk texts when merging.
+    /// Use `" "` for most languages, `""` for CJK.
+    pub merge_separator: String,
+}
+
+impl Default for EnergyAdaptiveConfig {
+    fn default() -> Self {
+        Self {
+            target_chunk_secs: 30.0,
+            search_window_secs: 3.0,
+            padding_secs: 0.0,
+            min_chunk_secs: 0.0,
+            frame_size: 480,
+            merge_separator: " ".into(),
+        }
+    }
+}
+
+/// Adaptive chunked transcription using energy-based split point search.
+///
+/// Targets a fixed chunk duration but adjusts the actual split point to
+/// land on a low-energy frame (natural pause) within a configurable
+/// search window around the target. No VAD model needed — just RMS
+/// energy analysis on buffered audio.
+///
+/// Good default for file transcription when you don't have or want a
+/// neural VAD model. Avoids splitting mid-word by finding natural
+/// pause points via energy analysis.
+pub struct EnergyAdaptiveChunked {
+    config: EnergyAdaptiveConfig,
+    options: TranscribeOptions,
+    // internal state
+    buffer: Vec<f32>,
+    elapsed_samples: usize,
+    chunk_index: usize,
+    results: Vec<TranscriptionResult>,
+}
+
+impl EnergyAdaptiveChunked {
+    pub fn new(config: EnergyAdaptiveConfig, options: TranscribeOptions) -> Self {
+        Self {
+            config,
+            options,
+            buffer: Vec::new(),
+            elapsed_samples: 0,
+            chunk_index: 0,
+            results: Vec::new(),
+        }
+    }
+
+    /// Find the best split point in the buffer, searching around
+    /// `target_samples` for the minimum-energy frame.
+    fn find_split_point(&self, target_samples: usize) -> usize {
+        let search_samples = (self.config.search_window_secs * SAMPLE_RATE) as usize;
+        let search_start = target_samples.saturating_sub(search_samples);
+        let search_end = (target_samples + search_samples).min(self.buffer.len());
+
+        // Align to frame boundaries
+        let search_start = (search_start / self.config.frame_size) * self.config.frame_size;
+
+        let mut min_rms = f32::MAX;
+        let mut best_offset = target_samples.min(self.buffer.len());
+
+        let mut offset = search_start;
+        while offset + self.config.frame_size <= search_end {
+            let frame = &self.buffer[offset..offset + self.config.frame_size];
+            let rms = rms_energy(frame);
+            if rms < min_rms {
+                min_rms = rms;
+                best_offset = offset + self.config.frame_size;
+            }
+            offset += self.config.frame_size;
+        }
+
+        log::debug!(
+            "energy adaptive: target={:.2}s, split at {:.2}s (rms={:.4})",
+            target_samples as f32 / SAMPLE_RATE,
+            best_offset as f32 / SAMPLE_RATE,
+            min_rms,
+        );
+
+        best_offset
+    }
+
+    fn transcribe_chunk(
+        &mut self,
+        model: &mut dyn SpeechModel,
+        chunk: &[f32],
+        chunk_start_samples: usize,
+    ) -> Result<TranscriptionResult, TranscribeError> {
+        let chunk_start_secs = chunk_start_samples as f32 / SAMPLE_RATE;
+
+        log::info!(
+            "chunk {}: start={:.2}s duration={:.2}s samples={} padding={:.0}ms",
+            self.chunk_index,
+            chunk_start_secs,
+            chunk.len() as f32 / SAMPLE_RATE,
+            chunk.len(),
+            self.config.padding_secs * 1000.0,
+        );
+
+        self.chunk_index += 1;
+
+        let result = transcribe_padded(
+            model,
+            chunk,
+            self.config.padding_secs,
+            self.config.min_chunk_secs,
+            chunk_start_secs,
+            &self.options,
+        )?;
+
+        log::info!("  -> \"{}\"", result.text.trim());
+
+        self.results.push(result.clone());
+        Ok(result)
+    }
+
+    fn finish_inner(
+        &mut self,
+        model: &mut dyn SpeechModel,
+    ) -> Result<TranscriptionResult, TranscribeError> {
+        if !self.buffer.is_empty() {
+            let chunk = std::mem::take(&mut self.buffer);
+            let chunk_secs = chunk.len() as f32 / SAMPLE_RATE;
+            if chunk_secs >= self.config.min_chunk_secs {
+                let chunk_start = self.elapsed_samples - chunk.len();
+                self.transcribe_chunk(model, &chunk, chunk_start)?;
+            } else {
+                log::debug!(
+                    "skipping short remainder ({:.2}s < min {:.2}s)",
+                    chunk_secs,
+                    self.config.min_chunk_secs
+                );
+            }
+        }
+        Ok(merge_sequential_with_separator(
+            &self.results,
+            &self.config.merge_separator,
+        ))
+    }
+
+    fn reset_state(&mut self) {
+        self.buffer.clear();
+        self.results.clear();
+        self.elapsed_samples = 0;
+        self.chunk_index = 0;
+    }
+}
+
+impl Transcriber for EnergyAdaptiveChunked {
+    fn feed(
+        &mut self,
+        model: &mut dyn SpeechModel,
+        samples: &[f32],
+    ) -> Result<Vec<TranscriptionResult>, TranscribeError> {
+        self.buffer.extend_from_slice(samples);
+        self.elapsed_samples += samples.len();
+
+        let target_samples = (self.config.target_chunk_secs * SAMPLE_RATE) as usize;
+        let search_samples = (self.config.search_window_secs * SAMPLE_RATE) as usize;
+        // We need at least target + search_window of audio to find the best
+        // split point (the optimal point could be past the target).
+        let min_buffer_for_split = target_samples + search_samples;
+
+        let mut new_results = Vec::new();
+
+        while self.buffer.len() >= min_buffer_for_split {
+            let split_at = self.find_split_point(target_samples);
+            let chunk: Vec<f32> = self.buffer.drain(..split_at).collect();
+            let chunk_start = self.elapsed_samples - self.buffer.len() - chunk.len();
+            new_results.push(self.transcribe_chunk(model, &chunk, chunk_start)?);
+        }
+
+        Ok(new_results)
+    }
+
+    fn finish(
+        &mut self,
+        model: &mut dyn SpeechModel,
+    ) -> Result<TranscriptionResult, TranscribeError> {
+        let result = self.finish_inner(model);
+        self.reset_state();
+        result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::transcriber::test_helpers::MockModel;
+
+    #[test]
+    fn energy_adaptive_splits_at_low_energy() {
+        // 3s target, 0.5s search window
+        let config = EnergyAdaptiveConfig {
+            target_chunk_secs: 3.0,
+            search_window_secs: 0.5,
+            ..Default::default()
+        };
+        let mut t = EnergyAdaptiveChunked::new(config, TranscribeOptions::default());
+        let mut model = MockModel;
+
+        // Build 5s of audio: loud except for a quiet region at ~2.8s
+        // (within search window of target 3.0s)
+        let mut audio = vec![1.0f32; 16000 * 5];
+        // Insert quiet region at 2.7-2.8s
+        let quiet_start = (2.7 * SAMPLE_RATE) as usize;
+        let quiet_end = (2.8 * SAMPLE_RATE) as usize;
+        for s in &mut audio[quiet_start..quiet_end] {
+            *s = 0.01;
+        }
+
+        let results = t.feed(&mut model, &audio).unwrap();
+        assert_eq!(results.len(), 1);
+
+        // The split should have landed in the quiet region (around 2.7-2.8s)
+        // rather than exactly at 3.0s. The chunk size in samples tells us where.
+        let chunk_samples: usize = results[0]
+            .text
+            .strip_prefix("chunk_")
+            .unwrap()
+            .parse()
+            .unwrap();
+        let chunk_secs = chunk_samples as f32 / SAMPLE_RATE;
+        assert!(
+            chunk_secs >= 2.5 && chunk_secs <= 3.5,
+            "split at {chunk_secs:.2}s, expected within search window of 3.0s"
+        );
+        // Should be closer to 2.8 than to 3.0
+        assert!(
+            chunk_secs < 3.0,
+            "split at {chunk_secs:.2}s, should prefer quiet region before target"
+        );
+    }
+
+    #[test]
+    fn energy_adaptive_uniform_audio_splits_near_target() {
+        let config = EnergyAdaptiveConfig {
+            target_chunk_secs: 1.0,
+            search_window_secs: 0.3,
+            ..Default::default()
+        };
+        let mut t = EnergyAdaptiveChunked::new(config, TranscribeOptions::default());
+        let mut model = MockModel;
+
+        // Uniform audio — all frames have equal energy
+        let audio = vec![0.5f32; 16000 * 3];
+        let results = t.feed(&mut model, &audio).unwrap();
+
+        // Should still produce chunks (first minimum-energy frame wins)
+        assert!(!results.is_empty());
+    }
+
+    #[test]
+    fn energy_adaptive_remainder_in_finish() {
+        let config = EnergyAdaptiveConfig {
+            target_chunk_secs: 3.0,
+            search_window_secs: 0.5,
+            ..Default::default()
+        };
+        let mut t = EnergyAdaptiveChunked::new(config, TranscribeOptions::default());
+        let mut model = MockModel;
+
+        // 2s of audio — not enough for a chunk in feed()
+        let audio = vec![0.5f32; 16000 * 2];
+        let results = t.feed(&mut model, &audio).unwrap();
+        assert!(results.is_empty());
+
+        // finish() should transcribe the remainder
+        let final_result = t.finish(&mut model).unwrap();
+        assert_eq!(final_result.text, "chunk_32000");
+    }
+
+    #[test]
+    fn energy_adaptive_min_chunk_skips_short_remainder() {
+        let config = EnergyAdaptiveConfig {
+            target_chunk_secs: 3.0,
+            search_window_secs: 0.5,
+            min_chunk_secs: 3.0, // remainder must be >= 3s
+            ..Default::default()
+        };
+        let mut t = EnergyAdaptiveChunked::new(config, TranscribeOptions::default());
+        let mut model = MockModel;
+
+        // 2s of audio — shorter than min_chunk_secs
+        let audio = vec![0.5f32; 16000 * 2];
+        t.feed(&mut model, &audio).unwrap();
+
+        let final_result = t.finish(&mut model).unwrap();
+        assert_eq!(final_result.text, ""); // skipped
+    }
+
+    #[test]
+    fn energy_adaptive_timestamps_correct() {
+        let config = EnergyAdaptiveConfig {
+            target_chunk_secs: 1.0,
+            search_window_secs: 0.0,
+            ..Default::default()
+        };
+        let mut t = EnergyAdaptiveChunked::new(config, TranscribeOptions::default());
+        let mut model = MockModel;
+
+        // search_window=0 means split exactly at target (fixed-duration chunks)
+        let audio = vec![0.5f32; 16000 * 3];
+        let results = t.feed(&mut model, &audio).unwrap();
+
+        // With 0 search window, min_buffer_for_split = target = 1s.
+        // 3s of audio yields 3 chunks (48000 → 32000 → 16000 → 0).
+        assert_eq!(results.len(), 3);
+
+        if results.len() >= 2 {
+            let seg0 = &results[0].segments.as_ref().unwrap()[0];
+            let seg1 = &results[1].segments.as_ref().unwrap()[0];
+            assert!((seg0.start - 0.0).abs() < 0.01);
+            assert!((seg1.start - 1.0).abs() < 0.01);
+        }
+    }
+
+    #[test]
+    fn energy_adaptive_timestamps_clamped_to_zero() {
+        let config = EnergyAdaptiveConfig {
+            target_chunk_secs: 1.0,
+            search_window_secs: 0.0,
+            padding_secs: 0.5,
+            ..Default::default()
+        };
+        let mut t = EnergyAdaptiveChunked::new(config, TranscribeOptions::default());
+        let mut model = MockModel;
+
+        let audio = vec![0.5f32; 16000 * 2];
+        let results = t.feed(&mut model, &audio).unwrap();
+        assert!(!results.is_empty());
+
+        // With 500ms padding on the first chunk (start=0), timestamps must be >= 0
+        let segs = results[0].segments.as_ref().unwrap();
+        assert!(
+            segs[0].start >= 0.0,
+            "timestamp should not be negative, got {}",
+            segs[0].start
+        );
+        assert!(
+            segs[0].end >= 0.0,
+            "timestamp should not be negative, got {}",
+            segs[0].end
+        );
+    }
+
+    #[test]
+    fn energy_adaptive_transcribe_convenience() {
+        let config = EnergyAdaptiveConfig {
+            target_chunk_secs: 1.0,
+            search_window_secs: 0.3,
+            ..Default::default()
+        };
+        let mut t = EnergyAdaptiveChunked::new(config, TranscribeOptions::default());
+        let mut model = MockModel;
+
+        let audio = vec![0.5f32; 16000 * 5];
+        let result = t.transcribe(&mut model, &audio).unwrap();
+        assert!(!result.text.is_empty());
+    }
+
+    #[test]
+    fn energy_adaptive_empty_input() {
+        let config = EnergyAdaptiveConfig {
+            target_chunk_secs: 1.0,
+            search_window_secs: 0.3,
+            ..Default::default()
+        };
+        let mut t = EnergyAdaptiveChunked::new(config, TranscribeOptions::default());
+        let mut model = MockModel;
+
+        let result = t.transcribe(&mut model, &[]).unwrap();
+        assert_eq!(result.text, "");
+    }
+
+    #[test]
+    fn energy_adaptive_object_safe() {
+        let config = EnergyAdaptiveConfig {
+            target_chunk_secs: 1.0,
+            search_window_secs: 0.3,
+            ..Default::default()
+        };
+        let mut transcriber: Box<dyn Transcriber> = Box::new(EnergyAdaptiveChunked::new(
+            config,
+            TranscribeOptions::default(),
+        ));
+        let mut model = MockModel;
+
+        let audio = vec![0.5f32; 16000 * 5];
+        let result = transcriber.transcribe(&mut model, &audio).unwrap();
+        assert!(!result.text.is_empty());
+    }
+
+    #[test]
+    fn energy_adaptive_reusable_after_error() {
+        use crate::transcriber::test_helpers::FailOnNthModel;
+
+        let config = EnergyAdaptiveConfig {
+            target_chunk_secs: 3.0,
+            search_window_secs: 0.5,
+            ..Default::default()
+        };
+        let mut t = EnergyAdaptiveChunked::new(config, TranscribeOptions::default());
+
+        // First session: feed 2s (below 3.5s split threshold), error during finish
+        let audio = vec![0.5f32; 16000 * 2];
+        t.feed(&mut FailOnNthModel::new(99), &audio).unwrap();
+        assert!(t.finish(&mut FailOnNthModel::new(1)).is_err());
+
+        // Second session: should work cleanly after error reset
+        let mut model = MockModel;
+        let result = t.transcribe(&mut model, &audio).unwrap();
+        assert!(!result.text.is_empty());
+    }
+}

--- a/src/transcriber/merge.rs
+++ b/src/transcriber/merge.rs
@@ -1,0 +1,150 @@
+use crate::{TranscriptionResult, TranscriptionSegment};
+
+/// Default separator for merging chunk texts.
+pub const DEFAULT_MERGE_SEPARATOR: &str = " ";
+
+/// Merge chunk results into a single result.
+///
+/// Text is joined with `separator` (default `" "`). Use `""` for
+/// languages that don't use space separators (Chinese, Japanese, etc.).
+/// Segments are concatenated (timestamps should already be adjusted to
+/// session-relative time by the caller).
+pub fn merge_sequential(results: &[TranscriptionResult]) -> TranscriptionResult {
+    merge_sequential_with_separator(results, DEFAULT_MERGE_SEPARATOR)
+}
+
+/// Merge chunk results with a custom separator between chunk texts.
+pub fn merge_sequential_with_separator(
+    results: &[TranscriptionResult],
+    separator: &str,
+) -> TranscriptionResult {
+    let text = results
+        .iter()
+        .map(|r| r.text.trim())
+        .filter(|t| !t.is_empty())
+        .collect::<Vec<_>>()
+        .join(separator);
+
+    let segments = {
+        let all: Vec<TranscriptionSegment> = results
+            .iter()
+            .filter_map(|r| r.segments.as_ref())
+            .flatten()
+            .cloned()
+            .collect();
+        if all.is_empty() {
+            None
+        } else {
+            Some(all)
+        }
+    };
+
+    TranscriptionResult { text, segments }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn merge_empty() {
+        let result = merge_sequential(&[]);
+        assert_eq!(result.text, "");
+        assert!(result.segments.is_none());
+    }
+
+    #[test]
+    fn merge_single() {
+        let results = vec![TranscriptionResult {
+            text: "hello world".to_string(),
+            segments: Some(vec![TranscriptionSegment {
+                start: 0.0,
+                end: 1.0,
+                text: "hello world".to_string(),
+            }]),
+        }];
+        let merged = merge_sequential(&results);
+        assert_eq!(merged.text, "hello world");
+        assert_eq!(merged.segments.unwrap().len(), 1);
+    }
+
+    #[test]
+    fn merge_multiple_texts() {
+        let results = vec![
+            TranscriptionResult {
+                text: "hello".to_string(),
+                segments: None,
+            },
+            TranscriptionResult {
+                text: "world".to_string(),
+                segments: None,
+            },
+        ];
+        let merged = merge_sequential(&results);
+        assert_eq!(merged.text, "hello world");
+        assert!(merged.segments.is_none());
+    }
+
+    #[test]
+    fn merge_skips_empty_text() {
+        let results = vec![
+            TranscriptionResult {
+                text: "hello".to_string(),
+                segments: None,
+            },
+            TranscriptionResult {
+                text: "  ".to_string(),
+                segments: None,
+            },
+            TranscriptionResult {
+                text: "world".to_string(),
+                segments: None,
+            },
+        ];
+        let merged = merge_sequential(&results);
+        assert_eq!(merged.text, "hello world");
+    }
+
+    #[test]
+    fn merge_concatenates_segments() {
+        let results = vec![
+            TranscriptionResult {
+                text: "hello".to_string(),
+                segments: Some(vec![TranscriptionSegment {
+                    start: 0.0,
+                    end: 1.0,
+                    text: "hello".to_string(),
+                }]),
+            },
+            TranscriptionResult {
+                text: "world".to_string(),
+                segments: Some(vec![TranscriptionSegment {
+                    start: 5.0,
+                    end: 6.0,
+                    text: "world".to_string(),
+                }]),
+            },
+        ];
+        let merged = merge_sequential(&results);
+        let segs = merged.segments.unwrap();
+        assert_eq!(segs.len(), 2);
+        assert_eq!(segs[0].start, 0.0);
+        assert_eq!(segs[1].start, 5.0);
+    }
+
+    #[test]
+    fn merge_trims_whitespace() {
+        let results = vec![
+            TranscriptionResult {
+                text: "  hello  ".to_string(),
+                segments: None,
+            },
+            TranscriptionResult {
+                text: "  world  ".to_string(),
+                segments: None,
+            },
+        ];
+        let merged = merge_sequential(&results);
+        assert_eq!(merged.text, "hello world");
+    }
+}

--- a/src/transcriber/mod.rs
+++ b/src/transcriber/mod.rs
@@ -1,0 +1,155 @@
+//! Chunked transcription strategies.
+//!
+//! The [`Transcriber`] trait provides a universal wrapper for non-trivial
+//! transcription workflows. Different implementations handle different
+//! chunking approaches:
+//!
+//! - [`VadChunked`] — splits audio on speech/silence boundaries using a [`Vad`](crate::vad::Vad)
+//! - [`EnergyAdaptiveChunked`] — fixed-duration chunks with energy-based split point search
+//!
+//! The model is borrowed per-call (`&mut dyn SpeechModel`), never owned.
+//! This works naturally with `Arc<Mutex<Box<dyn SpeechModel>>>` — lock for
+//! the call, unlock after.
+//!
+//! # Examples
+//!
+//! **File transcription with VAD chunking:**
+//! ```ignore
+//! use transcribe_rs::transcriber::{Transcriber, VadChunked, VadChunkedConfig};
+//! use transcribe_rs::vad::{SmoothedVad, EnergyVad};
+//!
+//! let vad = SmoothedVad::new(Box::new(EnergyVad::new(480, 0.01)), 15, 15, 2);
+//! let mut chunker = VadChunked::new(Box::new(vad), VadChunkedConfig::default(), options);
+//! let result = chunker.transcribe_file(&mut model, &path)?;
+//! ```
+//!
+//! **Live audio with per-frame feeding:**
+//! ```ignore
+//! let mut t = VadChunked::new(vad, config, options);
+//! for frame in audio_frames {
+//!     for result in t.feed(&mut model, &frame)? {
+//!         println!("{}", result.text);
+//!     }
+//! }
+//! let final_result = t.finish(&mut model)?;
+//! ```
+
+mod energy_adaptive_chunked;
+mod merge;
+#[cfg(test)]
+pub(crate) mod test_helpers;
+mod vad_chunked;
+
+pub use energy_adaptive_chunked::{EnergyAdaptiveChunked, EnergyAdaptiveConfig};
+pub use merge::{merge_sequential, merge_sequential_with_separator, DEFAULT_MERGE_SEPARATOR};
+pub use vad_chunked::{VadChunked, VadChunkedConfig};
+
+/// Expected sample rate for all transcription audio.
+pub(crate) const SAMPLE_RATE: f32 = 16000.0;
+
+/// Compute RMS energy of an audio frame.
+pub(crate) fn rms_energy(frame: &[f32]) -> f32 {
+    if frame.is_empty() {
+        return 0.0;
+    }
+    (frame.iter().map(|s| s * s).sum::<f32>() / frame.len() as f32).sqrt()
+}
+
+use std::path::Path;
+
+use crate::{audio, SpeechModel, TranscribeError, TranscribeOptions, TranscriptionResult};
+
+/// Transcribe a chunk with optional silence padding and timestamp adjustment.
+///
+/// Prepends and appends `padding_secs` of silence, enforces `min_duration_secs`
+/// via zero-padding, calls `model.transcribe`, then adjusts segment timestamps
+/// to account for the padding and the chunk's position in the overall audio.
+pub(crate) fn transcribe_padded(
+    model: &mut dyn SpeechModel,
+    samples: &[f32],
+    padding_secs: f32,
+    min_duration_secs: f32,
+    chunk_start_secs: f32,
+    options: &TranscribeOptions,
+) -> Result<TranscriptionResult, TranscribeError> {
+    let pad_samples = (padding_secs * SAMPLE_RATE) as usize;
+    let mut padded = Vec::with_capacity(pad_samples + samples.len() + pad_samples);
+    padded.resize(pad_samples, 0.0);
+    padded.extend_from_slice(samples);
+    padded.resize(padded.len() + pad_samples, 0.0);
+
+    let min_samples = (min_duration_secs * SAMPLE_RATE) as usize;
+    if padded.len() < min_samples {
+        padded.resize(min_samples, 0.0);
+    }
+
+    let mut result = model.transcribe(&padded, options)?;
+
+    if let Some(segments) = &mut result.segments {
+        for seg in segments.iter_mut() {
+            seg.start = (seg.start - padding_secs + chunk_start_secs).max(0.0);
+            seg.end = (seg.end - padding_secs + chunk_start_secs).max(0.0);
+        }
+    }
+
+    Ok(result)
+}
+
+/// A chunked transcription strategy.
+///
+/// Implementations split audio into chunks, transcribe each chunk via
+/// a [`SpeechModel`], and merge the results. The model is borrowed
+/// per-call, never owned.
+///
+/// All methods take `&mut self`, making the trait fully object-safe
+/// (`Box<dyn Transcriber>` works). After [`finish()`](Transcriber::finish)
+/// returns, the transcriber is reset and ready for a new session.
+pub trait Transcriber: Send {
+    /// Feed audio samples. Internally buffers, detects chunk boundaries,
+    /// and transcribes chunks as they become ready.
+    ///
+    /// Returns all chunk results that completed during this call.
+    ///
+    /// For live audio: called per-frame (e.g. 480 samples), usually returns
+    /// an empty vec, occasionally returns 1 result when a chunk boundary
+    /// is detected.
+    ///
+    /// For files: called with all samples at once, returns N results
+    /// (one per chunk that completed during processing).
+    fn feed(
+        &mut self,
+        model: &mut dyn SpeechModel,
+        samples: &[f32],
+    ) -> Result<Vec<TranscriptionResult>, TranscribeError>;
+
+    /// Transcribe any remaining buffered audio and return the merged
+    /// result of the entire session. Resets internal state for reuse.
+    fn finish(
+        &mut self,
+        model: &mut dyn SpeechModel,
+    ) -> Result<TranscriptionResult, TranscribeError>;
+
+    /// Convenience: feed all samples and finish in one call.
+    ///
+    /// The return value of `feed()` is intentionally discarded here —
+    /// intermediate results are accumulated internally and merged by
+    /// `finish()`.
+    fn transcribe(
+        &mut self,
+        model: &mut dyn SpeechModel,
+        samples: &[f32],
+    ) -> Result<TranscriptionResult, TranscribeError> {
+        self.feed(model, samples)?;
+        self.finish(model)
+    }
+
+    /// Convenience: load a WAV file, feed, and finish.
+    fn transcribe_file(
+        &mut self,
+        model: &mut dyn SpeechModel,
+        path: &Path,
+    ) -> Result<TranscriptionResult, TranscribeError> {
+        let samples = audio::read_wav_samples(path)?;
+        self.transcribe(model, &samples)
+    }
+}

--- a/src/transcriber/mod.rs
+++ b/src/transcriber/mod.rs
@@ -61,9 +61,10 @@ use crate::{audio, SpeechModel, TranscribeError, TranscribeOptions, Transcriptio
 
 /// Transcribe a chunk with optional silence padding and timestamp adjustment.
 ///
-/// Prepends and appends `padding_secs` of silence, enforces `min_duration_secs`
-/// via zero-padding, calls `model.transcribe`, then adjusts segment timestamps
-/// to account for the padding and the chunk's position in the overall audio.
+/// Sets leading/trailing silence on [`TranscribeOptions`] and delegates padding
+/// and leading-silence timestamp correction to [`SpeechModel::transcribe`].
+/// Enforces `min_duration_secs` via zero-padding of the content, then offsets
+/// segment timestamps by `chunk_start_secs`.
 pub(crate) fn transcribe_padded(
     model: &mut dyn SpeechModel,
     samples: &[f32],
@@ -72,24 +73,31 @@ pub(crate) fn transcribe_padded(
     chunk_start_secs: f32,
     options: &TranscribeOptions,
 ) -> Result<TranscriptionResult, TranscribeError> {
-    let pad_samples = (padding_secs * SAMPLE_RATE) as usize;
-    let mut padded = Vec::with_capacity(pad_samples + samples.len() + pad_samples);
-    padded.resize(pad_samples, 0.0);
-    padded.extend_from_slice(samples);
-    padded.resize(padded.len() + pad_samples, 0.0);
+    let padding_ms = (padding_secs * 1000.0) as u32;
 
-    let min_samples = (min_duration_secs * SAMPLE_RATE) as usize;
-    if padded.len() < min_samples {
-        padded.resize(min_samples, 0.0);
+    // The trait will prepend + append padding. Ensure the total
+    // (padding + content + padding) meets the minimum duration.
+    let pad_total = 2 * padding_ms as usize * audio::SAMPLES_PER_MS;
+    let min_total = (min_duration_secs * SAMPLE_RATE) as usize;
+    let min_content = min_total.saturating_sub(pad_total);
+
+    let mut content = samples.to_vec();
+    if content.len() < min_content {
+        content.resize(min_content, 0.0);
     }
 
-    let mut result = model.transcribe(&padded, options)?;
+    // Override any user-specified padding — chunked transcription manages
+    // its own padding to ensure consistent overlap between chunks.
+    let mut opts = options.clone();
+    opts.leading_silence_ms = Some(padding_ms);
+    opts.trailing_silence_ms = Some(padding_ms);
 
-    if let Some(segments) = &mut result.segments {
-        for seg in segments.iter_mut() {
-            seg.start = (seg.start - padding_secs + chunk_start_secs).max(0.0);
-            seg.end = (seg.end - padding_secs + chunk_start_secs).max(0.0);
-        }
+    let mut result = model.transcribe(&content, &opts)?;
+
+    // The trait already subtracted leading silence from timestamps.
+    // Offset by this chunk's position in the overall audio.
+    if chunk_start_secs > 0.0 {
+        result.offset_timestamps(chunk_start_secs);
     }
 
     Ok(result)

--- a/src/transcriber/test_helpers.rs
+++ b/src/transcriber/test_helpers.rs
@@ -1,0 +1,89 @@
+use super::SAMPLE_RATE;
+use crate::{
+    ModelCapabilities, SpeechModel, TranscribeError, TranscribeOptions, TranscriptionResult,
+    TranscriptionSegment,
+};
+
+/// Mock model that returns the sample count as text.
+pub(crate) struct MockModel;
+
+impl SpeechModel for MockModel {
+    fn capabilities(&self) -> ModelCapabilities {
+        ModelCapabilities {
+            name: "mock",
+            engine_id: "mock",
+            sample_rate: 16000,
+            languages: &[],
+            supports_timestamps: false,
+            supports_translation: false,
+            supports_streaming: false,
+        }
+    }
+
+    fn transcribe(
+        &mut self,
+        samples: &[f32],
+        _options: &TranscribeOptions,
+    ) -> Result<TranscriptionResult, TranscribeError> {
+        Ok(TranscriptionResult {
+            text: format!("chunk_{}", samples.len()),
+            segments: Some(vec![TranscriptionSegment {
+                start: 0.0,
+                end: samples.len() as f32 / SAMPLE_RATE,
+                text: format!("chunk_{}", samples.len()),
+            }]),
+        })
+    }
+}
+
+/// Mock model that fails on the Nth call.
+pub(crate) struct FailOnNthModel {
+    call_count: usize,
+    fail_on: usize,
+}
+
+impl FailOnNthModel {
+    pub(crate) fn new(fail_on: usize) -> Self {
+        Self {
+            call_count: 0,
+            fail_on,
+        }
+    }
+}
+
+impl SpeechModel for FailOnNthModel {
+    fn capabilities(&self) -> ModelCapabilities {
+        ModelCapabilities {
+            name: "mock",
+            engine_id: "mock",
+            sample_rate: 16000,
+            languages: &[],
+            supports_timestamps: false,
+            supports_translation: false,
+            supports_streaming: false,
+        }
+    }
+
+    fn transcribe(
+        &mut self,
+        _samples: &[f32],
+        _options: &TranscribeOptions,
+    ) -> Result<TranscriptionResult, TranscribeError> {
+        self.call_count += 1;
+        if self.call_count == self.fail_on {
+            return Err(TranscribeError::Inference("mock failure".into()));
+        }
+        Ok(TranscriptionResult {
+            text: format!("chunk_{}", self.call_count),
+            segments: None,
+        })
+    }
+}
+
+pub(crate) fn make_speech(frame_size: usize, num_frames: usize) -> Vec<f32> {
+    vec![1.0f32; frame_size * num_frames]
+}
+
+pub(crate) fn make_silence(frame_size: usize, num_frames: usize) -> Vec<f32> {
+    vec![0.0f32; frame_size * num_frames]
+}

--- a/src/transcriber/test_helpers.rs
+++ b/src/transcriber/test_helpers.rs
@@ -20,7 +20,7 @@ impl SpeechModel for MockModel {
         }
     }
 
-    fn transcribe(
+    fn transcribe_raw(
         &mut self,
         samples: &[f32],
         _options: &TranscribeOptions,
@@ -64,7 +64,7 @@ impl SpeechModel for FailOnNthModel {
         }
     }
 
-    fn transcribe(
+    fn transcribe_raw(
         &mut self,
         _samples: &[f32],
         _options: &TranscribeOptions,

--- a/src/transcriber/vad_chunked.rs
+++ b/src/transcriber/vad_chunked.rs
@@ -1,0 +1,754 @@
+use crate::vad::Vad;
+use crate::{SpeechModel, TranscribeError, TranscribeOptions, TranscriptionResult};
+
+use super::merge::merge_sequential_with_separator;
+use super::{rms_energy, transcribe_padded, Transcriber, SAMPLE_RATE};
+
+/// Configuration for [`VadChunked`].
+pub struct VadChunkedConfig {
+    /// Minimum chunk duration in seconds. Chunks shorter than this
+    /// are carried forward and merged with the next speech region
+    /// (unlike [`EnergyAdaptiveConfig::min_chunk_secs`] which skips
+    /// short remainders). Final chunks in `finish()` are zero-padded
+    /// to this duration before transcription.
+    pub min_chunk_secs: f32,
+    /// Maximum chunk duration in seconds. Force-split if VAD finds
+    /// no silence within this duration.
+    pub max_chunk_secs: f32,
+    /// Seconds of silence to prepend and append to each chunk before
+    /// transcription. Helps models that need surrounding context.
+    pub padding_secs: f32,
+    /// If set, when force-splitting at `max_chunk_secs`, scan backward
+    /// over this many seconds of audio to find the lowest-energy frame
+    /// and split there instead of hard-cutting. This avoids splitting
+    /// mid-word during long monologues. `None` disables (hard cut).
+    pub smart_split_search_secs: Option<f32>,
+    /// Separator inserted between chunk texts when merging.
+    /// Use `" "` for most languages, `""` for CJK.
+    pub merge_separator: String,
+}
+
+impl Default for VadChunkedConfig {
+    fn default() -> Self {
+        Self {
+            min_chunk_secs: 1.0,
+            max_chunk_secs: 30.0,
+            padding_secs: 0.0,
+            smart_split_search_secs: None,
+            merge_separator: " ".into(),
+        }
+    }
+}
+
+/// VAD-based chunked transcription.
+///
+/// Splits audio on speech/silence boundaries detected by a [`Vad`].
+/// Each speech region is transcribed independently, then merged in
+/// [`finish()`](Transcriber::finish).
+///
+/// Works for both live audio (small per-frame feeds) and file
+/// transcription (one large feed).
+pub struct VadChunked {
+    vad: Box<dyn Vad>,
+    config: VadChunkedConfig,
+    options: TranscribeOptions,
+    // internal state
+    speech_buffer: Vec<f32>,
+    /// Accumulates sub-frame remainders across `feed()` calls so they
+    /// can be combined with the next call's samples to form a complete
+    /// frame for VAD processing.
+    pending: Vec<f32>,
+    in_speech: bool,
+    elapsed_samples: usize,
+    /// Sample offset where the first sample entered the current speech
+    /// buffer. Used for accurate timestamp calculation, especially when
+    /// short speech carries forward across silence gaps.
+    speech_start_sample: Option<usize>,
+    chunk_index: usize,
+    results: Vec<TranscriptionResult>,
+}
+
+impl VadChunked {
+    pub fn new(vad: Box<dyn Vad>, config: VadChunkedConfig, options: TranscribeOptions) -> Self {
+        Self {
+            vad,
+            config,
+            options,
+            speech_buffer: Vec::new(),
+            pending: Vec::new(),
+            in_speech: false,
+            elapsed_samples: 0,
+            speech_start_sample: None,
+            chunk_index: 0,
+            results: Vec::new(),
+        }
+    }
+
+    /// When force-splitting, scan backward over `search_secs` of the
+    /// speech buffer to find the frame with the lowest RMS energy. Splits
+    /// the buffer there, transcribes the first part, and keeps the
+    /// remainder for the next chunk.
+    fn smart_split_buffer(
+        &mut self,
+        model: &mut dyn SpeechModel,
+        search_secs: f32,
+    ) -> Result<TranscriptionResult, TranscribeError> {
+        let frame_size = self.vad.frame_size();
+        let search_samples = (search_secs * SAMPLE_RATE) as usize;
+        let buf_len = self.speech_buffer.len();
+
+        // Find the lowest-energy frame in the search window
+        let search_start = buf_len.saturating_sub(search_samples);
+        // Align to frame boundaries
+        let search_start = (search_start / frame_size) * frame_size;
+
+        let mut min_rms = f32::MAX;
+        let mut best_offset = buf_len; // default: split at end (same as hard cut)
+
+        let mut offset = search_start;
+        while offset + frame_size <= buf_len {
+            let frame = &self.speech_buffer[offset..offset + frame_size];
+            let rms = rms_energy(frame);
+            if rms < min_rms {
+                min_rms = rms;
+                best_offset = offset + frame_size; // split after this frame
+            }
+            offset += frame_size;
+        }
+
+        log::info!(
+            "smart split: search window {:.2}s, best split at {:.2}s (rms={:.4}), buffer={:.2}s",
+            search_secs,
+            best_offset as f32 / SAMPLE_RATE,
+            min_rms,
+            buf_len as f32 / SAMPLE_RATE,
+        );
+
+        // Drain the chunk; remainder stays in speech_buffer.
+        let chunk: Vec<f32> = self.speech_buffer.drain(..best_offset).collect();
+        let chunk_start_secs = self.speech_start_sample.unwrap_or_else(|| {
+            self.elapsed_samples
+                .saturating_sub(self.speech_buffer.len() + chunk.len())
+        }) as f32
+            / SAMPLE_RATE;
+
+        // Update speech_start_sample for the remainder
+        if self.speech_buffer.is_empty() {
+            self.speech_start_sample = None;
+        } else {
+            self.speech_start_sample = self.speech_start_sample.map(|s| s + best_offset);
+        }
+
+        self.transcribe_chunk(model, chunk, chunk_start_secs)
+    }
+
+    /// Take the entire speech buffer and transcribe it as one chunk.
+    fn flush_speech_buffer(
+        &mut self,
+        model: &mut dyn SpeechModel,
+    ) -> Result<TranscriptionResult, TranscribeError> {
+        let samples = std::mem::take(&mut self.speech_buffer);
+        let chunk_start_secs = self
+            .speech_start_sample
+            .unwrap_or_else(|| self.elapsed_samples.saturating_sub(samples.len()))
+            as f32
+            / SAMPLE_RATE;
+        self.speech_start_sample = None;
+        self.transcribe_chunk(model, samples, chunk_start_secs)
+    }
+
+    /// Transcribe a chunk of audio samples at a given position. Does not
+    /// touch `self.speech_buffer` or `self.speech_start_sample` — callers
+    /// manage buffer state before calling this.
+    fn transcribe_chunk(
+        &mut self,
+        model: &mut dyn SpeechModel,
+        samples: Vec<f32>,
+        chunk_start_secs: f32,
+    ) -> Result<TranscriptionResult, TranscribeError> {
+        log::info!(
+            "chunk {}: start={:.2}s duration={:.2}s samples={} padding={:.0}ms",
+            self.chunk_index,
+            chunk_start_secs,
+            samples.len() as f32 / SAMPLE_RATE,
+            samples.len(),
+            self.config.padding_secs * 1000.0,
+        );
+
+        self.chunk_index += 1;
+
+        let result = transcribe_padded(
+            model,
+            &samples,
+            self.config.padding_secs,
+            self.config.min_chunk_secs,
+            chunk_start_secs,
+            &self.options,
+        )?;
+
+        log::info!("  -> \"{}\"", result.text.trim());
+
+        self.results.push(result.clone());
+        Ok(result)
+    }
+
+    fn finish_inner(
+        &mut self,
+        model: &mut dyn SpeechModel,
+    ) -> Result<TranscriptionResult, TranscribeError> {
+        // Flush any pending sub-frame samples into the speech buffer.
+        // Pending holds at most frame_size-1 samples (~29ms at 480/16kHz) that
+        // were never VAD-classified. This is practically harmless: if we're in a
+        // speech region the tail belongs there, and if not, the model will produce
+        // empty/whitespace text that merge filters out.
+        if !self.pending.is_empty() {
+            let pending = std::mem::take(&mut self.pending);
+            if self.speech_buffer.is_empty() && self.speech_start_sample.is_none() {
+                self.speech_start_sample = Some(self.elapsed_samples);
+            }
+            self.speech_buffer.extend_from_slice(&pending);
+            self.elapsed_samples += pending.len();
+        }
+
+        if !self.speech_buffer.is_empty() {
+            log::info!(
+                "finish: transcribing remaining buffer ({:.2}s)",
+                self.speech_buffer.len() as f32 / SAMPLE_RATE
+            );
+            self.flush_speech_buffer(model)?;
+        }
+        log::info!("session complete: {} chunks transcribed", self.chunk_index);
+        Ok(merge_sequential_with_separator(
+            &self.results,
+            &self.config.merge_separator,
+        ))
+    }
+
+    fn reset_state(&mut self) {
+        self.results.clear();
+        self.speech_buffer.clear();
+        self.pending.clear();
+        self.in_speech = false;
+        self.elapsed_samples = 0;
+        self.speech_start_sample = None;
+        self.chunk_index = 0;
+        self.vad.reset();
+    }
+}
+
+impl Transcriber for VadChunked {
+    fn feed(
+        &mut self,
+        model: &mut dyn SpeechModel,
+        samples: &[f32],
+    ) -> Result<Vec<TranscriptionResult>, TranscribeError> {
+        let frame_size = self.vad.frame_size();
+        let mut new_results = Vec::new();
+
+        // Combine pending sub-frame samples from previous call
+        let combined;
+        let to_process = if self.pending.is_empty() {
+            samples
+        } else {
+            self.pending.extend_from_slice(samples);
+            combined = std::mem::take(&mut self.pending);
+            &combined
+        };
+
+        for frame in to_process.chunks(frame_size) {
+            if frame.len() < frame_size {
+                // Partial frame at end — hold for next feed() call
+                self.pending.extend_from_slice(frame);
+                continue;
+            }
+
+            let is_speech = self.vad.is_speech(frame)?;
+            self.elapsed_samples += frame_size;
+
+            if is_speech {
+                if !self.in_speech {
+                    // Speech onset — recover pre-onset audio from VAD prefill
+                    let prefill = self.vad.drain_prefill();
+                    if self.speech_start_sample.is_none() {
+                        self.speech_start_sample =
+                            Some((self.elapsed_samples - frame_size).saturating_sub(prefill.len()));
+                    }
+                    self.speech_buffer.extend_from_slice(&prefill);
+                }
+                self.speech_buffer.extend_from_slice(frame);
+                self.in_speech = true;
+
+                // Force-split if exceeding max duration
+                let chunk_secs = self.speech_buffer.len() as f32 / SAMPLE_RATE;
+                if chunk_secs >= self.config.max_chunk_secs {
+                    log::info!(
+                        "force-splitting at {:.2}s (max_chunk_secs={:.2})",
+                        self.elapsed_samples as f32 / SAMPLE_RATE,
+                        self.config.max_chunk_secs
+                    );
+                    let result = if let Some(search_secs) = self.config.smart_split_search_secs {
+                        self.smart_split_buffer(model, search_secs)?
+                    } else {
+                        self.flush_speech_buffer(model)?
+                    };
+                    new_results.push(result);
+                }
+            } else if self.in_speech {
+                // Speech -> silence transition: transcribe the chunk
+                self.in_speech = false;
+                if !self.speech_buffer.is_empty() {
+                    let chunk_secs = self.speech_buffer.len() as f32 / SAMPLE_RATE;
+                    if chunk_secs >= self.config.min_chunk_secs {
+                        log::info!(
+                            "speech->silence at {:.2}s, chunk buffered={:.2}s",
+                            self.elapsed_samples as f32 / SAMPLE_RATE,
+                            chunk_secs
+                        );
+                        new_results.push(self.flush_speech_buffer(model)?);
+                    } else {
+                        // Keep short speech in buffer so it merges with the
+                        // next speech region (don't lose brief utterances)
+                        log::debug!(
+                            "carrying forward short chunk ({:.2}s < min {:.2}s)",
+                            chunk_secs,
+                            self.config.min_chunk_secs
+                        );
+                    }
+                }
+            }
+        }
+
+        Ok(new_results)
+    }
+
+    fn finish(
+        &mut self,
+        model: &mut dyn SpeechModel,
+    ) -> Result<TranscriptionResult, TranscribeError> {
+        let result = self.finish_inner(model);
+        self.reset_state();
+        result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::transcriber::test_helpers::{make_silence, make_speech, FailOnNthModel, MockModel};
+    use crate::vad::{EnergyVad, SmoothedVad};
+
+    #[test]
+    fn vad_chunked_basic_speech_then_silence() {
+        let vad = EnergyVad::new(480, 0.01);
+        let config = VadChunkedConfig {
+            min_chunk_secs: 0.0, // no minimum for test
+            ..Default::default()
+        };
+        let mut t = VadChunked::new(Box::new(vad), config, TranscribeOptions::default());
+        let mut model = MockModel;
+
+        // Feed speech frames
+        let speech = make_speech(480, 10); // 10 frames = 300ms
+        let results = t.feed(&mut model, &speech).unwrap();
+        assert!(results.is_empty()); // no silence boundary yet
+
+        // Feed silence to trigger transcription
+        let silence = make_silence(480, 5);
+        let results = t.feed(&mut model, &silence).unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].text, "chunk_4800"); // 10 * 480 samples
+    }
+
+    #[test]
+    fn vad_chunked_finish_transcribes_remainder() {
+        let vad = EnergyVad::new(480, 0.01);
+        let config = VadChunkedConfig {
+            min_chunk_secs: 0.0,
+            ..Default::default()
+        };
+        let mut t = VadChunked::new(Box::new(vad), config, TranscribeOptions::default());
+        let mut model = MockModel;
+
+        // Feed only speech, no silence
+        let speech = make_speech(480, 10);
+        let results = t.feed(&mut model, &speech).unwrap();
+        assert!(results.is_empty());
+
+        // finish should transcribe the remainder
+        let final_result = t.finish(&mut model).unwrap();
+        assert_eq!(final_result.text, "chunk_4800");
+    }
+
+    #[test]
+    fn vad_chunked_max_duration_force_splits() {
+        let vad = EnergyVad::new(480, 0.01);
+        let config = VadChunkedConfig {
+            min_chunk_secs: 0.0,
+            max_chunk_secs: 0.06, // 60ms = 960 samples = 2 frames
+            ..Default::default()
+        };
+        let mut t = VadChunked::new(Box::new(vad), config, TranscribeOptions::default());
+        let mut model = MockModel;
+
+        // Feed 10 frames of speech — should force-split multiple times
+        let speech = make_speech(480, 10);
+        let results = t.feed(&mut model, &speech).unwrap();
+        assert!(results.len() >= 4); // 10 frames / 2 frames per chunk
+    }
+
+    #[test]
+    fn vad_chunked_short_speech_carries_forward() {
+        let vad = EnergyVad::new(480, 0.01);
+        let config = VadChunkedConfig {
+            min_chunk_secs: 1.0, // 1 second minimum
+            ..Default::default()
+        };
+        let mut t = VadChunked::new(Box::new(vad), config, TranscribeOptions::default());
+        let mut model = MockModel;
+
+        // Feed very short speech (1 frame = 30ms) then silence
+        let speech = make_speech(480, 1);
+        t.feed(&mut model, &speech).unwrap();
+
+        let silence = make_silence(480, 5);
+        let results = t.feed(&mut model, &silence).unwrap();
+        assert!(results.is_empty()); // too short, not transcribed yet
+
+        // Feed more speech — the short chunk should merge with this one
+        let speech2 = make_speech(480, 40); // 1.2s
+        t.feed(&mut model, &speech2).unwrap();
+
+        let silence2 = make_silence(480, 5);
+        let results = t.feed(&mut model, &silence2).unwrap();
+        assert_eq!(results.len(), 1);
+        // Should contain the original 1 frame + 40 new frames = 41 * 480 = 19680 samples
+        assert_eq!(results[0].text, "chunk_19680");
+    }
+
+    #[test]
+    fn vad_chunked_carry_forward_timestamp_correct() {
+        let vad = EnergyVad::new(480, 0.01);
+        let config = VadChunkedConfig {
+            min_chunk_secs: 1.0,
+            ..Default::default()
+        };
+        let mut t = VadChunked::new(Box::new(vad), config, TranscribeOptions::default());
+        let mut model = MockModel;
+
+        // Speech at t=0 (1 frame), silence gap, then more speech
+        let speech = make_speech(480, 1);
+        t.feed(&mut model, &speech).unwrap();
+
+        let silence = make_silence(480, 5);
+        t.feed(&mut model, &silence).unwrap();
+
+        let speech2 = make_speech(480, 40);
+        t.feed(&mut model, &speech2).unwrap();
+
+        let silence2 = make_silence(480, 5);
+        let results = t.feed(&mut model, &silence2).unwrap();
+        assert_eq!(results.len(), 1);
+
+        // Timestamp should reflect the start of the first speech (t=0),
+        // not the back-calculated position
+        let segs = results[0].segments.as_ref().unwrap();
+        assert!(
+            segs[0].start < 0.01,
+            "expected start near 0.0, got {}",
+            segs[0].start
+        );
+    }
+
+    #[test]
+    fn vad_chunked_timestamps_adjusted() {
+        let vad = EnergyVad::new(480, 0.01);
+        let config = VadChunkedConfig {
+            min_chunk_secs: 0.0,
+            ..Default::default()
+        };
+        let mut t = VadChunked::new(Box::new(vad), config, TranscribeOptions::default());
+        let mut model = MockModel;
+
+        // Feed silence first (1 second = ~33 frames at 480)
+        let silence = make_silence(480, 34);
+        t.feed(&mut model, &silence).unwrap();
+
+        // Then speech
+        let speech = make_speech(480, 10);
+        t.feed(&mut model, &speech).unwrap();
+
+        // Then silence to trigger
+        let silence2 = make_silence(480, 5);
+        let results = t.feed(&mut model, &silence2).unwrap();
+        assert_eq!(results.len(), 1);
+
+        // Segment timestamps should be offset by the initial silence
+        let segs = results[0].segments.as_ref().unwrap();
+        assert!(segs[0].start > 0.9); // ~1.02 seconds of silence preceded it
+    }
+
+    #[test]
+    fn vad_chunked_timestamps_clamped_to_zero() {
+        let vad = EnergyVad::new(480, 0.01);
+        let config = VadChunkedConfig {
+            min_chunk_secs: 0.0,
+            padding_secs: 0.5, // 500ms padding
+            ..Default::default()
+        };
+        let mut t = VadChunked::new(Box::new(vad), config, TranscribeOptions::default());
+        let mut model = MockModel;
+
+        // Feed speech immediately (chunk_start_secs ≈ 0)
+        let speech = make_speech(480, 10);
+        t.feed(&mut model, &speech).unwrap();
+
+        let silence = make_silence(480, 5);
+        let results = t.feed(&mut model, &silence).unwrap();
+        assert_eq!(results.len(), 1);
+
+        // With 500ms padding and chunk starting near 0, timestamps must be >= 0
+        let segs = results[0].segments.as_ref().unwrap();
+        assert!(
+            segs[0].start >= 0.0,
+            "timestamp should not be negative, got {}",
+            segs[0].start
+        );
+        assert!(
+            segs[0].end >= 0.0,
+            "timestamp should not be negative, got {}",
+            segs[0].end
+        );
+    }
+
+    #[test]
+    fn vad_chunked_propagates_transcription_error() {
+        let vad = EnergyVad::new(480, 0.01);
+        let config = VadChunkedConfig {
+            min_chunk_secs: 0.0,
+            max_chunk_secs: 0.06, // force split every 2 frames
+            ..Default::default()
+        };
+        let mut t = VadChunked::new(Box::new(vad), config, TranscribeOptions::default());
+        let mut model = FailOnNthModel::new(2); // fail on 2nd chunk
+
+        // Feed enough speech for 4+ chunks — should error on 2nd chunk
+        let speech = make_speech(480, 10);
+        let result = t.feed(&mut model, &speech);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn vad_chunked_transcribe_convenience() {
+        let vad = EnergyVad::new(480, 0.01);
+        let config = VadChunkedConfig {
+            min_chunk_secs: 0.0,
+            ..Default::default()
+        };
+        let mut t = VadChunked::new(Box::new(vad), config, TranscribeOptions::default());
+        let mut model = MockModel;
+
+        let speech = make_speech(480, 10);
+        let result = t.transcribe(&mut model, &speech).unwrap();
+        assert!(!result.text.is_empty());
+    }
+
+    #[test]
+    fn vad_chunked_smart_split_finds_low_energy() {
+        let vad = EnergyVad::new(480, 0.01);
+        let config = VadChunkedConfig {
+            min_chunk_secs: 0.0,
+            max_chunk_secs: 0.3, // 300ms = 10 frames to force split
+            smart_split_search_secs: Some(0.15), // search last 150ms (5 frames)
+            ..Default::default()
+        };
+        let mut t = VadChunked::new(Box::new(vad), config, TranscribeOptions::default());
+        let mut model = MockModel;
+
+        // Build 12 frames of speech where frame 7 (0-indexed) is quieter.
+        // Frames 0-6: loud (1.0), frame 7: quiet (0.1), frames 8-11: loud (1.0)
+        // Search window covers frames 5-9 (last 5 frames of the 10-frame max).
+        // Smart split should pick frame 7 as the split point.
+        let mut audio = Vec::new();
+        for i in 0..12 {
+            let val = if i == 7 { 0.1 } else { 1.0 };
+            audio.extend(vec![val; 480]);
+        }
+
+        let results = t.feed(&mut model, &audio).unwrap();
+        // Should have at least 1 result from force-split
+        assert!(!results.is_empty());
+
+        // The first chunk should be split at frame 8 (after the quiet frame 7),
+        // so it should contain 8 * 480 = 3840 samples
+        assert_eq!(results[0].text, "chunk_3840");
+    }
+
+    #[test]
+    fn vad_chunked_smart_split_disabled_hard_cuts() {
+        let vad = EnergyVad::new(480, 0.01);
+        let config = VadChunkedConfig {
+            min_chunk_secs: 0.0,
+            max_chunk_secs: 0.06,          // 60ms = 2 frames
+            smart_split_search_secs: None, // disabled
+            ..Default::default()
+        };
+        let mut t = VadChunked::new(Box::new(vad), config, TranscribeOptions::default());
+        let mut model = MockModel;
+
+        // All uniform energy — with smart split disabled, hard-cuts at exactly 2 frames
+        let speech = make_speech(480, 6);
+        let results = t.feed(&mut model, &speech).unwrap();
+        assert_eq!(results.len(), 3); // 6 frames / 2 = 3 exact chunks
+        assert_eq!(results[0].text, "chunk_960"); // 2 * 480
+    }
+
+    #[test]
+    fn vad_chunked_multiple_speech_regions() {
+        let vad = EnergyVad::new(480, 0.01);
+        let config = VadChunkedConfig {
+            min_chunk_secs: 0.0,
+            ..Default::default()
+        };
+        let mut t = VadChunked::new(Box::new(vad), config, TranscribeOptions::default());
+        let mut model = MockModel;
+
+        // speech -> silence -> speech -> silence
+        let mut audio = Vec::new();
+        audio.extend(make_speech(480, 5));
+        audio.extend(make_silence(480, 5));
+        audio.extend(make_speech(480, 8));
+        audio.extend(make_silence(480, 5));
+
+        let results = t.feed(&mut model, &audio).unwrap();
+        assert_eq!(results.len(), 2); // two speech regions
+    }
+
+    #[test]
+    fn vad_chunked_object_safe() {
+        let vad = EnergyVad::new(480, 0.01);
+        let config = VadChunkedConfig {
+            min_chunk_secs: 0.0,
+            ..Default::default()
+        };
+        let mut transcriber: Box<dyn Transcriber> = Box::new(VadChunked::new(
+            Box::new(vad),
+            config,
+            TranscribeOptions::default(),
+        ));
+        let mut model = MockModel;
+
+        let speech = make_speech(480, 10);
+        let result = transcriber.transcribe(&mut model, &speech).unwrap();
+        assert!(!result.text.is_empty());
+    }
+
+    #[test]
+    fn vad_chunked_prefill_captures_onset_audio() {
+        // SmoothedVad with onset_frames=2 and prefill_frames=5.
+        // Without prefill, the first onset frame (which SmoothedVad returns
+        // false for) would be lost. With prefill, it's recovered.
+        let inner = EnergyVad::new(480, 0.01);
+        let vad = SmoothedVad::new(Box::new(inner), 5, 0, 2);
+        let config = VadChunkedConfig {
+            min_chunk_secs: 0.0,
+            ..Default::default()
+        };
+        let mut t = VadChunked::new(Box::new(vad), config, TranscribeOptions::default());
+        let mut model = MockModel;
+
+        // Feed 3 frames of speech then silence to trigger transcription.
+        // With onset_frames=2: frame 1 returns false, frame 2 triggers onset.
+        // Prefill recovers frame 1, so all 3 speech frames are captured.
+        let speech = make_speech(480, 3);
+        t.feed(&mut model, &speech).unwrap();
+
+        let silence = make_silence(480, 5);
+        let results = t.feed(&mut model, &silence).unwrap();
+        assert_eq!(results.len(), 1);
+        // All 3 frames captured (not just 2): 3 * 480 = 1440
+        assert_eq!(results[0].text, "chunk_1440");
+    }
+
+    #[test]
+    fn vad_chunked_prefill_timestamp_accounts_for_prefill() {
+        let inner = EnergyVad::new(480, 0.01);
+        let vad = SmoothedVad::new(Box::new(inner), 5, 0, 2);
+        let config = VadChunkedConfig {
+            min_chunk_secs: 0.0,
+            ..Default::default()
+        };
+        let mut t = VadChunked::new(Box::new(vad), config, TranscribeOptions::default());
+        let mut model = MockModel;
+
+        // 3 silence frames, then 3 speech frames, then silence
+        let silence = make_silence(480, 3);
+        t.feed(&mut model, &silence).unwrap();
+
+        let speech = make_speech(480, 3);
+        t.feed(&mut model, &speech).unwrap();
+
+        let silence2 = make_silence(480, 5);
+        let results = t.feed(&mut model, &silence2).unwrap();
+        assert_eq!(results.len(), 1);
+
+        // Prefill includes the 3 silence frames + onset frame 1.
+        // Speech start should account for prefill reaching back into the
+        // silence region. The first speech frame starts at sample 3*480=1440,
+        // and prefill includes 3 silence frames before it, so start ≈ 0.
+        let segs = results[0].segments.as_ref().unwrap();
+        assert!(
+            segs[0].start < 0.01,
+            "expected start near 0.0, got {}",
+            segs[0].start
+        );
+    }
+
+    #[test]
+    fn vad_chunked_pending_frame_alignment() {
+        let vad = EnergyVad::new(480, 0.01);
+        let config = VadChunkedConfig {
+            min_chunk_secs: 0.0,
+            ..Default::default()
+        };
+        let mut t = VadChunked::new(Box::new(vad), config, TranscribeOptions::default());
+        let mut model = MockModel;
+
+        // Feed 1000 samples (2 full frames of 480 + 40 remainder)
+        // The 40 remainder should go to pending, not speech_buffer
+        let speech = make_speech(1, 1000); // 1000 samples of speech
+        t.feed(&mut model, &speech).unwrap();
+
+        // Feed another 1000: pending(40) + 1000 = 1040 → 2 frames + 80 pending
+        t.feed(&mut model, &speech).unwrap();
+
+        // Feed silence to trigger. The 80 pending speech samples combine with
+        // the start of silence to form a frame that VAD still classifies as
+        // speech (RMS > threshold), so 5 full frames total.
+        let silence = make_silence(480, 5);
+        let results = t.feed(&mut model, &silence).unwrap();
+        assert_eq!(results.len(), 1);
+
+        // 4 full speech frames (1920) + 1 mixed frame (80 speech + 400 silence = 480)
+        assert_eq!(results[0].text, "chunk_2400");
+    }
+
+    #[test]
+    fn vad_chunked_reusable_after_error() {
+        let vad = EnergyVad::new(480, 0.01);
+        let config = VadChunkedConfig {
+            min_chunk_secs: 0.0,
+            ..Default::default()
+        };
+        let mut t = VadChunked::new(Box::new(vad), config, TranscribeOptions::default());
+
+        // First session: force an error during finish
+        let speech = make_speech(480, 10);
+        t.feed(&mut FailOnNthModel::new(1), &speech).unwrap();
+        assert!(t.finish(&mut FailOnNthModel::new(1)).is_err());
+
+        // Second session: should work cleanly after error reset
+        let mut model = MockModel;
+        let result = t.transcribe(&mut model, &speech).unwrap();
+        assert_eq!(result.text, "chunk_4800");
+    }
+}

--- a/src/vad/mod.rs
+++ b/src/vad/mod.rs
@@ -1,0 +1,467 @@
+//! Voice Activity Detection (VAD).
+//!
+//! This module provides the [`Vad`] trait for frame-level voice activity detection,
+//! along with built-in implementations:
+//!
+//! - [`EnergyVad`] — simple RMS energy threshold (pure Rust, no dependencies)
+//! - [`SmoothedVad`] — wraps any `Vad` with onset detection and hangover
+//! - [`SileroVad`] — Silero ONNX model (requires `vad-silero` feature)
+//!
+//! # Recommended Parameters
+//!
+//! | Parameter | Value | Meaning |
+//! |-----------|-------|---------|
+//! | Silero threshold | 0.3 | 30% speech probability to register |
+//! | Prefill frames | 15 | 450ms audio history before speech |
+//! | Hangover frames | 15 | 450ms continuation after speech ends |
+//! | Onset frames | 2 | 60ms consecutive speech to trigger |
+//! | Frame size | 480 | 30ms at 16kHz |
+
+#[cfg(feature = "vad-silero")]
+mod silero;
+#[cfg(feature = "vad-silero")]
+pub use silero::SileroVad;
+
+use std::collections::VecDeque;
+
+use crate::TranscribeError;
+
+/// Voice activity detection.
+///
+/// Implementations classify fixed-size audio frames as speech or non-speech.
+/// The frame size is determined by the implementation (e.g. 480 samples for
+/// Silero at 16kHz).
+pub trait Vad: Send {
+    /// Number of samples required per frame.
+    ///
+    /// Silero: 480 (30ms at 16kHz). EnergyVad: configurable.
+    fn frame_size(&self) -> usize;
+
+    /// Returns `true` if the frame contains speech.
+    ///
+    /// The frame must be exactly [`frame_size()`](Vad::frame_size) samples.
+    fn is_speech(&mut self, frame: &[f32]) -> Result<bool, TranscribeError>;
+
+    /// Drain any buffered prefill audio and return it as a flat sample vector.
+    ///
+    /// Call this immediately after [`is_speech()`](Vad::is_speech) returns `true`
+    /// for the first time (speech onset) to recover pre-onset audio that the
+    /// smoothing/onset logic consumed. The returned samples do **not** include
+    /// the current frame — the caller should append that separately.
+    ///
+    /// Returns an empty vec by default (no prefill support).
+    fn drain_prefill(&mut self) -> Vec<f32> {
+        Vec::new()
+    }
+
+    /// Reset internal state. Call between unrelated audio segments.
+    fn reset(&mut self);
+}
+
+/// Simple RMS energy-based VAD. Zero dependencies.
+///
+/// Classifies a frame as speech if its RMS energy exceeds the configured
+/// threshold. Suitable for clean audio with minimal background noise.
+/// Use [`SileroVad`] for noisy environments.
+pub struct EnergyVad {
+    frame_size: usize,
+    threshold_rms: f32,
+}
+
+impl EnergyVad {
+    /// Create a new `EnergyVad`.
+    ///
+    /// - `frame_size`: number of samples per frame
+    /// - `threshold_rms`: RMS threshold above which a frame is classified as speech
+    pub fn new(frame_size: usize, threshold_rms: f32) -> Self {
+        Self {
+            frame_size,
+            threshold_rms,
+        }
+    }
+}
+
+impl Vad for EnergyVad {
+    fn frame_size(&self) -> usize {
+        self.frame_size
+    }
+
+    fn is_speech(&mut self, frame: &[f32]) -> Result<bool, TranscribeError> {
+        if frame.len() != self.frame_size {
+            return Err(TranscribeError::Audio(format!(
+                "expected {} samples, got {}",
+                self.frame_size,
+                frame.len()
+            )));
+        }
+        let rms = (frame.iter().map(|s| s * s).sum::<f32>() / frame.len() as f32).sqrt();
+        Ok(rms > self.threshold_rms)
+    }
+
+    fn reset(&mut self) {}
+}
+
+/// Wraps any [`Vad`] with onset detection and hangover smoothing.
+///
+/// - **Onset detection**: requires `onset_frames` consecutive speech frames
+///   before transitioning to the speech state.
+/// - **Hangover**: continues reporting speech for `hangover_frames` frames
+///   after the inner VAD stops detecting voice.
+/// - **Prefill buffer**: maintains a ring buffer of recent frames (up to
+///   `prefill_frames + 1`) for use by higher-level chunking logic.
+///
+/// The `is_speech()` method returns the smoothed speech/non-speech decision.
+/// Use [`in_speech()`](SmoothedVad::in_speech) to query the current state
+/// without feeding a new frame.
+pub struct SmoothedVad {
+    inner: Box<dyn Vad>,
+    onset_frames: usize,
+    hangover_frames: usize,
+    prefill_frames: usize,
+    // internal state
+    frame_buffer: VecDeque<Vec<f32>>,
+    hangover_counter: usize,
+    onset_counter: usize,
+    in_speech: bool,
+    /// Set on speech onset, cleared by `drain_prefill()`. Guards against
+    /// draining at the wrong time or double-draining.
+    at_onset: bool,
+}
+
+impl SmoothedVad {
+    /// Create a new `SmoothedVad` wrapping the given inner VAD.
+    ///
+    /// - `inner`: the underlying VAD implementation
+    /// - `prefill_frames`: number of historical frames to retain in the ring buffer
+    /// - `hangover_frames`: number of non-speech frames to wait before leaving speech state
+    /// - `onset_frames`: number of consecutive speech frames required to enter speech state
+    pub fn new(
+        inner: Box<dyn Vad>,
+        prefill_frames: usize,
+        hangover_frames: usize,
+        onset_frames: usize,
+    ) -> Self {
+        Self {
+            inner,
+            onset_frames,
+            hangover_frames,
+            prefill_frames,
+            frame_buffer: VecDeque::new(),
+            hangover_counter: 0,
+            onset_counter: 0,
+            in_speech: false,
+            at_onset: false,
+        }
+    }
+
+    /// Whether currently in a speech region (after onset, before hangover expires).
+    pub fn in_speech(&self) -> bool {
+        self.in_speech
+    }
+
+    /// Access the prefill frame buffer.
+    ///
+    /// Contains up to `prefill_frames + 1` most recent frames. Useful for
+    /// higher-level chunking logic that needs audio history when speech onset
+    /// is detected.
+    pub fn frame_buffer(&self) -> &VecDeque<Vec<f32>> {
+        &self.frame_buffer
+    }
+}
+
+impl Vad for SmoothedVad {
+    fn frame_size(&self) -> usize {
+        self.inner.frame_size()
+    }
+
+    fn is_speech(&mut self, frame: &[f32]) -> Result<bool, TranscribeError> {
+        // Buffer frame for prefill (skip copy if prefill disabled).
+        // The current frame is included in the buffer so that
+        // `drain_prefill()` can pop it off — callers add the current
+        // frame themselves.
+        if self.prefill_frames > 0 {
+            self.frame_buffer.push_back(frame.to_vec());
+            while self.frame_buffer.len() > self.prefill_frames + 1 {
+                self.frame_buffer.pop_front();
+            }
+        }
+
+        let voice = self.inner.is_speech(frame)?;
+
+        match (self.in_speech, voice) {
+            (false, true) => {
+                self.onset_counter += 1;
+                if self.onset_counter >= self.onset_frames {
+                    self.in_speech = true;
+                    self.at_onset = true;
+                    self.hangover_counter = self.hangover_frames;
+                    self.onset_counter = 0;
+                    Ok(true)
+                } else {
+                    Ok(false)
+                }
+            }
+            (true, true) => {
+                self.hangover_counter = self.hangover_frames;
+                Ok(true)
+            }
+            (true, false) => {
+                if self.hangover_counter > 0 {
+                    self.hangover_counter -= 1;
+                    Ok(true)
+                } else {
+                    self.in_speech = false;
+                    Ok(false)
+                }
+            }
+            (false, false) => {
+                self.onset_counter = 0;
+                Ok(false)
+            }
+        }
+    }
+
+    fn drain_prefill(&mut self) -> Vec<f32> {
+        if !self.at_onset {
+            return Vec::new();
+        }
+        self.at_onset = false;
+        // Remove the current frame (pushed during the is_speech call that
+        // triggered this drain) — the caller appends it separately.
+        self.frame_buffer.pop_back();
+        let frame_size = self.inner.frame_size();
+        let mut out = Vec::with_capacity(self.frame_buffer.len() * frame_size);
+        for buf in self.frame_buffer.drain(..) {
+            out.extend(buf);
+        }
+        out
+    }
+
+    fn reset(&mut self) {
+        self.frame_buffer.clear();
+        self.hangover_counter = 0;
+        self.onset_counter = 0;
+        self.in_speech = false;
+        self.at_onset = false;
+        self.inner.reset();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── EnergyVad tests ──────────────────────────────────────────────
+
+    #[test]
+    fn energy_vad_silence_below_threshold() {
+        let mut vad = EnergyVad::new(480, 0.01);
+        let silence = vec![0.0f32; 480];
+        assert!(!vad.is_speech(&silence).unwrap());
+    }
+
+    #[test]
+    fn energy_vad_loud_signal_above_threshold() {
+        let mut vad = EnergyVad::new(480, 0.01);
+        let loud = vec![1.0f32; 480];
+        assert!(vad.is_speech(&loud).unwrap());
+    }
+
+    #[test]
+    fn energy_vad_wrong_frame_size() {
+        let mut vad = EnergyVad::new(480, 0.01);
+        let short = vec![0.0f32; 100];
+        assert!(vad.is_speech(&short).is_err());
+    }
+
+    #[test]
+    fn energy_vad_threshold_boundary() {
+        let mut vad = EnergyVad::new(480, 0.5);
+
+        // Well below threshold
+        let below = vec![0.1f32; 480];
+        assert!(!vad.is_speech(&below).unwrap());
+
+        // Well above threshold
+        let above = vec![0.9f32; 480];
+        assert!(vad.is_speech(&above).unwrap());
+    }
+
+    #[test]
+    fn energy_vad_frame_size_getter() {
+        let vad = EnergyVad::new(320, 0.01);
+        assert_eq!(vad.frame_size(), 320);
+    }
+
+    // ── SmoothedVad tests ────────────────────────────────────────────
+
+    /// Helper: creates a SmoothedVad wrapping an EnergyVad
+    fn make_smoothed(onset: usize, hangover: usize, prefill: usize) -> SmoothedVad {
+        SmoothedVad::new(
+            Box::new(EnergyVad::new(480, 0.01)),
+            prefill,
+            hangover,
+            onset,
+        )
+    }
+
+    #[test]
+    fn smoothed_onset_requires_n_frames() {
+        let mut vad = make_smoothed(3, 5, 0);
+        let speech = vec![1.0f32; 480];
+
+        // First two speech frames should NOT trigger onset
+        assert!(!vad.is_speech(&speech).unwrap());
+        assert!(!vad.in_speech());
+        assert!(!vad.is_speech(&speech).unwrap());
+        assert!(!vad.in_speech());
+
+        // Third speech frame triggers onset
+        assert!(vad.is_speech(&speech).unwrap());
+        assert!(vad.in_speech());
+    }
+
+    #[test]
+    fn smoothed_hangover_extends_speech() {
+        let mut vad = make_smoothed(1, 3, 0);
+        let speech = vec![1.0f32; 480];
+        let silence = vec![0.0f32; 480];
+
+        // Enter speech
+        assert!(vad.is_speech(&speech).unwrap());
+        assert!(vad.in_speech());
+
+        // Hangover: 3 silent frames should still report speech
+        assert!(vad.is_speech(&silence).unwrap()); // hangover 2
+        assert!(vad.in_speech());
+        assert!(vad.is_speech(&silence).unwrap()); // hangover 1
+        assert!(vad.in_speech());
+        assert!(vad.is_speech(&silence).unwrap()); // hangover 0
+        assert!(vad.in_speech());
+
+        // After hangover expires, should report non-speech
+        assert!(!vad.is_speech(&silence).unwrap());
+        assert!(!vad.in_speech());
+    }
+
+    #[test]
+    fn smoothed_speech_resets_hangover() {
+        let mut vad = make_smoothed(1, 2, 0);
+        let speech = vec![1.0f32; 480];
+        let silence = vec![0.0f32; 480];
+
+        // Enter speech
+        assert!(vad.is_speech(&speech).unwrap());
+
+        // One silent frame (hangover 1 remaining)
+        assert!(vad.is_speech(&silence).unwrap());
+
+        // Speech again resets hangover
+        assert!(vad.is_speech(&speech).unwrap());
+
+        // Now need full 2 silent frames again
+        assert!(vad.is_speech(&silence).unwrap()); // hangover 1
+        assert!(vad.is_speech(&silence).unwrap()); // hangover 0
+        assert!(!vad.is_speech(&silence).unwrap()); // expired
+    }
+
+    #[test]
+    fn smoothed_onset_counter_resets_on_silence() {
+        let mut vad = make_smoothed(3, 0, 0);
+        let speech = vec![1.0f32; 480];
+        let silence = vec![0.0f32; 480];
+
+        // Two speech frames (need 3 for onset)
+        assert!(!vad.is_speech(&speech).unwrap());
+        assert!(!vad.is_speech(&speech).unwrap());
+
+        // Silence resets the onset counter
+        assert!(!vad.is_speech(&silence).unwrap());
+
+        // Need to start over — two more speech frames not enough
+        assert!(!vad.is_speech(&speech).unwrap());
+        assert!(!vad.is_speech(&speech).unwrap());
+        assert!(!vad.in_speech());
+
+        // Third consecutive speech frame triggers
+        assert!(vad.is_speech(&speech).unwrap());
+        assert!(vad.in_speech());
+    }
+
+    #[test]
+    fn smoothed_reset_clears_state() {
+        let mut vad = make_smoothed(1, 5, 10);
+        let speech = vec![1.0f32; 480];
+
+        // Enter speech and feed a few frames
+        assert!(vad.is_speech(&speech).unwrap());
+        assert!(vad.is_speech(&speech).unwrap());
+        assert!(vad.in_speech());
+        assert!(!vad.frame_buffer().is_empty());
+
+        // Reset
+        vad.reset();
+        assert!(!vad.in_speech());
+        assert!(vad.frame_buffer().is_empty());
+    }
+
+    #[test]
+    fn smoothed_prefill_buffer_size() {
+        let mut vad = make_smoothed(1, 0, 5);
+        let speech = vec![1.0f32; 480];
+
+        // Feed 10 frames — buffer should cap at prefill_frames + 1 = 6
+        for _ in 0..10 {
+            let _ = vad.is_speech(&speech).unwrap();
+        }
+        assert_eq!(vad.frame_buffer().len(), 6);
+    }
+
+    #[test]
+    fn smoothed_frame_size_delegates() {
+        let vad = make_smoothed(1, 0, 0);
+        assert_eq!(vad.frame_size(), 480);
+    }
+
+    #[test]
+    fn smoothed_drain_prefill_returns_pre_onset_frames() {
+        let mut vad = make_smoothed(2, 0, 5);
+        let speech = vec![1.0f32; 480];
+        let silence = vec![0.0f32; 480];
+
+        // Feed 3 silence frames (buffered as prefill)
+        assert!(!vad.is_speech(&silence).unwrap());
+        assert!(!vad.is_speech(&silence).unwrap());
+        assert!(!vad.is_speech(&silence).unwrap());
+
+        // Feed 2 speech frames to trigger onset (onset_frames=2)
+        assert!(!vad.is_speech(&speech).unwrap()); // onset_counter=1
+        assert!(vad.is_speech(&speech).unwrap()); // onset_counter=2, triggers
+
+        // drain_prefill should return pre-onset frames (excluding current)
+        let prefill = vad.drain_prefill();
+        // Buffer had: [S1, S2, S3, F1, F2], pop F2 → return [S1, S2, S3, F1]
+        assert_eq!(prefill.len(), 4 * 480);
+    }
+
+    #[test]
+    fn smoothed_drain_prefill_empty_without_prefill() {
+        let mut vad = make_smoothed(1, 0, 0); // prefill disabled
+        let speech = vec![1.0f32; 480];
+
+        assert!(vad.is_speech(&speech).unwrap());
+        let prefill = vad.drain_prefill();
+        assert!(prefill.is_empty());
+    }
+
+    #[test]
+    fn smoothed_no_buffering_when_prefill_zero() {
+        let mut vad = make_smoothed(1, 0, 0);
+        let speech = vec![1.0f32; 480];
+
+        for _ in 0..10 {
+            let _ = vad.is_speech(&speech).unwrap();
+        }
+        assert!(vad.frame_buffer().is_empty());
+    }
+}

--- a/src/vad/silero.rs
+++ b/src/vad/silero.rs
@@ -1,0 +1,171 @@
+//! Silero VAD — neural voice activity detection using the Silero ONNX model.
+//!
+//! Requires the `vad-silero` feature flag and a `silero_vad_v4.onnx` model file.
+//!
+//! The model file is NOT bundled — the consumer provides the path:
+//!
+//! ```ignore
+//! use transcribe_rs::vad::SileroVad;
+//! let vad = SileroVad::new("/path/to/silero_vad_v4.onnx", 0.3)?;
+//! ```
+
+use std::path::Path;
+
+use ndarray::{Array1, Array3, ArrayView2};
+use ort::inputs;
+use ort::session::builder::GraphOptimizationLevel;
+use ort::session::Session;
+use ort::value::TensorRef;
+
+use super::Vad;
+use crate::TranscribeError;
+
+/// Number of samples per frame: 30ms at 16kHz.
+const FRAME_SAMPLES: usize = 480;
+
+/// Silero VAD using an ONNX model with LSTM state.
+///
+/// Classifies 30ms audio frames (480 samples at 16kHz) as speech or
+/// non-speech using the Silero VAD v4 model. Maintains internal LSTM
+/// hidden and cell states across frames for temporal context.
+///
+/// # Example
+///
+/// ```ignore
+/// use transcribe_rs::vad::{SileroVad, Vad};
+///
+/// let mut vad = SileroVad::new("silero_vad_v4.onnx", 0.3)?;
+/// let frame = vec![0.0f32; 480]; // 30ms of silence
+/// let is_speech = vad.is_speech(&frame)?;
+/// ```
+pub struct SileroVad {
+    session: Session,
+    h: Array3<f32>,  // LSTM hidden state (2, 1, 64)
+    c: Array3<f32>,  // LSTM cell state (2, 1, 64)
+    sr: Array1<i64>, // sample rate tensor
+    threshold: f32,
+}
+
+impl SileroVad {
+    /// Create a new `SileroVad` from a Silero ONNX model file.
+    ///
+    /// - `model_path`: path to `silero_vad_v4.onnx`
+    /// - `threshold`: speech probability threshold (recommended: 0.3)
+    pub fn new(model_path: impl AsRef<Path>, threshold: f32) -> Result<Self, TranscribeError> {
+        let path = model_path.as_ref();
+        let session = Session::builder()
+            .map_err(|e| TranscribeError::Config(format!("ort session builder: {e}")))?
+            .with_optimization_level(GraphOptimizationLevel::Level3)
+            .map_err(|e| TranscribeError::Config(format!("ort optimization level: {e}")))?
+            .with_intra_threads(1)
+            .map_err(|e| TranscribeError::Config(format!("ort intra threads: {e}")))?
+            .with_inter_threads(1)
+            .map_err(|e| TranscribeError::Config(format!("ort inter threads: {e}")))?
+            .commit_from_file(path)
+            .map_err(|e| {
+                if !path.exists() {
+                    TranscribeError::ModelNotFound(path.to_path_buf())
+                } else {
+                    TranscribeError::Inference(format!("failed to load VAD model: {e}"))
+                }
+            })?;
+
+        Ok(Self {
+            session,
+            h: Array3::zeros((2, 1, 64)),
+            c: Array3::zeros((2, 1, 64)),
+            sr: Array1::from_vec(vec![16000i64]),
+            threshold,
+        })
+    }
+
+    /// Current speech probability threshold.
+    pub fn threshold(&self) -> f32 {
+        self.threshold
+    }
+
+    /// Update the speech probability threshold (0.0–1.0).
+    pub fn set_threshold(&mut self, threshold: f32) {
+        self.threshold = threshold;
+    }
+
+    /// Run inference and return the raw speech probability (0.0–1.0).
+    ///
+    /// Unlike [`is_speech()`](Vad::is_speech), this returns the model's
+    /// confidence rather than a thresholded boolean. Useful for custom
+    /// smoothing, visualization, or sensitivity tuning.
+    pub fn speech_probability(&mut self, frame: &[f32]) -> Result<f32, TranscribeError> {
+        if frame.len() != FRAME_SAMPLES {
+            return Err(TranscribeError::Audio(format!(
+                "expected {FRAME_SAMPLES} samples, got {}",
+                frame.len()
+            )));
+        }
+
+        let input = ArrayView2::from_shape((1, FRAME_SAMPLES), frame)
+            .map_err(|e| TranscribeError::Inference(e.to_string()))?;
+
+        let t_input = TensorRef::from_array_view(input.into_dyn())
+            .map_err(|e| TranscribeError::Inference(format!("tensor input: {e}")))?;
+        let t_sr = TensorRef::from_array_view(self.sr.view().into_dyn())
+            .map_err(|e| TranscribeError::Inference(format!("tensor sr: {e}")))?;
+        let t_h = TensorRef::from_array_view(self.h.view().into_dyn())
+            .map_err(|e| TranscribeError::Inference(format!("tensor h: {e}")))?;
+        let t_c = TensorRef::from_array_view(self.c.view().into_dyn())
+            .map_err(|e| TranscribeError::Inference(format!("tensor c: {e}")))?;
+
+        let outputs = self
+            .session
+            .run(inputs![
+                "input" => t_input,
+                "sr" => t_sr,
+                "h" => t_h,
+                "c" => t_c,
+            ])
+            .map_err(|e| TranscribeError::Inference(e.to_string()))?;
+
+        // Extract updated LSTM states
+        let hn = outputs
+            .get("hn")
+            .ok_or_else(|| TranscribeError::Inference("missing output: hn".to_string()))?
+            .try_extract_array::<f32>()
+            .map_err(|e| TranscribeError::Inference(format!("extract hn: {e}")))?;
+        self.h = hn
+            .to_owned()
+            .into_shape_with_order((2, 1, 64))
+            .map_err(|e| TranscribeError::Inference(format!("reshape hn: {e}")))?;
+
+        let cn = outputs
+            .get("cn")
+            .ok_or_else(|| TranscribeError::Inference("missing output: cn".to_string()))?
+            .try_extract_array::<f32>()
+            .map_err(|e| TranscribeError::Inference(format!("extract cn: {e}")))?;
+        self.c = cn
+            .to_owned()
+            .into_shape_with_order((2, 1, 64))
+            .map_err(|e| TranscribeError::Inference(format!("reshape cn: {e}")))?;
+
+        let output = outputs
+            .get("output")
+            .ok_or_else(|| TranscribeError::Inference("missing output: output".to_string()))?
+            .try_extract_array::<f32>()
+            .map_err(|e| TranscribeError::Inference(format!("extract output: {e}")))?;
+
+        Ok(output[[0, 0]])
+    }
+}
+
+impl Vad for SileroVad {
+    fn frame_size(&self) -> usize {
+        FRAME_SAMPLES
+    }
+
+    fn is_speech(&mut self, frame: &[f32]) -> Result<bool, TranscribeError> {
+        Ok(self.speech_probability(frame)? > self.threshold)
+    }
+
+    fn reset(&mut self) {
+        self.h.fill(0.0);
+        self.c.fill(0.0);
+    }
+}

--- a/src/whisper_cpp/gpu.rs
+++ b/src/whisper_cpp/gpu.rs
@@ -1,0 +1,137 @@
+//! GPU device enumeration and auto-selection for whisper.cpp inference.
+//!
+//! Provides [`list_gpu_devices`] to enumerate available GPUs and
+//! [`auto_select_gpu_device`] to pick the best one automatically
+//! (preferring dedicated GPUs over integrated by total VRAM).
+
+use log::info;
+use serde::Serialize;
+use std::ffi::CStr;
+use whisper_rs::whisper_rs_sys;
+
+/// Whether a GPU is dedicated or integrated.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub enum GpuKind {
+    /// Dedicated GPU (discrete card with its own VRAM).
+    Dedicated,
+    /// Integrated GPU (shares system memory).
+    Integrated,
+}
+
+/// Information about a GPU device available for inference.
+#[derive(Debug, Clone, Serialize)]
+pub struct GpuDeviceInfo {
+    /// Device ID to pass to [`crate::whisper_cpp::WhisperLoadParams::gpu_device`].
+    ///
+    /// This is the Nth GPU/IGPU in ggml's global device list, matching the
+    /// index that whisper.cpp uses to select a device.
+    pub id: i32,
+    /// Human-readable device name (e.g. "NVIDIA GeForce RTX 4060").
+    pub name: String,
+    /// Whether this is a dedicated or integrated GPU.
+    pub kind: GpuKind,
+    /// Total VRAM in bytes.
+    pub total_vram: usize,
+    /// Free VRAM in bytes.
+    pub free_vram: usize,
+}
+
+/// List GPU devices available for whisper inference.
+///
+/// Uses the GGML backend API to enumerate GPU devices across all backends
+/// (Vulkan, CUDA, Metal, etc.). Device IDs match the index that whisper.cpp
+/// uses internally to select a GPU.
+///
+/// On Metal, `gpu_device` is ignored by whisper.cpp (there is only one Metal
+/// device), but the device is still listed for informational purposes.
+pub fn list_gpu_devices() -> Vec<GpuDeviceInfo> {
+    // On some platforms (e.g. Windows) whisper_rs_sys generates these as i32,
+    // on others as u32. Cast to i32 for cross-platform compatibility.
+    let type_gpu = whisper_rs_sys::ggml_backend_dev_type_GGML_BACKEND_DEVICE_TYPE_GPU as i32;
+    let type_igpu = whisper_rs_sys::ggml_backend_dev_type_GGML_BACKEND_DEVICE_TYPE_IGPU as i32;
+
+    unsafe {
+        let count = whisper_rs_sys::ggml_backend_dev_count();
+        let mut gpu_devices = Vec::new();
+        let mut gpu_index: i32 = 0;
+
+        for i in 0..count {
+            let dev = whisper_rs_sys::ggml_backend_dev_get(i);
+            if dev.is_null() {
+                continue;
+            }
+
+            // Only include actual GPU devices (dedicated or integrated),
+            // skip CPU and ACCEL (e.g. Apple Accelerate framework).
+            let dev_type = whisper_rs_sys::ggml_backend_dev_type(dev) as i32;
+            if dev_type != type_gpu && dev_type != type_igpu {
+                continue;
+            }
+
+            let name = {
+                let ptr = whisper_rs_sys::ggml_backend_dev_description(dev);
+                if ptr.is_null() {
+                    format!("GPU {gpu_index}")
+                } else {
+                    CStr::from_ptr(ptr).to_string_lossy().into_owned()
+                }
+            };
+
+            let mut free: usize = 0;
+            let mut total: usize = 0;
+            whisper_rs_sys::ggml_backend_dev_memory(dev, &mut free, &mut total);
+
+            let kind = if dev_type == type_gpu {
+                GpuKind::Dedicated
+            } else {
+                GpuKind::Integrated
+            };
+
+            gpu_devices.push(GpuDeviceInfo {
+                id: gpu_index,
+                name,
+                kind,
+                total_vram: total,
+                free_vram: free,
+            });
+
+            gpu_index += 1;
+        }
+
+        gpu_devices
+    }
+}
+
+/// Auto-select the best GPU device for whisper inference.
+///
+/// Prefers dedicated GPUs over integrated, then picks the device with the most
+/// total VRAM as a tiebreaker.
+///
+/// Returns `0` if no devices are found or enumeration fails.
+pub fn auto_select_gpu_device() -> i32 {
+    let devices = list_gpu_devices();
+    if devices.is_empty() {
+        return 0;
+    }
+
+    let best = devices
+        .iter()
+        .max_by_key(|d| {
+            let kind_priority = match d.kind {
+                GpuKind::Dedicated => 1u8,
+                GpuKind::Integrated => 0,
+            };
+            (kind_priority, d.total_vram)
+        })
+        .unwrap(); // safe: devices is non-empty
+
+    info!(
+        "Auto-selected GPU device {} '{}' ({:?}, {} MB VRAM)",
+        best.id,
+        best.name,
+        best.kind,
+        best.total_vram / (1024 * 1024),
+    );
+
+    best.id
+}

--- a/src/whisper_cpp/mod.rs
+++ b/src/whisper_cpp/mod.rs
@@ -26,11 +26,15 @@
 //! # Ok::<(), Box<dyn std::error::Error>>(())
 //! ```
 
-use crate::accel::get_whisper_accelerator;
+pub mod gpu;
+
+use crate::accel::{get_whisper_accelerator, get_whisper_gpu_device, GPU_DEVICE_AUTO};
 use crate::{
     ModelCapabilities, SpeechModel, TranscribeError, TranscribeOptions, TranscriptionResult,
     TranscriptionSegment,
 };
+use gpu::auto_select_gpu_device;
+use log::info;
 use std::path::Path;
 use whisper_rs::{FullParams, SamplingStrategy, WhisperContext, WhisperContextParameters};
 
@@ -52,7 +56,11 @@ pub struct WhisperLoadParams {
     /// Enable flash attention for faster inference.
     /// Cannot be used with DTW token-level timestamps.
     pub flash_attn: bool,
-    /// GPU device index (0-based). Only relevant with multiple GPUs.
+    /// GPU device index.
+    ///
+    /// - [`GPU_DEVICE_AUTO`] (default): automatically select the best GPU
+    ///   (prefers dedicated over integrated, then most VRAM).
+    /// - `0, 1, 2, …`: use a specific device by backend index.
     pub gpu_device: i32,
 }
 
@@ -61,7 +69,7 @@ impl Default for WhisperLoadParams {
         Self {
             use_gpu: true,
             flash_attn: true,
-            gpu_device: 0,
+            gpu_device: GPU_DEVICE_AUTO,
         }
     }
 }
@@ -131,18 +139,23 @@ pub struct WhisperEngine {
 }
 
 impl WhisperEngine {
-    /// Load a Whisper model, respecting the global accelerator preference.
+    /// Load a Whisper model, respecting the global accelerator and GPU device preferences.
     ///
     /// Use [`load_with_params`](Self::load_with_params) for explicit control.
     pub fn load(model_path: &Path) -> Result<Self, TranscribeError> {
         let params = WhisperLoadParams {
             use_gpu: get_whisper_accelerator().use_gpu(),
+            gpu_device: get_whisper_gpu_device(),
             ..Default::default()
         };
         Self::load_with_params(model_path, params)
     }
 
     /// Load a Whisper model with custom parameters.
+    ///
+    /// When `params.gpu_device` is [`GPU_DEVICE_AUTO`] and GPU is enabled,
+    /// the best GPU is selected automatically (preferring dedicated over
+    /// integrated, then most VRAM).
     pub fn load_with_params(
         model_path: &Path,
         params: WhisperLoadParams,
@@ -151,10 +164,19 @@ impl WhisperEngine {
             return Err(TranscribeError::ModelNotFound(model_path.to_path_buf()));
         }
 
+        let gpu_device = if !params.use_gpu {
+            0
+        } else if params.gpu_device == GPU_DEVICE_AUTO {
+            auto_select_gpu_device()
+        } else {
+            info!("Using user-selected GPU device {}", params.gpu_device);
+            params.gpu_device
+        };
+
         let mut context_params = WhisperContextParameters::default();
         context_params.use_gpu = params.use_gpu;
         context_params.flash_attn = params.flash_attn;
-        context_params.gpu_device = params.gpu_device;
+        context_params.gpu_device = gpu_device;
         let context = WhisperContext::new_with_params(model_path.to_str().unwrap(), context_params)
             .map_err(|e| TranscribeError::Inference(e.to_string()))?;
 

--- a/src/whisper_cpp/mod.rs
+++ b/src/whisper_cpp/mod.rs
@@ -280,7 +280,7 @@ impl SpeechModel for WhisperEngine {
         }
     }
 
-    fn transcribe(
+    fn transcribe_raw(
         &mut self,
         samples: &[f32],
         options: &TranscribeOptions,

--- a/src/whisper_cpp/mod.rs
+++ b/src/whisper_cpp/mod.rs
@@ -110,6 +110,10 @@ pub struct WhisperInferenceParams {
 
     /// Initial prompt to provide context to the model.
     pub initial_prompt: Option<String>,
+
+    /// Start each decode with a clean prompt (whisper.cpp's `prompt_past`).
+    /// Default `true` suits push-to-talk; set `false` for continuous speech.
+    pub no_context: bool,
 }
 
 impl Default for WhisperInferenceParams {
@@ -126,6 +130,7 @@ impl Default for WhisperInferenceParams {
             no_speech_thold: 0.2,
             n_threads: 0,
             initial_prompt: None,
+            no_context: true,
         }
     }
 }
@@ -220,6 +225,7 @@ impl WhisperEngine {
         full_params.set_suppress_blank(params.suppress_blank);
         full_params.set_suppress_nst(params.suppress_non_speech_tokens);
         full_params.set_no_speech_thold(params.no_speech_thold);
+        full_params.set_no_context(params.no_context);
         if params.n_threads > 0 {
             full_params.set_n_threads(params.n_threads);
         }

--- a/src/whisperfile.rs
+++ b/src/whisperfile.rs
@@ -488,7 +488,7 @@ impl SpeechModel for WhisperfileEngine {
         CAPABILITIES
     }
 
-    fn transcribe(
+    fn transcribe_raw(
         &mut self,
         samples: &[f32],
         options: &TranscribeOptions,

--- a/tests/cohere.rs
+++ b/tests/cohere.rs
@@ -1,0 +1,30 @@
+mod common;
+
+use std::path::PathBuf;
+
+use transcribe_rs::onnx::cohere::CohereModel;
+use transcribe_rs::onnx::Quantization;
+use transcribe_rs::SpeechModel;
+
+#[test]
+fn test_cohere_jfk() {
+    let model_path = PathBuf::from("models/cohere-int4");
+    let audio_path = PathBuf::from("samples/jfk.wav");
+
+    if !common::require_paths(&[&model_path, &audio_path]) {
+        return;
+    }
+
+    let mut model =
+        CohereModel::load(&model_path, &Quantization::Int4).expect("Failed to load Cohere model");
+
+    let result = model
+        .transcribe_file(&audio_path, &transcribe_rs::TranscribeOptions::default())
+        .expect("Failed to transcribe with Cohere model");
+
+    println!("Transcription: {}", result.text);
+    assert!(
+        !result.text.trim().is_empty(),
+        "Cohere transcription should not be empty"
+    );
+}

--- a/tests/cohere.rs
+++ b/tests/cohere.rs
@@ -28,3 +28,40 @@ fn test_cohere_jfk() {
         "Cohere transcription should not be empty"
     );
 }
+
+#[test]
+fn test_cohere_german() {
+    let model_path = PathBuf::from("models/cohere-int4");
+    let audio_path = PathBuf::from("samples/german.wav");
+
+    if !common::require_paths(&[&model_path, &audio_path]) {
+        return;
+    }
+
+    let mut model =
+        CohereModel::load(&model_path, &Quantization::Int4).expect("Failed to load Cohere model");
+
+    let result = model
+        .transcribe_file(
+            &audio_path,
+            &transcribe_rs::TranscribeOptions {
+                language: Some("de".into()),
+                ..Default::default()
+            },
+        )
+        .expect("Failed to transcribe German audio with Cohere model");
+
+    println!("German transcription: {}", result.text);
+    assert!(
+        !result.text.trim().is_empty(),
+        "Cohere German transcription should not be empty"
+    );
+
+    // Output should contain German words
+    let text_lower = result.text.to_lowercase();
+    assert!(
+        text_lower.contains("strand") || text_lower.contains("die") || text_lower.contains("der"),
+        "German transcription should contain German words, got: '{}'",
+        result.text
+    );
+}

--- a/tests/cohere.rs
+++ b/tests/cohere.rs
@@ -65,3 +65,39 @@ fn test_cohere_german() {
         result.text
     );
 }
+
+#[test]
+fn test_cohere_chinese() {
+    let model_path = PathBuf::from("models/cohere-int4");
+    let audio_path = PathBuf::from("samples/chinese.wav");
+
+    if !common::require_paths(&[&model_path, &audio_path]) {
+        return;
+    }
+
+    let mut model =
+        CohereModel::load(&model_path, &Quantization::Int4).expect("Failed to load Cohere model");
+
+    let result = model
+        .transcribe_file(
+            &audio_path,
+            &transcribe_rs::TranscribeOptions {
+                language: Some("zh".into()),
+                ..Default::default()
+            },
+        )
+        .expect("Failed to transcribe Chinese audio with Cohere model");
+
+    println!("Chinese transcription: {}", result.text);
+    assert!(
+        !result.text.trim().is_empty(),
+        "Cohere Chinese transcription should not be empty"
+    );
+
+    // Output should contain actual Chinese characters, not byte tokens like <0xE5>
+    assert!(
+        !result.text.contains("<0x"),
+        "Chinese transcription should not contain raw byte tokens, got: '{}'",
+        result.text
+    );
+}

--- a/tests/qwen3.rs
+++ b/tests/qwen3.rs
@@ -1,0 +1,129 @@
+mod common;
+
+use std::path::PathBuf;
+
+use transcribe_rs::onnx::qwen3::{Qwen3Model, Qwen3Params};
+use transcribe_rs::onnx::Quantization;
+use transcribe_rs::SpeechModel;
+
+#[test]
+fn test_qwen3_transcribe() -> Result<(), Box<dyn std::error::Error>> {
+    env_logger::try_init().ok();
+
+    let model_path = PathBuf::from("models/qwen3-asr-0.6b");
+    let wav_path = PathBuf::from("samples/jfk.wav");
+
+    if !common::require_paths(&[&model_path, &wav_path]) {
+        return Ok(());
+    }
+
+    let mut model = Qwen3Model::load(&model_path, &Quantization::default())?;
+
+    let result = model.transcribe_file(&wav_path, &transcribe_rs::TranscribeOptions::default())?;
+
+    // INT8 produces comma; FP32 produces semicolon.
+    // Both are acceptable transcriptions of the JFK quote.
+    let acceptable = [
+        "And so, my fellow Americans, ask not what your country can do for you; ask what you can do for your country.",
+        "And so, my fellow Americans, ask not what your country can do for you, ask what you can do for your country.",
+    ];
+    assert!(
+        acceptable.contains(&result.text.trim()),
+        "\nExpected one of: {:?}\nActual: '{}'",
+        acceptable,
+        result.text.trim()
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_qwen3_1_7b_transcribe() -> Result<(), Box<dyn std::error::Error>> {
+    env_logger::try_init().ok();
+
+    let model_path = PathBuf::from("models/qwen3-asr-1.7b");
+    let wav_path = PathBuf::from("samples/jfk.wav");
+
+    if !common::require_paths(&[&model_path, &wav_path]) {
+        return Ok(());
+    }
+
+    let mut model = Qwen3Model::load(&model_path, &Quantization::default())?;
+    let result = model.transcribe_file(&wav_path, &transcribe_rs::TranscribeOptions::default())?;
+
+    // FP32 decoder produces ". Ask" (sentence break); INT8 decoder produces "; ask".
+    // Both are acceptable transcriptions of the JFK quote.
+    let acceptable = [
+        "And so, my fellow Americans, ask not what your country can do for you. Ask what you can do for your country.",
+        "And so, my fellow Americans, ask not what your country can do for you; ask what you can do for your country.",
+    ];
+    assert!(
+        acceptable.contains(&result.text.trim()),
+        "\nExpected one of: {:?}\nActual: '{}'",
+        acceptable,
+        result.text.trim()
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_qwen3_max_tokens_truncation() -> Result<(), Box<dyn std::error::Error>> {
+    env_logger::try_init().ok();
+
+    let model_path = PathBuf::from("models/qwen3-asr-0.6b");
+    let wav_path = PathBuf::from("samples/jfk.wav");
+
+    if !common::require_paths(&[&model_path, &wav_path]) {
+        return Ok(());
+    }
+
+    let samples = transcribe_rs::audio::read_wav_samples(&wav_path)?;
+    let mut model = Qwen3Model::load(&model_path, &Quantization::default())?;
+    let result = model.transcribe_with(&samples, &Qwen3Params { max_tokens: 5 })?;
+
+    assert!(
+        !result.text.is_empty(),
+        "truncated result should be non-empty"
+    );
+    // With max_tokens=5, the output should be much shorter than the full transcription.
+    assert!(
+        result.text.trim().len() < 80,
+        "5-token result should be shorter than full transcription, got: '{}'",
+        result.text.trim()
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_qwen3_empty_audio() -> Result<(), Box<dyn std::error::Error>> {
+    env_logger::try_init().ok();
+
+    let model_path = PathBuf::from("models/qwen3-asr-0.6b");
+
+    if !common::require_paths(&[&model_path]) {
+        return Ok(());
+    }
+
+    let mut model = Qwen3Model::load(&model_path, &Quantization::default())?;
+    let result = model.transcribe_with(&[], &Qwen3Params::default())?;
+    assert_eq!(result.text, "", "empty audio should return empty string");
+
+    Ok(())
+}
+
+#[test]
+fn test_qwen3_audio_too_long() -> Result<(), Box<dyn std::error::Error>> {
+    let model_path = PathBuf::from("models/qwen3-asr-0.6b");
+    if !common::require_paths(&[&model_path]) {
+        return Ok(());
+    }
+    let mut model = Qwen3Model::load(&model_path, &Quantization::default())?;
+    let too_long = vec![0.0f32; 60 * 16_000 + 1];
+    let result = model.transcribe_with(&too_long, &Qwen3Params::default());
+    assert!(result.is_err(), "expected error for audio > 60s");
+    let err = result.unwrap_err().to_string();
+    assert!(err.contains("audio too long"), "unexpected error: {err}");
+    Ok(())
+}

--- a/tests/qwen3.rs
+++ b/tests/qwen3.rs
@@ -127,3 +127,64 @@ fn test_qwen3_audio_too_long() -> Result<(), Box<dyn std::error::Error>> {
     assert!(err.contains("audio too long"), "unexpected error: {err}");
     Ok(())
 }
+
+#[test]
+fn test_qwen3_int4_fp16_embed() -> Result<(), Box<dyn std::error::Error>> {
+    env_logger::try_init().ok();
+
+    // Tests FP16 embed_tokens.bin loading (embed_tokens_dtype: float16 in config.json).
+    let model_path = PathBuf::from("models/qwen3-asr-0.6b-int4");
+    let wav_path = PathBuf::from("samples/jfk.wav");
+
+    if !model_path.join("decoder_init.int4.onnx").exists()
+        || !model_path.join("embed_tokens.bin").exists()
+        || !wav_path.exists()
+    {
+        return Ok(());
+    }
+
+    let mut model = Qwen3Model::load(&model_path, &Quantization::Int4)?;
+    let result = model.transcribe_file(&wav_path, &transcribe_rs::TranscribeOptions::default())?;
+
+    let acceptable = [
+        "And so, my fellow Americans, ask not what your country can do for you, ask what you can do for your country.",
+        "And so, my fellow Americans, ask not what your country can do for you; ask what you can do for your country.",
+    ];
+    assert!(
+        acceptable.contains(&result.text.trim()),
+        "\nExpected one of: {:?}\nActual: '{}'",
+        acceptable,
+        result.text.trim()
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_qwen3_1_7b_int4_transcribe() -> Result<(), Box<dyn std::error::Error>> {
+    env_logger::try_init().ok();
+
+    let model_path = PathBuf::from("models/qwen3-asr-1.7b");
+    let wav_path = PathBuf::from("samples/jfk.wav");
+    let int4_path = model_path.join("decoder_init.int4.onnx");
+
+    if !common::require_paths(&[&model_path, &wav_path]) || !int4_path.exists() {
+        return Ok(());
+    }
+
+    let mut model = Qwen3Model::load(&model_path, &Quantization::Int4)?;
+    let result = model.transcribe_file(&wav_path, &transcribe_rs::TranscribeOptions::default())?;
+
+    let acceptable = [
+        "And so, my fellow Americans, ask not what your country can do for you. Ask what you can do for your country.",
+        "And so, my fellow Americans, ask not what your country can do for you; ask what you can do for your country.",
+    ];
+    assert!(
+        acceptable.contains(&result.text.trim()),
+        "\nExpected one of: {:?}\nActual: '{}'",
+        acceptable,
+        result.text.trim()
+    );
+
+    Ok(())
+}

--- a/tests/qwen3.rs
+++ b/tests/qwen3.rs
@@ -80,7 +80,13 @@ fn test_qwen3_max_tokens_truncation() -> Result<(), Box<dyn std::error::Error>> 
 
     let samples = transcribe_rs::audio::read_wav_samples(&wav_path)?;
     let mut model = Qwen3Model::load(&model_path, &Quantization::default())?;
-    let result = model.transcribe_with(&samples, &Qwen3Params { max_tokens: 5 })?;
+    let result = model.transcribe_with(
+        &samples,
+        &Qwen3Params {
+            max_tokens: 5,
+            ..Default::default()
+        },
+    )?;
 
     assert!(
         !result.text.is_empty(),

--- a/tests/transcribe_single_chunk.rs
+++ b/tests/transcribe_single_chunk.rs
@@ -1,0 +1,62 @@
+#![cfg(feature = "onnx")]
+
+mod common;
+
+use std::path::PathBuf;
+use transcribe_rs::audio::read_wav_samples;
+use transcribe_rs::onnx::canary::CanaryModel;
+use transcribe_rs::onnx::parakeet::ParakeetModel;
+use transcribe_rs::onnx::Quantization;
+use transcribe_rs::SpeechModel;
+
+#[test]
+fn transcribe_fixed_chunk_002_parakeet() {
+    let model_path = PathBuf::from("models/parakeet-tdt-0.6b-v3-int8");
+    let chunk_path = PathBuf::from("target/debug_chunks/fixed/fixed_chunk_002.wav");
+
+    if !common::require_paths(&[&model_path, &chunk_path]) {
+        return;
+    }
+
+    let mut model =
+        ParakeetModel::load(&model_path, &Quantization::Int8).expect("Failed to load model");
+
+    let samples = read_wav_samples(&chunk_path).expect("Failed to read chunk");
+    println!(
+        "fixed_chunk_002: {} samples, {:.2}s",
+        samples.len(),
+        samples.len() as f32 / 16000.0
+    );
+
+    let result = model
+        .transcribe(&samples, &transcribe_rs::TranscribeOptions::default())
+        .expect("Transcription failed");
+
+    println!("parakeet result: \"{}\"", result.text);
+}
+
+#[test]
+fn transcribe_fixed_chunk_002_canary() {
+    let model_path = PathBuf::from("models/canary-1b-v2");
+    let chunk_path = PathBuf::from("target/debug_chunks/fixed/fixed_chunk_002.wav");
+
+    if !common::require_paths(&[&model_path, &chunk_path]) {
+        return;
+    }
+
+    let mut model =
+        CanaryModel::load(&model_path, &Quantization::Int8).expect("Failed to load model");
+
+    let samples = read_wav_samples(&chunk_path).expect("Failed to read chunk");
+    println!(
+        "fixed_chunk_002: {} samples, {:.2}s",
+        samples.len(),
+        samples.len() as f32 / 16000.0
+    );
+
+    let result = model
+        .transcribe(&samples, &transcribe_rs::TranscribeOptions::default())
+        .expect("Transcription failed");
+
+    println!("canary result: \"{}\"", result.text);
+}

--- a/tests/transcriber.rs
+++ b/tests/transcriber.rs
@@ -1,0 +1,149 @@
+mod common;
+
+use std::path::PathBuf;
+
+use transcribe_rs::audio::read_wav_samples;
+use transcribe_rs::onnx::parakeet::ParakeetModel;
+use transcribe_rs::onnx::Quantization;
+use transcribe_rs::transcriber::{
+    EnergyAdaptiveChunked, EnergyAdaptiveConfig, Transcriber, VadChunked, VadChunkedConfig,
+};
+use transcribe_rs::vad::{SileroVad, SmoothedVad};
+use transcribe_rs::{SpeechModel, TranscribeOptions};
+
+#[test]
+fn compare_oneshot_vs_chunked() {
+    let _ = env_logger::builder().is_test(true).try_init();
+
+    let model_path = PathBuf::from("models/parakeet-tdt-0.6b-v3-int8");
+    let vad_path = PathBuf::from("models/silero_vad_v4.onnx");
+    let audio_path = PathBuf::from("samples/dots.wav");
+
+    if !common::require_paths(&[&model_path, &vad_path, &audio_path]) {
+        return;
+    }
+
+    let samples = read_wav_samples(&audio_path).expect("Failed to read audio");
+    let options = TranscribeOptions::default();
+
+    let mut model =
+        ParakeetModel::load(&model_path, &Quantization::Int8).expect("Failed to load model");
+
+    // --- One-shot ---
+    let oneshot = model
+        .transcribe(&samples, &options)
+        .expect("One-shot transcription failed");
+
+    // --- EnergyAdaptiveChunked (10s target, 3s search window) ---
+    let energy_config = EnergyAdaptiveConfig {
+        target_chunk_secs: 10.0,
+        search_window_secs: 3.0,
+        padding_secs: 0.5,
+        ..Default::default()
+    };
+    let energy = EnergyAdaptiveChunked::new(energy_config, options.clone())
+        .transcribe(&mut model, &samples)
+        .expect("EnergyAdaptiveChunked transcription failed");
+
+    // --- VadChunked (SileroVad) ---
+    let silero = SileroVad::new(&vad_path, 0.5).expect("Failed to load Silero VAD");
+    let vad = SmoothedVad::new(Box::new(silero), 15, 20, 2);
+    let vad_config = VadChunkedConfig {
+        padding_secs: 0.2,
+        ..Default::default()
+    };
+    let vad_result = VadChunked::new(Box::new(vad), vad_config, options.clone())
+        .transcribe(&mut model, &samples)
+        .expect("VadChunked transcription failed");
+
+    println!("\n{}", "=".repeat(60));
+    println!("ONE-SHOT ({} chars):", oneshot.text.len());
+    println!("{}", oneshot.text);
+    println!();
+    println!("ENERGY ADAPTIVE 10s CHUNKS ({} chars):", energy.text.len());
+    println!("{}", energy.text);
+    println!();
+    println!("VAD CHUNKED ({} chars):", vad_result.text.len());
+    println!("{}", vad_result.text);
+    println!("{}", "=".repeat(60));
+
+    // All three should produce non-empty output
+    assert!(!oneshot.text.is_empty(), "one-shot produced empty text");
+    assert!(
+        !energy.text.is_empty(),
+        "energy adaptive produced empty text"
+    );
+    assert!(
+        !vad_result.text.is_empty(),
+        "vad chunked produced empty text"
+    );
+}
+
+/// Simulate streaming by feeding audio in small increments (30ms frames)
+/// with short chunk windows (3s). Tests EnergyAdaptiveChunked under
+/// streaming-like conditions.
+#[test]
+fn compare_streaming_energy_adaptive() {
+    let _ = env_logger::builder().is_test(true).try_init();
+
+    let model_path = PathBuf::from("models/parakeet-tdt-0.6b-v3-int8");
+    let audio_path = PathBuf::from("samples/dots.wav");
+
+    if !common::require_paths(&[&model_path, &audio_path]) {
+        return;
+    }
+
+    let samples = read_wav_samples(&audio_path).expect("Failed to read audio");
+    let options = TranscribeOptions::default();
+
+    let mut model =
+        ParakeetModel::load(&model_path, &Quantization::Int8).expect("Failed to load model");
+
+    // --- One-shot baseline ---
+    let oneshot = model
+        .transcribe(&samples, &options)
+        .expect("One-shot transcription failed");
+
+    // --- EnergyAdaptiveChunked 3s target, 1s search, simulated streaming ---
+    let energy_config = EnergyAdaptiveConfig {
+        target_chunk_secs: 3.0,
+        search_window_secs: 1.0,
+        padding_secs: 0.3,
+        ..Default::default()
+    };
+    let mut energy = EnergyAdaptiveChunked::new(energy_config, options.clone());
+
+    let frame_size = 480; // 30ms at 16kHz
+    let mut energy_intermediate: Vec<String> = Vec::new();
+    for chunk in samples.chunks(frame_size) {
+        let results = energy.feed(&mut model, chunk).expect("feed failed");
+        for r in &results {
+            energy_intermediate.push(r.text.clone());
+        }
+    }
+    let energy_result = energy.finish(&mut model).expect("finish failed");
+
+    println!("\n{}", "=".repeat(60));
+    println!("SIMULATED STREAMING (30ms frames, 3s chunks)");
+    println!("{}", "=".repeat(60));
+
+    println!("\nONE-SHOT BASELINE ({} chars):", oneshot.text.len());
+    println!("{}", oneshot.text);
+
+    println!("\nENERGY ADAPTIVE 3s - intermediate chunks:");
+    for (i, text) in energy_intermediate.iter().enumerate() {
+        println!("  chunk {}: \"{}\"", i, text.trim());
+    }
+    println!(
+        "ENERGY ADAPTIVE 3s MERGED ({} chars):",
+        energy_result.text.len()
+    );
+    println!("{}", energy_result.text);
+
+    println!("{}", "=".repeat(60));
+
+    assert!(
+        !energy_result.text.is_empty(),
+        "energy adaptive produced empty text"
+    );
+}

--- a/tests/vad_silero.rs
+++ b/tests/vad_silero.rs
@@ -1,0 +1,151 @@
+mod common;
+
+use std::path::PathBuf;
+
+use transcribe_rs::vad::{SileroVad, SmoothedVad, Vad};
+
+#[test]
+fn test_silero_vad_detects_speech_in_audio() {
+    let model_path = PathBuf::from("models/silero_vad_v4.onnx");
+    let wav_path = PathBuf::from("samples/dots.wav");
+
+    if !common::require_paths(&[&model_path, &wav_path]) {
+        return;
+    }
+
+    let mut vad = SileroVad::new(&model_path, 0.3).expect("Failed to load Silero VAD");
+    let samples = transcribe_rs::audio::read_wav_samples(&wav_path).expect("Failed to read WAV");
+
+    let frame_size = vad.frame_size();
+    assert_eq!(frame_size, 480);
+
+    let mut speech_frames = 0;
+    let mut total_frames = 0;
+
+    for frame in samples.chunks_exact(frame_size) {
+        total_frames += 1;
+        if vad.is_speech(frame).unwrap() {
+            speech_frames += 1;
+        }
+    }
+
+    println!(
+        "Silero VAD: {speech_frames}/{total_frames} frames detected as speech ({:.1}%)",
+        speech_frames as f32 / total_frames as f32 * 100.0
+    );
+
+    // dots.wav has speech — should detect a meaningful amount
+    assert!(speech_frames > 0, "Should detect some speech");
+    assert!(
+        speech_frames < total_frames,
+        "Should not classify everything as speech"
+    );
+}
+
+#[test]
+fn test_silero_vad_silence_detection() {
+    let model_path = PathBuf::from("models/silero_vad_v4.onnx");
+
+    if !common::require_paths(&[&model_path]) {
+        return;
+    }
+
+    let mut vad = SileroVad::new(&model_path, 0.3).expect("Failed to load Silero VAD");
+
+    // Pure silence should not be detected as speech
+    let silence = vec![0.0f32; 480];
+    let is_speech = vad.is_speech(&silence).unwrap();
+    assert!(!is_speech, "Silence should not be classified as speech");
+}
+
+#[test]
+fn test_silero_vad_reset() {
+    let model_path = PathBuf::from("models/silero_vad_v4.onnx");
+    let wav_path = PathBuf::from("samples/dots.wav");
+
+    if !common::require_paths(&[&model_path, &wav_path]) {
+        return;
+    }
+
+    let mut vad = SileroVad::new(&model_path, 0.3).expect("Failed to load Silero VAD");
+    let samples = transcribe_rs::audio::read_wav_samples(&wav_path).expect("Failed to read WAV");
+
+    // Feed some frames to build up LSTM state
+    for frame in samples.chunks_exact(480).take(10) {
+        let _ = vad.is_speech(frame);
+    }
+
+    // Reset should clear LSTM state
+    vad.reset();
+
+    // After reset, silence should still be silence
+    let silence = vec![0.0f32; 480];
+    assert!(!vad.is_speech(&silence).unwrap());
+}
+
+#[test]
+fn test_smoothed_silero_vad() {
+    let model_path = PathBuf::from("models/silero_vad_v4.onnx");
+    let wav_path = PathBuf::from("samples/dots.wav");
+
+    if !common::require_paths(&[&model_path, &wav_path]) {
+        return;
+    }
+
+    let silero = SileroVad::new(&model_path, 0.3).expect("Failed to load Silero VAD");
+    let mut vad = SmoothedVad::new(Box::new(silero), 15, 15, 2);
+
+    let samples = transcribe_rs::audio::read_wav_samples(&wav_path).expect("Failed to read WAV");
+
+    let mut speech_frames = 0;
+    let mut total_frames = 0;
+
+    for frame in samples.chunks_exact(480) {
+        total_frames += 1;
+        if vad.is_speech(frame).unwrap() {
+            speech_frames += 1;
+        }
+    }
+
+    println!(
+        "SmoothedVad(Silero): {speech_frames}/{total_frames} frames detected as speech ({:.1}%)",
+        speech_frames as f32 / total_frames as f32 * 100.0
+    );
+
+    // Smoothed should still detect speech, but with fewer transients
+    assert!(speech_frames > 0, "Should detect some speech");
+}
+
+#[test]
+fn test_smoothed_silero_vad_chunk_count() {
+    let model_path = PathBuf::from("models/silero_vad_v4.onnx");
+    let wav_path = PathBuf::from("samples/dots.wav");
+
+    if !common::require_paths(&[&model_path, &wav_path]) {
+        return;
+    }
+
+    let silero = SileroVad::new(&model_path, 0.3).expect("Failed to load Silero VAD");
+    let mut vad = SmoothedVad::new(Box::new(silero), 15, 15, 2);
+
+    let samples = transcribe_rs::audio::read_wav_samples(&wav_path).expect("Failed to read WAV");
+
+    let mut chunks = 0;
+    let mut was_speech = false;
+
+    for frame in samples.chunks_exact(480) {
+        let is_speech = vad.is_speech(frame).unwrap();
+        if was_speech && !is_speech {
+            // speech → silence transition = end of a chunk
+            chunks += 1;
+        }
+        was_speech = is_speech;
+    }
+    // If audio ends during speech, that's a final chunk
+    if was_speech {
+        chunks += 1;
+    }
+
+    println!("SmoothedVad(Silero) on dots.wav: {chunks} speech chunks");
+    assert!(chunks >= 1, "Should detect at least one speech chunk");
+}

--- a/tests/whisper.rs
+++ b/tests/whisper.rs
@@ -56,13 +56,15 @@ fn test_jfk_transcription() {
         .transcribe_file(&audio_path, &transcribe_rs::TranscribeOptions::default())
         .expect("Failed to transcribe");
 
-    let expected = "And so my fellow Americans, ask not what your country can do for you, ask what you can do for your country.";
+    // We strip punctuation because different OS's have subtle floating-point variations,
+    // causing tiny models to sometimes output a comma or period on one OS but not another.
+    let actual = result.text.trim().replace(",", "").replace(".", "");
+    let expected = "And so my fellow Americans ask not what your country can do for you ask what you can do for your country";
+
     assert_eq!(
-        result.text.trim(),
-        expected,
+        actual, expected,
         "\nExpected: '{}'\nActual: '{}'",
-        expected,
-        result.text.trim()
+        expected, actual
     );
 }
 


### PR DESCRIPTION
## Summary

Enhanced the `examples/qwen3.rs` example to support:
- **Quantization selection** (fp32/fp16/int8/int4) via CLI arg, with auto-inference from model path
- **Language hint** parameter passed to `Qwen3Params`
- **Chunked transcription** for long audio with configurable chunk duration

## Changes

- `examples/qwen3.rs`: Extended CLI usage from `<model_dir> <audio.wav>` to `<model_dir> <audio.wav> [quantization] [language] [chunk_seconds]`
- Added `parse_quantization()`, `infer_quantization_from_path()`, `parse_chunk_seconds()` helpers
- Replaced single `model.transcribe()` with chunked loop using `model.transcribe_with()` + `Qwen3Params`

## Testing

Tested locally with Qwen3-ASR 0.6B int4 model on Windows:
- Short audio: correct transcription with language hint
- Quantization auto-detection from path works
- Chunked transcription produces per-chunk timing and combined output

## Context

Complementary improvement to PR #48 (Qwen3-ASR batch engine). Makes it easier for users to test Qwen3 with different configurations.