### PR TITLE
Relax ort release-candidate pin

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ env_logger = "0.10.0"
 derive_builder = { version = "0.20.2" }
 
 # ONNX runtime
-ort = { version = "=2.0.0-rc.12", optional = true }
+ort = { version = "2.0.0-rc.12", optional = true }
 ndarray = { version = "0.17", optional = true }
 regex = { version = "1.11.2", optional = true }
 once_cell = { version = "1.21.3", optional = true }


### PR DESCRIPTION
## Summary

Relax the exact `ort` rc.12 pin to Cargo's standard compatible version range, while retaining rc.12 as the minimum supported version.

## Why

The exact pin prevents downstream applications from unifying on a newer compatible `ort` release candidate and can make their dependency graph unresolvable because `ort-sys` owns the native ONNX Runtime link. Letting the application lockfile choose the compatible version keeps `transcribe-rs` flexible without changing its source API or checked-in rc.12 lockfile.

## Validation

- `cargo test --locked --no-run --features onnx`
