### PR TITLE
parakeet: skip frames via the TDT duration head in greedy decode

### DIFF
--- a/src/onnx/parakeet/mod.rs
+++ b/src/onnx/parakeet/mod.rs
@@ -343,14 +343,20 @@ impl ParakeetModel {
             let (probs, new_state) =
                 self.decode_step(&tokens, &prev_state, &encoder_step_dyn.view())?;
 
-            let vocab_logits_slice = probs
+            let logits_slice = probs
                 .as_slice()
                 .ok_or_else(|| TranscribeError::Inference("Logits not contiguous".to_string()))?;
 
-            let vocab_logits = if probs.len() > self.vocab_size {
-                &vocab_logits_slice[..self.vocab_size]
+            // TDT (Token-and-Duration Transducer) models emit duration logits
+            // after the vocab logits: the joint network predicts both the next
+            // token and how many encoder frames that prediction covers, so the
+            // decode loop can skip ahead instead of revisiting every frame.
+            // Plain RNN-T models emit no duration logits, leaving the slice
+            // empty.
+            let (vocab_logits, duration_logits) = if logits_slice.len() > self.vocab_size {
+                logits_slice.split_at(self.vocab_size)
             } else {
-                vocab_logits_slice
+                (logits_slice, &[][..])
             };
 
             let token = vocab_logits
@@ -367,7 +373,24 @@ impl ParakeetModel {
                 emitted_tokens += 1;
             }
 
-            if token == self.blank_idx || emitted_tokens == MAX_TOKENS_PER_STEP {
+            // The duration index is the number of frames to skip: NeMo's TDT
+            // ONNX exports use the identity duration set (0, 1, .., n-1). For
+            // RNN-T models `duration_logits` is empty and `skip` stays 0, so
+            // the frame index advances exactly as before: by one frame on
+            // blank or when the per-frame token cap is hit.
+            let skip = duration_logits
+                .iter()
+                .enumerate()
+                .max_by(|(_, a), (_, b)| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal))
+                .map(|(idx, _)| idx)
+                .unwrap_or(0);
+
+            if skip > 0 {
+                t += skip;
+                emitted_tokens = 0;
+            } else if token == self.blank_idx || emitted_tokens == MAX_TOKENS_PER_STEP {
+                // A zero-duration blank makes no progress; forcing a one-frame
+                // advance guarantees termination (mirrors NeMo's TDT decoder).
                 t += 1;
                 emitted_tokens = 0;
             }


### PR DESCRIPTION
Editorial note: I ended up having Claude generate this while debugging a performance problem in a branch of https://github.com/jonhoo/sirtea/ where I try to move processing to be local instead of relying on a Cloud service. It makes a pretty significant difference to decode time (as outlined below in the also-LLM-generated commit message), and from reading through it it seems very reasonable, so I figured I'd share it back. Not sure what your policy is on LLM-written PRs though, so decided an explicit acknowledgement was worthwhile!

---

Parakeet TDT (Token-and-Duration Transducer) models predict, alongside each token, how many encoder frames that prediction covers: the joint network emits duration logits after the vocab logits. The decode loop discarded those logits and advanced one 80ms frame per step, running one `decoder_joint` inference per frame — about 2,440 serial calls per 195s of audio, most of which produce a blank.

Decoding now advances the frame index by the predicted duration (argmax over the duration logits), matching the reference greedy decoders in NeMo and onnx-asr. A zero-duration blank forces a one-frame advance so the loop always terminates, and the existing `MAX_TOKENS_PER_STEP` cap still bounds zero-duration token emissions.

Plain RNN-T exports emit no duration logits; for them the duration slice is empty, the skip stays 0, and the loop advances exactly as before (one frame on blank or when the per-frame token cap is hit), so non-TDT models are unaffected.

One simplification worth noting: the duration argmax index is used directly as the frame skip, i.e. the identity duration set (0, 1, .., n-1). NeMo's TDT ONNX exports all use identity durations and the export carries no duration table to read, so there is nothing to look up until some export ships a non-identity set.

Measured with parakeet-tdt-0.6b-v3-int8 on a 73-minute video (Linux, 16 cores, WebGPU via Vulkan):

- `decoder_joint` calls per 195s segment: 3,471 -> 1,162 (~3x fewer)
- decode time per segment: 0.89s -> 0.30s (CPU EP), 9.8s -> 3.5s (WebGPU EP, where each call costs a GPU round-trip)
- end-to-end on WebGPU: 480s -> 331s (31% faster)

The transcript stays 98.3% word-identical on that video (within the variation already seen between the CPU and WebGPU execution providers), and the exact-transcript JFK test still passes.