### PR TITLE
Add Support for ORT's MIGraphX execution provider

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,11 +40,12 @@ ort-cuda     = ["onnx", "ort/cuda"]
 ort-tensorrt = ["ort-cuda", "ort/tensorrt"]
 ort-directml = ["onnx", "ort/directml"]
 ort-rocm     = ["onnx", "ort/rocm"]
+ort-migraphx = ["onnx", "ort/migraphx"]
 ort-coreml   = ["onnx", "ort/coreml"]
 ort-webgpu   = ["onnx", "ort/webgpu"]
 ort-xnnpack  = ["onnx", "ort/xnnpack"]
 ort-tracing  = ["onnx", "ort/tracing"]
-ort-accel    = ["ort-cuda", "ort-tensorrt", "ort-directml", "ort-rocm", "ort-coreml", "ort-webgpu", "ort-xnnpack"]
+ort-accel    = ["ort-cuda", "ort-tensorrt", "ort-directml", "ort-rocm", "ort-migraphx", "ort-coreml", "ort-webgpu", "ort-xnnpack"]
 
 # Convenience
 all = ["onnx", "whisper-cpp", "whisperfile", "openai"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ env_logger = "0.10.0"
 derive_builder = { version = "0.20.2" }
 
 # ONNX runtime
-ort = { version = "=2.0.0-rc.12", optional = true }
+ort = { version = "=2.0.0-rc.12", optional = true, default-features = false, features = ["std", "ndarray", "api-24"] }
 ndarray = { version = "0.17", optional = true }
 regex = { version = "1.11.2", optional = true }
 once_cell = { version = "1.21.3", optional = true }

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ GPU accelerator features for ORT engines:
 |---------|---------|
 | `ort-cuda` | NVIDIA CUDA |
 | `ort-rocm` | AMD ROCm |
+| `ort-migraphx` | AMD MIGraphX |
 | `ort-directml` | Microsoft DirectML (Windows) |
 | `ort-coreml` | Apple CoreML (macOS/iOS) |
 | `ort-webgpu` | WebGPU via Dawn |
@@ -82,6 +83,9 @@ use transcribe_rs::{set_ort_accelerator, OrtAccelerator};
 
 // Use CUDA for all ORT engines (SenseVoice, GigaAM, Parakeet, Moonshine)
 set_ort_accelerator(OrtAccelerator::Cuda);
+
+// Or use AMD MIGraphX
+set_ort_accelerator(OrtAccelerator::Migraphx);
 
 // Or auto-detect the best available GPU
 set_ort_accelerator(OrtAccelerator::Auto);

--- a/src/accel.rs
+++ b/src/accel.rs
@@ -24,7 +24,7 @@ use serde::{Deserialize, Serialize};
 /// (~800 MB+), significantly increasing the final binary and its runtime dependencies
 /// (CUDA toolkit / cuDNN). Prefer `CpuOnly` or lighter providers unless GPU acceleration
 /// is specifically required.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 #[non_exhaustive]
 #[repr(u8)]
@@ -32,6 +32,7 @@ pub enum OrtAccelerator {
     /// Automatically select the best available execution provider (default).
     /// DirectML and WebGPU are excluded from auto-selection because they
     /// require sequential execution mode; set them explicitly to use.
+    #[default]
     Auto = 0,
     /// Force CPU-only execution — no GPU providers.
     #[serde(rename = "cpu", alias = "cpu_only")]
@@ -128,12 +129,6 @@ impl OrtAccelerator {
     }
 }
 
-impl Default for OrtAccelerator {
-    fn default() -> Self {
-        Self::Auto
-    }
-}
-
 impl fmt::Display for OrtAccelerator {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let s = match self {
@@ -180,11 +175,12 @@ impl FromStr for OrtAccelerator {
 ///
 /// The actual GPU backend (Metal, Vulkan, etc.) is selected at compile time
 /// via whisper-rs feature flags. This enum only controls whether GPU is used.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 #[repr(u8)]
 pub enum WhisperAccelerator {
     /// Automatically select the best available backend (default — uses GPU if available).
+    #[default]
     Auto = 0,
     /// Force CPU-only execution.
     CpuOnly = 1,
@@ -237,12 +233,6 @@ impl WhisperAccelerator {
             2 => Self::Gpu,
             _ => Self::Auto,
         }
-    }
-}
-
-impl Default for WhisperAccelerator {
-    fn default() -> Self {
-        Self::Auto
     }
 }
 

--- a/src/accel.rs
+++ b/src/accel.rs
@@ -56,6 +56,9 @@ pub enum OrtAccelerator {
     /// kernels; uses its own threadpool independent of the session intra-op pool.
     #[serde(rename = "xnnpack")]
     Xnnpack = 8,
+    /// AMD MIGraphX (requires `ort-migraphx` feature).
+    #[serde(rename = "migraphx")]
+    Migraphx = 9,
 }
 
 static ORT_ACCELERATOR: AtomicU8 = AtomicU8::new(OrtAccelerator::Auto as u8);
@@ -102,6 +105,9 @@ impl OrtAccelerator {
         #[cfg(feature = "ort-xnnpack")]
         v.push(OrtAccelerator::Xnnpack);
 
+        #[cfg(feature = "ort-migraphx")]
+        v.push(OrtAccelerator::Migraphx);
+
         v
     }
 
@@ -116,6 +122,7 @@ impl OrtAccelerator {
             6 => Self::WebGpu,
             7 => Self::TensorRt,
             8 => Self::Xnnpack,
+            9 => Self::Migraphx,
             _ => Self::Auto,
         }
     }
@@ -139,6 +146,7 @@ impl fmt::Display for OrtAccelerator {
             Self::CoreMl => "coreml",
             Self::WebGpu => "webgpu",
             Self::Xnnpack => "xnnpack",
+            Self::Migraphx => "migraphx",
         };
         f.write_str(s)
     }
@@ -158,6 +166,7 @@ impl FromStr for OrtAccelerator {
             "coreml" | "core_ml" => Ok(Self::CoreMl),
             "webgpu" | "web_gpu" => Ok(Self::WebGpu),
             "xnnpack" => Ok(Self::Xnnpack),
+            "migraphx" => Ok(Self::Migraphx),
             other => Err(format!("unknown ORT accelerator: {other}")),
         }
     }
@@ -347,6 +356,7 @@ mod tests {
             OrtAccelerator::CoreMl,
             OrtAccelerator::WebGpu,
             OrtAccelerator::Xnnpack,
+            OrtAccelerator::Migraphx,
         ] {
             let s = pref.to_string();
             let parsed: OrtAccelerator = s.parse().unwrap();
@@ -391,6 +401,7 @@ mod tests {
             (OrtAccelerator::CoreMl, "\"coreml\""),
             (OrtAccelerator::WebGpu, "\"webgpu\""),
             (OrtAccelerator::Xnnpack, "\"xnnpack\""),
+            (OrtAccelerator::Migraphx, "\"migraphx\""),
         ] {
             let json = serde_json::to_string(&pref).unwrap();
             assert_eq!(json, expected, "serialize {:?}", pref);

--- a/src/decode/greedy.rs
+++ b/src/decode/greedy.rs
@@ -1,10 +1,10 @@
-/// Greedy autoregressive token selection with repetition detection.
-///
-/// Wraps the common argmax + EOS + repeat-guard pattern shared by all
-/// autoregressive decoder engines (Canary, Moonshine, Cohere).
-///
-/// Each engine still owns its KV cache and decoder session — this struct
-/// only handles token selection and stopping decisions.
+//! Greedy autoregressive token selection with repetition detection.
+//!
+//! Wraps the common argmax + EOS + repeat-guard pattern shared by all
+//! autoregressive decoder engines (Canary, Moonshine, Cohere).
+//!
+//! Each engine still owns its KV cache and decoder session — this struct
+//! only handles token selection and stopping decisions.
 
 const DEFAULT_MAX_CONSECUTIVE_REPEATS: usize = 8;
 

--- a/src/features/mel.rs
+++ b/src/features/mel.rs
@@ -79,7 +79,7 @@ fn compute_fbank(samples: &[f32], config: &MelConfig, sr: f32, f_max: f32) -> Ar
             1 + (samples.len() - frame_length) / frame_shift
         }
     } else {
-        (samples.len() + frame_shift - 1) / frame_shift
+        samples.len().div_ceil(frame_shift)
     };
 
     if num_frames == 0 {

--- a/src/onnx/canary/decoder.rs
+++ b/src/onnx/canary/decoder.rs
@@ -106,7 +106,7 @@ fn extract_decoder_mems_shape(decoder: &Session) -> Result<(usize, usize), Trans
 
     match mems_input.dtype() {
         ValueType::Tensor { shape, .. } => {
-            let dims: &[i64] = &shape;
+            let dims: &[i64] = shape;
             if dims.len() != 4 {
                 return Err(TranscribeError::Inference(format!(
                     "Expected 4D decoder_mems, got {}D",

--- a/src/onnx/moonshine/mod.rs
+++ b/src/onnx/moonshine/mod.rs
@@ -7,8 +7,9 @@ pub use streaming::{MoonshineStreamingParams, StreamingConfig, StreamingModel, S
 pub const SAMPLE_RATE: u32 = 16000;
 
 /// Moonshine model variant.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum MoonshineVariant {
+    #[default]
     Tiny,
     TinyAr,
     TinyZh,
@@ -61,11 +62,5 @@ impl MoonshineVariant {
             | MoonshineVariant::TinyKo
             | MoonshineVariant::TinyVi => 13,
         }
-    }
-}
-
-impl Default for MoonshineVariant {
-    fn default() -> Self {
-        MoonshineVariant::Tiny
     }
 }

--- a/src/onnx/moonshine/model.rs
+++ b/src/onnx/moonshine/model.rs
@@ -168,7 +168,7 @@ impl MoonshineModel {
         max_length: usize,
     ) -> Result<Vec<i64>, TranscribeError> {
         let audio_duration = samples.len() as f32 / SAMPLE_RATE as f32;
-        if audio_duration < 0.1 || audio_duration > 64.0 {
+        if !(0.1..=64.0).contains(&audio_duration) {
             return Err(TranscribeError::Inference(format!(
                 "Audio duration must be between 0.1s and 64s, got {:.2}s",
                 audio_duration

--- a/src/onnx/session.rs
+++ b/src/onnx/session.rs
@@ -2,6 +2,8 @@
 use ort::ep::CoreML;
 #[cfg(feature = "ort-directml")]
 use ort::ep::DirectML;
+#[cfg(feature = "ort-migraphx")]
+use ort::ep::MIGraphX;
 #[cfg(feature = "ort-rocm")]
 use ort::ep::ROCm;
 #[cfg(feature = "ort-tensorrt")]
@@ -100,6 +102,14 @@ fn execution_providers() -> Vec<ort::ep::ExecutionProviderDispatch> {
                 "Accelerator set to XNNPACK but ort-xnnpack feature is not enabled; falling back to CPU"
             );
         }
+        OrtAccelerator::Migraphx => {
+            #[cfg(feature = "ort-migraphx")]
+            eps.push(MIGraphX::default().build());
+            #[cfg(not(feature = "ort-migraphx"))]
+            log::warn!(
+                "Accelerator set to MIGraphX but ort-migraphx feature is not enabled; falling back to CPU"
+            );
+        }
         OrtAccelerator::Auto => {
             // Add compiled-in GPU EPs in priority order.
             // DirectML and WebGPU are excluded from Auto because they require
@@ -115,6 +125,8 @@ fn execution_providers() -> Vec<ort::ep::ExecutionProviderDispatch> {
             eps.push(CUDA::default().build());
             #[cfg(feature = "ort-rocm")]
             eps.push(ROCm::default().build());
+            #[cfg(feature = "ort-migraphx")]
+            eps.push(MIGraphX::default().build());
             // CoreML is safe for Auto on macOS — analogous to CUDA on NVIDIA
             // and ROCm on AMD. It does not require sequential execution or
             // disabled memory patterns.


### PR DESCRIPTION
AMD created a graph inference engine called [MIGraphX](https://github.com/ROCm/AMDMIGraphX), designed to run on their GPU hardware, which, in their words, "accelerates machine learning model inference".

Microsoft has adopted this technology into [onnxruntime](https://onnxruntime.ai/docs/execution-providers/MIGraphX-ExecutionProvider.html). ORT has followed suit, adding [an MIGraphX execution provider](https://ort.pyke.io/perf/execution-providers) to ORT, gated behind an "migraphx" feature flag.

The critical reason for me proposing this patch is that for recent NixOS builds of the `onnxruntime` package, the package maintainers have swapped over from directly-supporting ROCm to [supporting the new MIGraphX runtime](https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/on/onnxruntime/package.nix) instead.

Fortunately, given how `transcribe-rs`'s source is structured, the patch to add support for another ORT execution provider was quite simple. I structured the sparse few lines of new code identically to the other providers, so this should be a pretty simple merge.