### PR TITLE
[codex] add Voxtral backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "async-openai"
 version = "0.29.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -45,7 +54,7 @@ dependencies = [
  "secrecy",
  "serde",
  "serde_json",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -143,7 +152,7 @@ dependencies = [
  "quote",
  "regex",
  "rustc-hash",
- "shlex",
+ "shlex 1.3.0",
  "syn",
 ]
 
@@ -160,6 +169,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -173,12 +188,14 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"
-version = "1.2.36"
+version = "1.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5252b3d2648e5eedbc1a6f501e3c795e07025c1e93bbf8bbdd6eef7f447a6d54"
+checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
 dependencies = [
  "find-msvc-tools",
- "shlex",
+ "jobserver",
+ "libc",
+ "shlex 2.0.1",
 ]
 
 [[package]]
@@ -201,6 +218,19 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-link 0.2.1",
+]
 
 [[package]]
 name = "clang-sys"
@@ -351,6 +381,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "env_logger"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -392,9 +442,9 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.1"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fd99930f64d146689264c637b5af2f0233a933bef0d8570e2526bf9e083192d"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "flate2"
@@ -703,6 +753,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "icu_collections"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -878,6 +952,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.3",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -914,6 +998,32 @@ name = "litemap"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
+
+[[package]]
+name = "llama-cpp-4"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5038d99992ede8295c65f4fbcbb03be5f26cd700ab05d76d4acdd6c5171bd03d"
+dependencies = [
+ "enumflags2",
+ "llama-cpp-sys-4",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "llama-cpp-sys-4"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a012304347e3046e82018636a34caee7dc70f3591a411714b9ddba6666f5f5"
+dependencies = [
+ "bindgen",
+ "cc",
+ "cmake",
+ "glob",
+ "patch-apply",
+ "winreg",
+]
 
 [[package]]
 name = "log"
@@ -1034,6 +1144,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom_locate"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e3c83c053b0713da60c5b8de47fe8e494fe3ece5267b2f23090a07a053ba8f3"
+dependencies = [
+ "bytecount",
+ "memchr",
+ "nom",
+]
+
+[[package]]
 name = "num-complex"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1145,6 +1266,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "patch-apply"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fe95476ec50a4e9b95ed12a4677ff5996aba4329bf2535fb21c49afaad20809"
+dependencies = [
+ "chrono",
+ "nom",
+ "nom_locate",
+]
+
+[[package]]
 name = "pem-rfc7468"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1252,7 +1384,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -1273,7 +1405,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -1705,6 +1837,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
 name = "slab"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1825,11 +1963,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.16"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3467d614147380f2e4e374161426ff399c91084acd2363eaf549172b3d5e60c0"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.16",
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -1845,9 +1983,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.16"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c5e1be1c48b9172ee610da68fd9cd2770e7a4056cb3fc98710ee6906f0c7960"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2028,6 +2166,7 @@ dependencies = [
  "derive_builder",
  "env_logger",
  "hound",
+ "llama-cpp-4",
  "log",
  "ndarray",
  "once_cell",
@@ -2036,7 +2175,7 @@ dependencies = [
  "rustfft",
  "serde",
  "serde_json",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
  "tokio",
  "ureq",
  "whisper-rs",
@@ -2342,6 +2481,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link 0.2.1",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2352,6 +2526,24 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link 0.2.1",
+]
 
 [[package]]
 name = "windows-sys"
@@ -2517,6 +2709,16 @@ name = "windows_x86_64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+
+[[package]]
+name = "winreg"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d6f32a0ff4a9f6f01231eb2059cc85479330739333e0e58cadf03b6af2cca10"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,12 @@ whisper-cuda   = ["whisper-cpp", "whisper-rs/cuda"]
 # Whisperfile server
 whisperfile = ["dep:ureq"]
 
+# Voxtral via llama.cpp libmtmd
+voxtral = ["dep:llama-cpp-4"]
+voxtral-metal = ["voxtral", "llama-cpp-4/metal"]
+voxtral-vulkan = ["voxtral", "llama-cpp-4/vulkan"]
+voxtral-cuda = ["voxtral", "llama-cpp-4/cuda"]
+
 # Remote engines
 openai = ["dep:async-openai", "dep:tokio", "dep:async-trait"]
 
@@ -81,6 +87,9 @@ async-trait = { version = "0.1.89", optional = true }
 # Whisper (GPU features controlled by whisper-metal / whisper-vulkan / whisper-cuda feature flags)
 whisper-rs = { version = "0.16.0", optional = true }
 
+# Voxtral / llama.cpp (GPU features controlled by voxtral-metal / voxtral-vulkan / voxtral-cuda)
+llama-cpp-4 = { version = "0.3.2", default-features = false, features = ["mtmd"], optional = true }
+
 # Examples with required features
 [[example]]
 name = "parakeet"
@@ -122,6 +131,10 @@ required-features = ["whisperfile"]
 name = "openai"
 required-features = ["openai"]
 
+[[example]]
+name = "voxtral"
+required-features = ["voxtral"]
+
 [dev-dependencies]
 once_cell = "1.21.3"
 
@@ -161,6 +174,10 @@ required-features = ["whisperfile"]
 [[test]]
 name = "openai"
 required-features = ["openai"]
+
+[[test]]
+name = "voxtral"
+required-features = ["voxtral"]
 
 [[test]]
 name = "transcriber"

--- a/examples/voxtral.rs
+++ b/examples/voxtral.rs
@@ -1,0 +1,57 @@
+use std::path::PathBuf;
+use std::time::Instant;
+
+use transcribe_rs::voxtral::{VoxtralModel, VoxtralParams};
+use transcribe_rs::SpeechModel;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    env_logger::init();
+
+    let model_path = std::env::var("VOXTRAL_MODEL")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| PathBuf::from("models/voxtral-mini/Voxtral-Mini-3B-2507-Q4_K_M.gguf"));
+    let mmproj_path = std::env::var("VOXTRAL_MMPROJ")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| {
+            PathBuf::from("models/voxtral-mini/mmproj-Voxtral-Mini-3B-2507-Q8_0.gguf")
+        });
+    let wav_path = std::env::var("VOXTRAL_WAV")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| PathBuf::from("samples/jfk.wav"));
+    let language = std::env::var("VOXTRAL_LANGUAGE").ok();
+    let translate = std::env::var("VOXTRAL_TRANSLATE")
+        .ok()
+        .is_some_and(|value| matches!(value.as_str(), "1" | "true" | "yes"));
+    let repeat = std::env::var("VOXTRAL_REPEAT")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(1)
+        .max(1);
+
+    let params = VoxtralParams {
+        max_new_tokens: 192,
+        ..Default::default()
+    };
+    let load_start = Instant::now();
+    let mut model = VoxtralModel::load_files(&model_path, &mmproj_path, params)?;
+    eprintln!("load_time_ms={}", load_start.elapsed().as_millis());
+
+    for index in 0..repeat {
+        let start = Instant::now();
+        let result = model.transcribe_file(
+            &wav_path,
+            &transcribe_rs::TranscribeOptions {
+                language: language.clone(),
+                translate,
+                ..Default::default()
+            },
+        )?;
+        eprintln!(
+            "run={} transcribe_time_ms={}",
+            index + 1,
+            start.elapsed().as_millis()
+        );
+        println!("{}", result.text);
+    }
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,6 +106,8 @@ pub mod onnx;
 pub mod transcriber;
 pub mod vad;
 
+#[cfg(feature = "voxtral")]
+pub mod voxtral;
 #[cfg(feature = "whisper-cpp")]
 pub mod whisper_cpp;
 #[cfg(feature = "whisperfile")]

--- a/src/voxtral.rs
+++ b/src/voxtral.rs
@@ -1,0 +1,370 @@
+//! Voxtral transcription engine backed by llama.cpp's libmtmd.
+
+use std::num::NonZeroU32;
+use std::path::{Path, PathBuf};
+
+use llama_cpp_4::{
+    context::params::LlamaContextParams,
+    llama_backend::LlamaBackend,
+    llama_batch::LlamaBatch,
+    model::{params::LlamaModelParams, LlamaModel, Special},
+    mtmd::{MtmdBitmap, MtmdContext, MtmdContextParams, MtmdInputChunks, MtmdInputText},
+    sampling::LlamaSampler,
+};
+
+use crate::{
+    ModelCapabilities, SpeechModel, TranscribeError, TranscribeOptions, TranscriptionResult,
+};
+
+const SAMPLE_RATE: u32 = 16_000;
+const DEFAULT_CONTEXT_SIZE: u32 = 4096;
+const DEFAULT_BATCH_SIZE: u32 = 2048;
+const DEFAULT_MAX_NEW_TOKENS: usize = 192;
+
+const CAPABILITIES: ModelCapabilities = ModelCapabilities {
+    name: "Voxtral",
+    engine_id: "voxtral",
+    sample_rate: SAMPLE_RATE,
+    languages: &["en", "fr", "de", "es", "it", "pt", "nl", "hi"],
+    supports_timestamps: false,
+    supports_translation: true,
+    supports_streaming: false,
+};
+
+/// Runtime knobs for Voxtral generation.
+#[derive(Debug, Clone)]
+pub struct VoxtralParams {
+    /// Language hint. When omitted, Voxtral auto-detects the language.
+    pub language: Option<String>,
+    /// Ask Voxtral to translate the audio to English instead of transcribing in the source language.
+    pub translate: bool,
+    /// Maximum autoregressive tokens to emit.
+    pub max_new_tokens: usize,
+    /// Number of llama.cpp layers to offload. Use a large number to request full offload.
+    pub n_gpu_layers: u32,
+    /// Context window for each transcription request.
+    pub context_size: u32,
+    /// Batch size for prompt/audio evaluation.
+    pub batch_size: u32,
+    /// Threads used by llama.cpp and libmtmd.
+    pub n_threads: Option<i32>,
+}
+
+impl Default for VoxtralParams {
+    fn default() -> Self {
+        Self {
+            language: None,
+            translate: false,
+            max_new_tokens: DEFAULT_MAX_NEW_TOKENS,
+            n_gpu_layers: 99,
+            context_size: DEFAULT_CONTEXT_SIZE,
+            batch_size: DEFAULT_BATCH_SIZE,
+            n_threads: None,
+        }
+    }
+}
+
+/// Loaded Voxtral GGUF model plus multimodal projector.
+pub struct VoxtralModel {
+    mtmd: MtmdContext,
+    model: LlamaModel,
+    backend: LlamaBackend,
+    params: VoxtralParams,
+}
+
+impl VoxtralModel {
+    /// Load a Voxtral model directory.
+    ///
+    /// The directory must contain one text-model `.gguf` and one `mmproj*.gguf` file.
+    pub fn load(model_dir: &Path) -> Result<Self, TranscribeError> {
+        let model_path = find_model_file(model_dir)?;
+        let mmproj_path = find_mmproj_file(model_dir)?;
+        Self::load_files(&model_path, &mmproj_path, VoxtralParams::default())
+    }
+
+    /// Load explicit text-model and mmproj GGUF files.
+    pub fn load_files(
+        model_path: &Path,
+        mmproj_path: &Path,
+        params: VoxtralParams,
+    ) -> Result<Self, TranscribeError> {
+        if !model_path.exists() {
+            return Err(TranscribeError::ModelNotFound(model_path.to_path_buf()));
+        }
+        if !mmproj_path.exists() {
+            return Err(TranscribeError::ModelNotFound(mmproj_path.to_path_buf()));
+        }
+
+        let backend = map_llama(LlamaBackend::init(), "initializing llama.cpp backend")?;
+        let model_params = LlamaModelParams::default().with_n_gpu_layers(params.n_gpu_layers);
+        let model = map_llama(
+            LlamaModel::load_from_file(&backend, model_path, &model_params),
+            "loading Voxtral GGUF model",
+        )?;
+
+        let mut mtmd_params = MtmdContextParams::default().use_gpu(params.n_gpu_layers > 0);
+        if let Some(n_threads) = params.n_threads {
+            mtmd_params = mtmd_params.n_threads(n_threads);
+        }
+        let mtmd = map_llama(
+            MtmdContext::init_from_file(mmproj_path, &model, mtmd_params),
+            "loading Voxtral mmproj",
+        )?;
+        if !mtmd.supports_audio() {
+            return Err(TranscribeError::Config(
+                "Voxtral mmproj does not report audio support".to_string(),
+            ));
+        }
+
+        Ok(Self {
+            mtmd,
+            model,
+            backend,
+            params,
+        })
+    }
+
+    pub fn transcribe_with(
+        &mut self,
+        samples: &[f32],
+        params: &VoxtralParams,
+    ) -> Result<TranscriptionResult, TranscribeError> {
+        if samples.is_empty() {
+            return Ok(TranscriptionResult {
+                text: String::new(),
+                segments: None,
+            });
+        }
+
+        let text = self.generate(samples, params)?;
+        Ok(TranscriptionResult {
+            text: clean_generated_text(&text),
+            segments: None,
+        })
+    }
+
+    fn generate(
+        &mut self,
+        samples: &[f32],
+        params: &VoxtralParams,
+    ) -> Result<String, TranscribeError> {
+        let context_size = NonZeroU32::new(params.context_size).ok_or_else(|| {
+            TranscribeError::Config("Voxtral context_size must be greater than zero".to_string())
+        })?;
+
+        let mut ctx_params = LlamaContextParams::default()
+            .with_n_ctx(Some(context_size))
+            .with_n_batch(params.batch_size)
+            .with_n_ubatch(params.batch_size.min(512))
+            .with_flash_attention(true);
+        if let Some(n_threads) = params.n_threads {
+            ctx_params = ctx_params
+                .with_n_threads(n_threads)
+                .with_n_threads_batch(n_threads);
+        }
+        let mut ctx = map_llama(
+            self.model.new_context(&self.backend, ctx_params),
+            "creating Voxtral context",
+        )?;
+
+        let bitmap = map_llama(
+            MtmdBitmap::from_audio(samples),
+            "creating Voxtral audio input",
+        )?;
+        let prompt = self.build_prompt(params)?;
+        let input_text = MtmdInputText::new(&prompt, true, true);
+        let mut chunks = MtmdInputChunks::new();
+        map_llama(
+            self.mtmd.tokenize(&input_text, &[&bitmap], &mut chunks),
+            "tokenizing Voxtral prompt",
+        )?;
+
+        let mut n_past = 0_i32;
+        let n_batch = ctx.n_batch() as i32;
+        map_llama(
+            self.mtmd
+                .eval_chunks(ctx.as_ptr(), &chunks, 0, 0, n_batch, true, &mut n_past),
+            "evaluating Voxtral audio prompt",
+        )?;
+
+        let mut sampler = LlamaSampler::chain_simple([LlamaSampler::greedy()]);
+        let mut batch = LlamaBatch::new(params.batch_size as usize, 1);
+        let mut generated = Vec::new();
+        let mut pos = n_past;
+
+        for _ in 0..params.max_new_tokens {
+            let token = sampler.sample(&ctx, -1);
+            if self.model.is_eog_token(token) {
+                break;
+            }
+
+            generated.extend(map_llama(
+                self.model.token_to_bytes(token, Special::Plaintext),
+                "decoding Voxtral token",
+            )?);
+            sampler.accept(token);
+
+            batch.clear();
+            map_llama(batch.add(token, pos, &[0], true), "feeding Voxtral token")?;
+            map_llama(ctx.decode(&mut batch), "decoding Voxtral token")?;
+            pos += 1;
+        }
+
+        Ok(String::from_utf8_lossy(&generated).into_owned())
+    }
+
+    fn build_prompt(&self, params: &VoxtralParams) -> Result<String, TranscribeError> {
+        let marker = MtmdContext::default_marker();
+        let task = match (params.translate, params.language.as_deref()) {
+            (true, Some(language)) => {
+                let language = display_language_name(language);
+                format!(
+                    "Translate the {language} speech to English. Return only the English translation."
+                )
+            }
+            (true, None) => "Translate the speech to English. Return only the English translation."
+                .to_string(),
+            (false, Some(language)) => {
+                let language = display_language_name(language);
+                format!(
+                    "Transcribe the {language} speech exactly in {language}. Translation is disabled. Do not translate to any other language. Return only the transcript text, without timestamps."
+                )
+            }
+            (false, None) => {
+                "Detect the spoken language. Transcribe the speech verbatim in the detected language. Translation is disabled. Do not translate to any other language. Return only the transcript text, without timestamps."
+                    .to_string()
+            }
+        };
+        Ok(format!("[INST] {marker}\n{task}[/INST]"))
+    }
+}
+
+impl SpeechModel for VoxtralModel {
+    fn capabilities(&self) -> ModelCapabilities {
+        CAPABILITIES
+    }
+
+    fn transcribe_raw(
+        &mut self,
+        samples: &[f32],
+        options: &TranscribeOptions,
+    ) -> Result<TranscriptionResult, TranscribeError> {
+        let params = VoxtralParams {
+            language: options.language.clone(),
+            translate: options.translate,
+            ..self.params.clone()
+        };
+        self.transcribe_with(samples, &params)
+    }
+}
+
+fn find_model_file(model_dir: &Path) -> Result<PathBuf, TranscribeError> {
+    find_gguf(model_dir, |name| !name.starts_with("mmproj"))
+}
+
+fn find_mmproj_file(model_dir: &Path) -> Result<PathBuf, TranscribeError> {
+    find_gguf(model_dir, |name| name.starts_with("mmproj"))
+}
+
+fn find_gguf(
+    model_dir: &Path,
+    predicate: impl Fn(&str) -> bool,
+) -> Result<PathBuf, TranscribeError> {
+    let mut candidates = std::fs::read_dir(model_dir)?
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .filter(|path| {
+            path.extension().and_then(|ext| ext.to_str()) == Some("gguf")
+                && path
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .map(&predicate)
+                    .unwrap_or(false)
+        })
+        .collect::<Vec<_>>();
+    candidates.sort();
+    candidates
+        .into_iter()
+        .next()
+        .ok_or_else(|| TranscribeError::ModelNotFound(model_dir.to_path_buf()))
+}
+
+fn clean_generated_text(text: &str) -> String {
+    strip_timestamp_markers(text)
+        .trim()
+        .trim_matches('"')
+        .trim_matches('\'')
+        .trim()
+        .to_string()
+}
+
+fn display_language_name(language: &str) -> &str {
+    match language {
+        "de" => "German",
+        "en" => "English",
+        "es" => "Spanish",
+        "fr" => "French",
+        "it" => "Italian",
+        "nl" => "Dutch",
+        "pt" => "Portuguese",
+        "hi" => "Hindi",
+        other => other,
+    }
+}
+
+fn strip_timestamp_markers(text: &str) -> String {
+    let mut output = String::with_capacity(text.len());
+    let mut rest = text;
+
+    while let Some(start) = rest.find('[') {
+        output.push_str(&rest[..start]);
+        let Some(relative_end) = rest[start..].find(']') else {
+            output.push_str(&rest[start..]);
+            return output;
+        };
+
+        let end = start + relative_end;
+        let marker = &rest[start + 1..end];
+        if looks_like_timestamp_marker(marker) {
+            rest = &rest[end + 1..];
+        } else {
+            output.push_str(&rest[start..=end]);
+            rest = &rest[end + 1..];
+        }
+    }
+
+    output.push_str(rest);
+    output
+}
+
+fn looks_like_timestamp_marker(marker: &str) -> bool {
+    let marker = marker.trim();
+    marker.contains('-')
+        && marker.contains('m')
+        && marker.contains('s')
+        && marker
+            .chars()
+            .all(|ch| ch.is_ascii_digit() || matches!(ch, 'm' | 's' | '-' | '.' | ',' | ' ' | '\t'))
+}
+
+fn map_llama<T, E: std::fmt::Display>(
+    result: Result<T, E>,
+    context: &str,
+) -> Result<T, TranscribeError> {
+    result.map_err(|e| TranscribeError::Inference(format!("{context}: {e}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::clean_generated_text;
+
+    #[test]
+    fn removes_voxtral_timestamp_markers() {
+        let text = "[ 0m0s694ms - 0m1s64ms ] Kannst du das Mistral Modell beschleunigen?";
+
+        assert_eq!(
+            clean_generated_text(text),
+            "Kannst du das Mistral Modell beschleunigen?"
+        );
+    }
+}

--- a/tests/voxtral.rs
+++ b/tests/voxtral.rs
@@ -1,0 +1,48 @@
+mod common;
+
+use std::path::PathBuf;
+
+use transcribe_rs::voxtral::{VoxtralModel, VoxtralParams};
+use transcribe_rs::SpeechModel;
+
+#[test]
+fn test_voxtral_transcribe_jfk() {
+    let model_path = match std::env::var("VOXTRAL_MODEL") {
+        Ok(path) => PathBuf::from(path),
+        Err(_) => return,
+    };
+    let mmproj_path = match std::env::var("VOXTRAL_MMPROJ") {
+        Ok(path) => PathBuf::from(path),
+        Err(_) => return,
+    };
+    let wav_path = PathBuf::from("samples/jfk.wav");
+
+    if !common::require_paths(&[&model_path, &mmproj_path, &wav_path]) {
+        return;
+    }
+
+    let params = VoxtralParams {
+        max_new_tokens: 160,
+        ..Default::default()
+    };
+    let mut model =
+        VoxtralModel::load_files(&model_path, &mmproj_path, params).expect("load Voxtral");
+    let result = model
+        .transcribe_file(
+            &wav_path,
+            &transcribe_rs::TranscribeOptions {
+                language: Some("en".to_string()),
+                ..Default::default()
+            },
+        )
+        .expect("transcribe with Voxtral");
+
+    assert!(
+        result
+            .text
+            .to_lowercase()
+            .contains("ask not what your country"),
+        "unexpected transcript: {}",
+        result.text
+    );
+}


### PR DESCRIPTION
## Summary

- add an optional Voxtral backend using llama.cpp libmtmd through `llama-cpp-4`
- expose `voxtral`, `voxtral-metal`, `voxtral-vulkan`, and `voxtral-cuda` feature flags
- add a Voxtral example CLI plus an opt-in integration test gated by `VOXTRAL_MODEL` and `VOXTRAL_MMPROJ`

## Context

This is intended to address the Voxtral backend request in cjpais/transcribe-rs#32 and unblock downstream Handy experimentation discussed in cjpais/Handy#81 and cjpais/Handy#126.

The backend loads a GGUF text model plus a matching `mmproj*.gguf`, supports language hints and translation mode, and strips timestamp markers that Voxtral may emit even when timestamps are not requested.

## Testing

- `cargo fmt --all`
- `CPATH=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/c++/v1 cargo test --features voxtral-metal voxtral::tests::removes_voxtral_timestamp_markers`
- `CPATH=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/c++/v1 cargo check --features voxtral-metal --example voxtral`
- `CPATH=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/c++/v1 VOXTRAL_MODEL="$HOME/Library/Application Support/com.pais.handy/models/voxtral-mini-3b-q4/Voxtral-Mini-3B-2507-Q4_K_M.gguf" VOXTRAL_MMPROJ="$HOME/Library/Application Support/com.pais.handy/models/voxtral-mini-3b-q4/mmproj-Voxtral-Mini-3B-2507-Q8_0.gguf" cargo test --features voxtral-metal --test voxtral -- --nocapture`

The opt-in Voxtral test passed locally on Apple M5 Pro with Metal acceleration.

## Notes

- llama.cpp currently reports audio input as experimental; this PR keeps the backend behind opt-in Cargo features.
- The integration test skips unless local model paths are supplied through environment variables.
- MLX benchmarking was tested locally but intentionally not included in this PR.

## AI Assistance

AI assistance was used through Codex for implementation, prompt iteration, testing, and PR preparation. The feature was locally tested with real Voxtral Mini GGUF inference before opening this draft.
